### PR TITLE
New interface for node with directives 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.0.0.{build}
+version: 4.1.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-parser",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "index.js",
   "repository": "git@github.com:graphql-dotnet/parser.git",
   "author": "Joe McBride",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   
   <PropertyGroup>
-    <VersionPrefix>4.0.0</VersionPrefix>
-    <Version>4.0.0</Version>
-    <FileVersion>4.0.0</FileVersion>
-    <InformationalVersion>4.0.0</InformationalVersion>
+    <VersionPrefix>4.1.0</VersionPrefix>
+    <Version>4.1.0</Version>
+    <FileVersion>4.1.0</FileVersion>
+    <InformationalVersion>4.1.0</InformationalVersion>
     <Authors>Marek Magdziak</Authors>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Copyright>Copyright 2016-2019 Marek Magdziak et al. All rights reserved.</Copyright>

--- a/src/GraphQLParser.Benchmarks/LexerBenchmark.cs
+++ b/src/GraphQLParser.Benchmarks/LexerBenchmark.cs
@@ -67,7 +67,8 @@ fragment frag on Friend {
             var source = new Source(KitchenSink);
             var resetPosition = 0;
             Token token;
-            while((token = lexer.Lex(source, resetPosition)).Kind != TokenKind.EOF) {
+            while ((token = lexer.Lex(source, resetPosition)).Kind != TokenKind.EOF)
+            {
                 resetPosition = token.End;
             }
         }

--- a/src/GraphQLParser.Tests/GraphQLAstVisitorTests.cs
+++ b/src/GraphQLParser.Tests/GraphQLAstVisitorTests.cs
@@ -7,7 +7,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using Xunit;
-    
+
     public class GraphQLAstVisitorTests
     {
         private readonly Parser parser;

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -158,7 +158,7 @@
 
         private static GraphQLOperationDefinition GetSingleOperationDefinition(GraphQLDocument document)
         {
-            return ((GraphQLOperationDefinition)document.Definitions.Single());
+            return (GraphQLOperationDefinition)document.Definitions.Single();
         }
 
         private static ASTNode GetSingleSelection(GraphQLDocument document)

--- a/src/GraphQLParser.Tests/Validation/LexerValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/LexerValidationTests.cs
@@ -5,7 +5,6 @@
     using System;
     using Xunit;
 
-    
     public class LexerValidationTests
     {
         [Fact]
@@ -184,7 +183,6 @@
        ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
         }
-
 
         [Fact]
         public void Lex_NonNumericCharacterInNumberExponent_ThrowsExceptionWithCorrectMessage()

--- a/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
@@ -1,12 +1,10 @@
-﻿
-namespace GraphQLParser.Tests.Validation
+﻿namespace GraphQLParser.Tests.Validation
 {
     using Exceptions;
     using GraphQLParser;
     using System;
     using Xunit;
 
-    
     public class ParserValidationTests
     {
         [Fact]

--- a/src/GraphQLParser/AST/ASTNode.cs
+++ b/src/GraphQLParser/AST/ASTNode.cs
@@ -3,7 +3,9 @@
     public abstract class ASTNode
     {
         public abstract ASTNodeKind Kind { get; }
+
         public GraphQLLocation Location { get; set; }
+
         public GraphQLComment Comment { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLArgument.cs
+++ b/src/GraphQLParser/AST/GraphQLArgument.cs
@@ -1,6 +1,6 @@
 ﻿namespace GraphQLParser.AST
 {
-    public class GraphQLArgument : ASTNode
+    public class GraphQLArgument : ASTNode, INamedNode
     {
         public override ASTNodeKind Kind => ASTNodeKind.Argument;
 

--- a/src/GraphQLParser/AST/GraphQLDirective.cs
+++ b/src/GraphQLParser/AST/GraphQLDirective.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLDirective : ASTNode
+    public class GraphQLDirective : ASTNode, INamedNode
     {
         public IEnumerable<GraphQLArgument> Arguments { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
@@ -2,7 +2,7 @@
 {
     using System.Collections.Generic;
 
-    public class GraphQLDirectiveDefinition : GraphQLTypeDefinition
+    public class GraphQLDirectiveDefinition : GraphQLTypeDefinition, INamedNode
     {
         public IEnumerable<GraphQLInputValueDefinition> Arguments { get; set; }
         public IEnumerable<GraphQLInputValueDefinition> Definitions { get; set; }

--- a/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
@@ -5,11 +5,13 @@
     public class GraphQLDirectiveDefinition : GraphQLTypeDefinition, INamedNode
     {
         public IEnumerable<GraphQLInputValueDefinition> Arguments { get; set; }
+
         public IEnumerable<GraphQLInputValueDefinition> Definitions { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.DirectiveDefinition;
 
         public IEnumerable<GraphQLName> Locations { get; set; }
+
         public GraphQLName Name { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
@@ -9,6 +9,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.EnumTypeDefinition;
 
         public GraphQLName Name { get; set; }
+
         public IEnumerable<GraphQLEnumValueDefinition> Values { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLEnumTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLEnumTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLEnumTypeDefinition : GraphQLTypeDefinition
+    public class GraphQLEnumTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLEnumValueDefinition : GraphQLTypeDefinition
+    public class GraphQLEnumValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLEnumValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLEnumValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLFieldDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLFieldDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
     {
         public IEnumerable<GraphQLInputValueDefinition> Arguments { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
@@ -11,6 +11,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.FieldDefinition;
 
         public GraphQLName Name { get; set; }
+
         public GraphQLType Type { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLFieldDefinition : GraphQLTypeDefinition
+    public class GraphQLFieldDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLInputValueDefinition> Arguments { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLFieldSelection.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldSelection.cs
@@ -13,6 +13,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.Field;
 
         public GraphQLName Name { get; set; }
+
         public GraphQLSelectionSet SelectionSet { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLFieldSelection.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldSelection.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLFieldSelection : ASTNode, IHasDirectivesNode
+    public class GraphQLFieldSelection : ASTNode, IHasDirectivesNode, INamedNode
     {
         public GraphQLName Alias { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLFieldSelection.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldSelection.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLFieldSelection : ASTNode
+    public class GraphQLFieldSelection : ASTNode, IHasDirectivesNode
     {
         public GraphQLName Alias { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLFragmentDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFragmentDefinition.cs
@@ -1,6 +1,6 @@
 ﻿namespace GraphQLParser.AST
 {
-    public class GraphQLFragmentDefinition : GraphQLInlineFragment
+    public class GraphQLFragmentDefinition : GraphQLInlineFragment, INamedNode
     {
         public override ASTNodeKind Kind => ASTNodeKind.FragmentDefinition;
 

--- a/src/GraphQLParser/AST/GraphQLFragmentSpread.cs
+++ b/src/GraphQLParser/AST/GraphQLFragmentSpread.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLFragmentSpread : ASTNode, IHasDirectivesNode
+    public class GraphQLFragmentSpread : ASTNode, IHasDirectivesNode, INamedNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLFragmentSpread.cs
+++ b/src/GraphQLParser/AST/GraphQLFragmentSpread.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLFragmentSpread : ASTNode
+    public class GraphQLFragmentSpread : ASTNode, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLInlineFragment.cs
+++ b/src/GraphQLParser/AST/GraphQLInlineFragment.cs
@@ -9,6 +9,7 @@
         public override ASTNodeKind Kind => ASTNodeKind.InlineFragment;
 
         public GraphQLSelectionSet SelectionSet { get; set; }
+
         public GraphQLNamedType TypeCondition { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLInlineFragment.cs
+++ b/src/GraphQLParser/AST/GraphQLInlineFragment.cs
@@ -2,7 +2,7 @@
 {
     using System.Collections.Generic;
 
-    public class GraphQLInlineFragment : ASTNode
+    public class GraphQLInlineFragment : ASTNode, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
@@ -2,7 +2,7 @@
 {
     using System.Collections.Generic;
 
-    public class GraphQLInputObjectTypeDefinition : GraphQLTypeDefinition
+    public class GraphQLInputObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
@@ -2,7 +2,7 @@
 {
     using System.Collections.Generic;
 
-    public class GraphQLInputObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLInputObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInputValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLInputValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
     {
         public GraphQLValue DefaultValue { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
@@ -11,6 +11,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.InputValueDefinition;
 
         public GraphQLName Name { get; set; }
+
         public GraphQLType Type { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInputValueDefinition : GraphQLTypeDefinition
+    public class GraphQLInputValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public GraphQLValue DefaultValue { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinition
+    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLLocation.cs
+++ b/src/GraphQLParser/AST/GraphQLLocation.cs
@@ -3,6 +3,7 @@
     public class GraphQLLocation
     {
         public int End { get; set; }
+
         public int Start { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLNamedType.cs
+++ b/src/GraphQLParser/AST/GraphQLNamedType.cs
@@ -1,6 +1,6 @@
 ﻿namespace GraphQLParser.AST
 {
-    public class GraphQLNamedType : GraphQLType
+    public class GraphQLNamedType : GraphQLType, INamedNode
     {
         public override ASTNodeKind Kind => ASTNodeKind.NamedType;
 

--- a/src/GraphQLParser/AST/GraphQLNonNullType.cs
+++ b/src/GraphQLParser/AST/GraphQLNonNullType.cs
@@ -6,6 +6,6 @@
 
         public GraphQLType Type { get; set; }
 
-        public override string ToString() => Type.ToString() + "!";
+        public override string ToString() => Type + "!";
     }
 }

--- a/src/GraphQLParser/AST/GraphQLObjectField.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectField.cs
@@ -1,6 +1,6 @@
 ﻿namespace GraphQLParser.AST
 {
-    public class GraphQLObjectField : ASTNode
+    public class GraphQLObjectField : ASTNode, INamedNode
     {
         public override ASTNodeKind Kind => ASTNodeKind.ObjectField;
 

--- a/src/GraphQLParser/AST/GraphQLObjectField.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectField.cs
@@ -5,6 +5,7 @@
         public override ASTNodeKind Kind => ASTNodeKind.ObjectField;
 
         public GraphQLName Name { get; set; }
+
         public GraphQLValue Value { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLObjectTypeDefinition : ASTNode, IHasDirectivesNode
+    public class GraphQLObjectTypeDefinition : ASTNode, IHasDirectivesNode, INamedNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLObjectTypeDefinition : ASTNode
+    public class GraphQLObjectTypeDefinition : ASTNode, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLOperationDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLOperationDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLOperationDefinition : ASTNode, IHasDirectivesNode
+    public class GraphQLOperationDefinition : ASTNode, IHasDirectivesNode, INamedNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLOperationDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLOperationDefinition.cs
@@ -9,8 +9,11 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.OperationDefinition;
 
         public GraphQLName Name { get; set; }
+
         public OperationType Operation { get; set; }
+
         public GraphQLSelectionSet SelectionSet { get; set; }
+
         public IEnumerable<GraphQLVariableDefinition> VariableDefinitions { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLOperationDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLOperationDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLOperationDefinition : ASTNode
+    public class GraphQLOperationDefinition : ASTNode, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLOperationTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLOperationTypeDefinition.cs
@@ -5,6 +5,7 @@
         public override ASTNodeKind Kind => ASTNodeKind.OperationTypeDefinition;
 
         public OperationType Operation { get; set; }
+
         public GraphQLNamedType Type { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLScalarTypeDefinition : GraphQLTypeDefinition
+    public class GraphQLScalarTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLScalarTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLScalarTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLScalarValue.cs
+++ b/src/GraphQLParser/AST/GraphQLScalarValue.cs
@@ -18,7 +18,7 @@
             if (Kind == ASTNodeKind.StringValue)
                 return $"\"{Value}\"";
 
-            return Value.ToString();
+            return Value;
         }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLSchemaDefinition : ASTNode
+    public class GraphQLSchemaDefinition : ASTNode, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
         public override ASTNodeKind Kind => ASTNodeKind.SchemaDefinition;

--- a/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
@@ -5,7 +5,9 @@ namespace GraphQLParser.AST
     public class GraphQLSchemaDefinition : ASTNode, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
+
         public override ASTNodeKind Kind => ASTNodeKind.SchemaDefinition;
+
         public IEnumerable<GraphQLOperationTypeDefinition> OperationTypes { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
@@ -9,6 +9,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.UnionTypeDefinition;
 
         public GraphQLName Name { get; set; }
+
         public IEnumerable<GraphQLNamedType> Types { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLUnionTypeDefinition : GraphQLTypeDefinition
+    public class GraphQLUnionTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLUnionTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLUnionTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLVariable.cs
+++ b/src/GraphQLParser/AST/GraphQLVariable.cs
@@ -1,6 +1,6 @@
 ﻿namespace GraphQLParser.AST
 {
-    public class GraphQLVariable : GraphQLValue
+    public class GraphQLVariable : GraphQLValue, INamedNode
     {
         public override ASTNodeKind Kind => ASTNodeKind.Variable;
 

--- a/src/GraphQLParser/AST/GraphQLVariableDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLVariableDefinition.cs
@@ -7,6 +7,7 @@
         public override ASTNodeKind Kind => ASTNodeKind.VariableDefinition;
 
         public GraphQLType Type { get; set; }
+
         public GraphQLVariable Variable { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/IHasDirectivesNode.cs
+++ b/src/GraphQLParser/AST/IHasDirectivesNode.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace GraphQLParser.AST
+{
+    public interface IHasDirectivesNode
+    {
+        IEnumerable<GraphQLDirective> Directives { get; set; }
+    }
+}

--- a/src/GraphQLParser/AST/INamedNode.cs
+++ b/src/GraphQLParser/AST/INamedNode.cs
@@ -1,0 +1,7 @@
+﻿namespace GraphQLParser.AST
+{
+    public interface INamedNode
+    {
+        GraphQLName Name { get; set; }
+    }
+}

--- a/src/GraphQLParser/GraphQLAstVisitor.cs
+++ b/src/GraphQLParser/GraphQLAstVisitor.cs
@@ -9,7 +9,7 @@
 
         public GraphQLAstVisitor()
         {
-            this.Fragments = new Dictionary<string, GraphQLFragmentDefinition>();
+            Fragments = new Dictionary<string, GraphQLFragmentDefinition>();
         }
 
         public virtual GraphQLName BeginVisitAlias(GraphQLName alias)
@@ -20,18 +20,18 @@
         public virtual GraphQLArgument BeginVisitArgument(GraphQLArgument argument)
         {
             if (argument.Name != null)
-                this.BeginVisitNode(argument.Name);
+                BeginVisitNode(argument.Name);
 
             if (argument.Value != null)
-                this.BeginVisitNode(argument.Value);
+                BeginVisitNode(argument.Value);
 
-            return this.EndVisitArgument(argument);
+            return EndVisitArgument(argument);
         }
 
         public virtual IEnumerable<GraphQLArgument> BeginVisitArguments(IEnumerable<GraphQLArgument> arguments)
         {
             foreach (var argument in arguments)
-                this.BeginVisitNode(argument);
+                BeginVisitNode(argument);
 
             return arguments;
         }
@@ -44,10 +44,10 @@
         public virtual GraphQLDirective BeginVisitDirective(GraphQLDirective directive)
         {
             if (directive.Name != null)
-                this.BeginVisitNode(directive.Name);
+                BeginVisitNode(directive.Name);
 
             if (directive.Arguments != null)
-                this.BeginVisitArguments(directive.Arguments);
+                BeginVisitArguments(directive.Arguments);
 
             return directive;
         }
@@ -55,7 +55,7 @@
         public virtual IEnumerable<GraphQLDirective> BeginVisitDirectives(IEnumerable<GraphQLDirective> directives)
         {
             foreach (var directive in directives)
-                this.BeginVisitNode(directive);
+                BeginVisitNode(directive);
 
             return directives;
         }
@@ -67,21 +67,21 @@
 
         public virtual GraphQLFieldSelection BeginVisitFieldSelection(GraphQLFieldSelection selection)
         {
-            this.BeginVisitNode(selection.Name);
+            BeginVisitNode(selection.Name);
 
             if (selection.Alias != null)
-                this.BeginVisitAlias((GraphQLName)this.BeginVisitNode(selection.Alias));
+                BeginVisitAlias((GraphQLName)BeginVisitNode(selection.Alias));
 
             if (selection.Arguments != null)
-                this.BeginVisitArguments(selection.Arguments);
+                BeginVisitArguments(selection.Arguments);
 
             if (selection.SelectionSet != null)
-                this.BeginVisitNode(selection.SelectionSet);
+                BeginVisitNode(selection.SelectionSet);
 
             if (selection.Directives != null)
-                this.BeginVisitDirectives(selection.Directives);
+                BeginVisitDirectives(selection.Directives);
 
-            return this.EndVisitFieldSelection(selection);
+            return EndVisitFieldSelection(selection);
         }
 
         public virtual GraphQLScalarValue BeginVisitFloatValue(GraphQLScalarValue value)
@@ -91,31 +91,31 @@
 
         public virtual GraphQLFragmentDefinition BeginVisitFragmentDefinition(GraphQLFragmentDefinition node)
         {
-            this.BeginVisitNode(node.TypeCondition);
-            this.BeginVisitNode(node.Name);
+            BeginVisitNode(node.TypeCondition);
+            BeginVisitNode(node.Name);
 
             if (node.SelectionSet != null)
-                this.BeginVisitNode(node.SelectionSet);
+                BeginVisitNode(node.SelectionSet);
 
             return node;
         }
 
         public virtual GraphQLFragmentSpread BeginVisitFragmentSpread(GraphQLFragmentSpread fragmentSpread)
         {
-            this.BeginVisitNode(fragmentSpread.Name);
+            BeginVisitNode(fragmentSpread.Name);
             return fragmentSpread;
         }
 
         public virtual GraphQLInlineFragment BeginVisitInlineFragment(GraphQLInlineFragment inlineFragment)
         {
             if (inlineFragment.TypeCondition != null)
-                this.BeginVisitNode(inlineFragment.TypeCondition);
+                BeginVisitNode(inlineFragment.TypeCondition);
 
             if (inlineFragment.Directives != null)
-                this.BeginVisitDirectives(inlineFragment.Directives);
+                BeginVisitDirectives(inlineFragment.Directives);
 
             if (inlineFragment.SelectionSet != null)
-                this.BeginVisitSelectionSet(inlineFragment.SelectionSet);
+                BeginVisitSelectionSet(inlineFragment.SelectionSet);
 
             return inlineFragment;
         }
@@ -139,42 +139,41 @@
         {
             switch (node.Kind)
             {
-                case ASTNodeKind.OperationDefinition: return this.BeginVisitOperationDefinition((GraphQLOperationDefinition)node);
-                case ASTNodeKind.SelectionSet: return this.BeginVisitSelectionSet((GraphQLSelectionSet)node);
-                case ASTNodeKind.Field: return this.BeginVisitNonIntrospectionFieldSelection((GraphQLFieldSelection)node);
-                case ASTNodeKind.Name: return this.BeginVisitName((GraphQLName)node);
-                case ASTNodeKind.Argument: return this.BeginVisitArgument((GraphQLArgument)node);
-                case ASTNodeKind.FragmentSpread: return this.BeginVisitFragmentSpread((GraphQLFragmentSpread)node);
-                case ASTNodeKind.FragmentDefinition: return this.BeginVisitFragmentDefinition((GraphQLFragmentDefinition)node);
-                case ASTNodeKind.InlineFragment: return this.BeginVisitInlineFragment((GraphQLInlineFragment)node);
-                case ASTNodeKind.NamedType: return this.BeginVisitNamedType((GraphQLNamedType)node);
-                case ASTNodeKind.Directive: return this.BeginVisitDirective((GraphQLDirective)node);
-                case ASTNodeKind.Variable: return this.BeginVisitVariable((GraphQLVariable)node);
-                case ASTNodeKind.IntValue: return this.BeginVisitIntValue((GraphQLScalarValue)node);
-                case ASTNodeKind.FloatValue: return this.BeginVisitFloatValue((GraphQLScalarValue)node);
-                case ASTNodeKind.StringValue: return this.BeginVisitStringValue((GraphQLScalarValue)node);
-                case ASTNodeKind.BooleanValue: return this.BeginVisitBooleanValue((GraphQLScalarValue)node);
-                case ASTNodeKind.EnumValue: return this.BeginVisitEnumValue((GraphQLScalarValue)node);
-                case ASTNodeKind.ListValue: return this.BeginVisitListValue((GraphQLListValue)node);
-                case ASTNodeKind.ObjectValue: return this.BeginVisitObjectValue((GraphQLObjectValue)node);
-                case ASTNodeKind.ObjectField: return this.BeginVisitObjectField((GraphQLObjectField)node);
-                case ASTNodeKind.VariableDefinition: return this.BeginVisitVariableDefinition((GraphQLVariableDefinition)node);
+                case ASTNodeKind.OperationDefinition: return BeginVisitOperationDefinition((GraphQLOperationDefinition)node);
+                case ASTNodeKind.SelectionSet: return BeginVisitSelectionSet((GraphQLSelectionSet)node);
+                case ASTNodeKind.Field: return BeginVisitNonIntrospectionFieldSelection((GraphQLFieldSelection)node);
+                case ASTNodeKind.Name: return BeginVisitName((GraphQLName)node);
+                case ASTNodeKind.Argument: return BeginVisitArgument((GraphQLArgument)node);
+                case ASTNodeKind.FragmentSpread: return BeginVisitFragmentSpread((GraphQLFragmentSpread)node);
+                case ASTNodeKind.FragmentDefinition: return BeginVisitFragmentDefinition((GraphQLFragmentDefinition)node);
+                case ASTNodeKind.InlineFragment: return BeginVisitInlineFragment((GraphQLInlineFragment)node);
+                case ASTNodeKind.NamedType: return BeginVisitNamedType((GraphQLNamedType)node);
+                case ASTNodeKind.Directive: return BeginVisitDirective((GraphQLDirective)node);
+                case ASTNodeKind.Variable: return BeginVisitVariable((GraphQLVariable)node);
+                case ASTNodeKind.IntValue: return BeginVisitIntValue((GraphQLScalarValue)node);
+                case ASTNodeKind.FloatValue: return BeginVisitFloatValue((GraphQLScalarValue)node);
+                case ASTNodeKind.StringValue: return BeginVisitStringValue((GraphQLScalarValue)node);
+                case ASTNodeKind.BooleanValue: return BeginVisitBooleanValue((GraphQLScalarValue)node);
+                case ASTNodeKind.EnumValue: return BeginVisitEnumValue((GraphQLScalarValue)node);
+                case ASTNodeKind.ListValue: return BeginVisitListValue((GraphQLListValue)node);
+                case ASTNodeKind.ObjectValue: return BeginVisitObjectValue((GraphQLObjectValue)node);
+                case ASTNodeKind.ObjectField: return BeginVisitObjectField((GraphQLObjectField)node);
+                case ASTNodeKind.VariableDefinition: return BeginVisitVariableDefinition((GraphQLVariableDefinition)node);
+                default: return null;
             }
-
-            return null;
         }
 
         public virtual GraphQLOperationDefinition BeginVisitOperationDefinition(GraphQLOperationDefinition definition)
         {
             if (definition.Name != null)
-                this.BeginVisitNode(definition.Name);
+                BeginVisitNode(definition.Name);
 
             if (definition.VariableDefinitions != null)
-                this.BeginVisitVariableDefinitions(definition.VariableDefinitions);
+                BeginVisitVariableDefinitions(definition.VariableDefinitions);
 
-            this.BeginVisitNode(definition.SelectionSet);
+            BeginVisitNode(definition.SelectionSet);
 
-            return this.EndVisitOperationDefinition(definition);
+            return EndVisitOperationDefinition(definition);
         }
 
         public virtual GraphQLOperationDefinition EndVisitOperationDefinition(GraphQLOperationDefinition definition)
@@ -185,7 +184,7 @@
         public virtual GraphQLSelectionSet BeginVisitSelectionSet(GraphQLSelectionSet selectionSet)
         {
             foreach (var selection in selectionSet.Selections)
-                this.BeginVisitNode(selection);
+                BeginVisitNode(selection);
 
             return selectionSet;
         }
@@ -198,14 +197,14 @@
         public virtual GraphQLVariable BeginVisitVariable(GraphQLVariable variable)
         {
             if (variable.Name != null)
-                this.BeginVisitNode(variable.Name);
+                BeginVisitNode(variable.Name);
 
-            return this.EndVisitVariable(variable);
+            return EndVisitVariable(variable);
         }
 
         public virtual GraphQLVariableDefinition BeginVisitVariableDefinition(GraphQLVariableDefinition node)
         {
-            this.BeginVisitNode(node.Type);
+            BeginVisitNode(node.Type);
 
             return node;
         }
@@ -214,7 +213,7 @@
             IEnumerable<GraphQLVariableDefinition> variableDefinitions)
         {
             foreach (var definition in variableDefinitions)
-                this.BeginVisitNode(definition);
+                BeginVisitNode(definition);
 
             return variableDefinitions;
         }
@@ -241,21 +240,21 @@
                 if (definition.Kind == ASTNodeKind.FragmentDefinition)
                 {
                     var fragment = (GraphQLFragmentDefinition)definition;
-                    this.Fragments.Add(fragment.Name.Value, fragment);
+                    Fragments.Add(fragment.Name.Value, fragment);
                 }
             }
 
             foreach (var definition in ast.Definitions)
             {
-                this.BeginVisitNode(definition);
+                BeginVisitNode(definition);
             }
         }
 
         public virtual GraphQLObjectField BeginVisitObjectField(GraphQLObjectField node)
         {
-            this.BeginVisitNode(node.Name);
+            BeginVisitNode(node.Name);
 
-            this.BeginVisitNode(node.Value);
+            BeginVisitNode(node.Value);
 
             return node;
         }
@@ -263,9 +262,9 @@
         public virtual GraphQLObjectValue BeginVisitObjectValue(GraphQLObjectValue node)
         {
             foreach (var field in node.Fields)
-                this.BeginVisitNode(field);
+                BeginVisitNode(field);
 
-            return this.EndVisitObjectValue(node);
+            return EndVisitObjectValue(node);
         }
 
         public virtual GraphQLObjectValue EndVisitObjectValue(GraphQLObjectValue node)
@@ -281,14 +280,14 @@
         private ASTNode BeginVisitListValue(GraphQLListValue node)
         {
             foreach (var value in node.Values)
-                this.BeginVisitNode(value);
+                BeginVisitNode(value);
 
-            return this.EndVisitListValue(node);
+            return EndVisitListValue(node);
         }
 
         private ASTNode BeginVisitNonIntrospectionFieldSelection(GraphQLFieldSelection selection)
         {
-            return this.BeginVisitFieldSelection(selection);
+            return BeginVisitFieldSelection(selection);
         }
     }
 }

--- a/src/GraphQLParser/ISource.cs
+++ b/src/GraphQLParser/ISource.cs
@@ -3,6 +3,7 @@
     public interface ISource
     {
         string Body { get; set; }
+
         string Name { get; set; }
     }
 }

--- a/src/GraphQLParser/Location.cs
+++ b/src/GraphQLParser/Location.cs
@@ -22,6 +22,7 @@
         }
 
         public int Column { get; private set; }
+
         public int Line { get; private set; }
     }
 }

--- a/src/GraphQLParser/Parser.cs
+++ b/src/GraphQLParser/Parser.cs
@@ -13,7 +13,7 @@
 
         public GraphQLDocument Parse(ISource source)
         {
-            using (var context = new ParserContext(source, this.lexer))
+            using (var context = new ParserContext(source, lexer))
             {
                 return context.Parse();
             }

--- a/src/GraphQLParser/Source.cs
+++ b/src/GraphQLParser/Source.cs
@@ -13,6 +13,7 @@
         }
 
         public string Body { get; set; }
+
         public string Name { get; set; }
 
         private static string MonetizeLineBreaks(string input)

--- a/src/GraphQLParser/Token.cs
+++ b/src/GraphQLParser/Token.cs
@@ -26,8 +26,11 @@
     public class Token
     {
         public int End { get; set; }
+
         public TokenKind Kind { get; set; }
+
         public int Start { get; set; }
+
         public string Value { get; set; }
 
         public static string GetTokenKindDescription(TokenKind kind)
@@ -53,9 +56,8 @@
                 case TokenKind.FLOAT: return "Float";
                 case TokenKind.STRING: return "String";
                 case TokenKind.COMMENT: return "#";
+                default: return string.Empty;
             }
-
-            return string.Empty;
         }
 
         public override string ToString()


### PR DESCRIPTION
Related to graphql-dotnet/graphql-dotnet#1172

1. Adds `IHasDirectivesNode` interface.
2. Adds `INamedNode` interface. It is not required now, but it seemed useful to me to have.
3. Code cleanup in separate commit.