### PR TITLE
Move INamedNode to GraphQLTypeDefinition

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.1.2.{build}
+version: 4.2.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-parser",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "main": "index.js",
   "repository": "git@github.com:graphql-dotnet/parser.git",
   "author": "Joe McBride",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   
   <PropertyGroup>
-    <VersionPrefix>4.1.2</VersionPrefix>
+    <VersionPrefix>4.2.0</VersionPrefix>
     <Authors>Marek Magdziak</Authors>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Copyright>Copyright 2016-2019 Marek Magdziak et al. All rights reserved.</Copyright>

--- a/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
@@ -2,7 +2,7 @@
 {
     using System.Collections.Generic;
 
-    public class GraphQLDirectiveDefinition : GraphQLTypeDefinition, INamedNode
+    public class GraphQLDirectiveDefinition : GraphQLTypeDefinition
     {
         public IEnumerable<GraphQLInputValueDefinition> Arguments { get; set; }
 
@@ -11,7 +11,5 @@
         public override ASTNodeKind Kind => ASTNodeKind.DirectiveDefinition;
 
         public IEnumerable<GraphQLName> Locations { get; set; }
-
-        public GraphQLName Name { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
@@ -2,13 +2,11 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLEnumTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
+    public class GraphQLEnumTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.EnumTypeDefinition;
-
-        public GraphQLName Name { get; set; }
 
         public IEnumerable<GraphQLEnumValueDefinition> Values { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
@@ -2,12 +2,10 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLEnumValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
+    public class GraphQLEnumValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.EnumValueDefinition;
-
-        public GraphQLName Name { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
@@ -2,15 +2,13 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLFieldDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
+    public class GraphQLFieldDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLInputValueDefinition> Arguments { get; set; }
 
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.FieldDefinition;
-
-        public GraphQLName Name { get; set; }
 
         public GraphQLType Type { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
@@ -2,14 +2,12 @@
 {
     using System.Collections.Generic;
 
-    public class GraphQLInputObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
+    public class GraphQLInputObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 
         public IEnumerable<GraphQLInputValueDefinition> Fields { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.InputObjectTypeDefinition;
-
-        public GraphQLName Name { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
@@ -2,15 +2,13 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInputValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
+    public class GraphQLInputValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public GraphQLValue DefaultValue { get; set; }
 
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.InputValueDefinition;
-
-        public GraphQLName Name { get; set; }
 
         public GraphQLType Type { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
@@ -2,14 +2,12 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
+    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 
         public IEnumerable<GraphQLFieldDefinition> Fields { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.InterfaceTypeDefinition;
-
-        public GraphQLName Name { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLLocation.cs
+++ b/src/GraphQLParser/AST/GraphQLLocation.cs
@@ -1,5 +1,8 @@
-﻿namespace GraphQLParser.AST
+﻿using System.Diagnostics;
+
+namespace GraphQLParser.AST
 {
+    [DebuggerDisplay("(Start={Start}, End={End})")]
     public class GraphQLLocation
     {
         public int End { get; set; }

--- a/src/GraphQLParser/AST/GraphQLName.cs
+++ b/src/GraphQLParser/AST/GraphQLName.cs
@@ -1,5 +1,8 @@
-﻿namespace GraphQLParser.AST
+﻿using System.Diagnostics;
+
+namespace GraphQLParser.AST
 {
+    [DebuggerDisplay("{Value}")]
     public class GraphQLName : ASTNode
     {
         public override ASTNodeKind Kind => ASTNodeKind.Name;

--- a/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLObjectTypeDefinition : ASTNode, IHasDirectivesNode, INamedNode
+    public class GraphQLObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 
@@ -11,7 +11,5 @@ namespace GraphQLParser.AST
         public IEnumerable<GraphQLNamedType> Interfaces { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.ObjectTypeDefinition;
-
-        public GraphQLName Name { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
@@ -2,12 +2,10 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLScalarTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
+    public class GraphQLScalarTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.ScalarTypeDefinition;
-
-        public GraphQLName Name { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
@@ -1,6 +1,7 @@
 ﻿namespace GraphQLParser.AST
 {
-    public abstract class GraphQLTypeDefinition : ASTNode
+    public abstract class GraphQLTypeDefinition : ASTNode, INamedNode
     {
+        public GraphQLName Name { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
@@ -2,13 +2,11 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLUnionTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, INamedNode
+    public class GraphQLUnionTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public IEnumerable<GraphQLDirective> Directives { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.UnionTypeDefinition;
-
-        public GraphQLName Name { get; set; }
 
         public IEnumerable<GraphQLNamedType> Types { get; set; }
     }

--- a/src/GraphQLParser/LexerContext.cs
+++ b/src/GraphQLParser/LexerContext.cs
@@ -411,7 +411,7 @@
         private Token ReadName()
         {
             var start = currentIndex;
-            var code = (char)0;
+            char code;
 
             do
             {

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -893,6 +893,7 @@
             return new GraphQLTypeExtensionDefinition
             {
                 Comment = comment,
+                Name = definition.Name,
                 Definition = definition,
                 Location = GetLocation(start)
             };

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -272,7 +272,7 @@
 
             if (Peek(TokenKind.NAME))
             {
-                ASTNode definition = null;
+                ASTNode definition;
                 if ((definition = ParseNamedDefinition()) != null)
                     return definition;
             }
@@ -458,8 +458,8 @@
         {
             var start = currentToken.Start;
             var nameOrAlias = ParseName();
-            GraphQLName name = null;
-            GraphQLName alias = null;
+            GraphQLName name;
+            GraphQLName alias;
 
             if (Skip(TokenKind.COLON))
             {
@@ -636,28 +636,23 @@
 
         private ASTNode ParseNamedDefinition()
         {
-            switch (currentToken.Value)
+            return currentToken.Value switch
             {
-                // Note: subscription is an experimental non-spec addition.
-                case "query":
-                case "mutation":
-                case "subscription":
-                    return ParseOperationDefinition();
-
-                case "fragment": return ParseFragmentDefinition();
-
-                // Note: the Type System IDL is an experimental non-spec addition.
-                case "schema": return ParseSchemaDefinition();
-                case "scalar": return ParseScalarTypeDefinition();
-                case "type": return ParseObjectTypeDefinition();
-                case "interface": return ParseInterfaceTypeDefinition();
-                case "union": return ParseUnionTypeDefinition();
-                case "enum": return ParseEnumTypeDefinition();
-                case "input": return ParseInputObjectTypeDefinition();
-                case "extend": return ParseTypeExtensionDefinition();
-                case "directive": return ParseDirectiveDefinition();
-                default: return null;
-            }
+                "query" => ParseOperationDefinition(),
+                "mutation" => ParseOperationDefinition(),
+                "subscription" => ParseOperationDefinition(),
+                "fragment" => ParseFragmentDefinition(),
+                "schema" => ParseSchemaDefinition(),
+                "scalar" => ParseScalarTypeDefinition(),
+                "type" => ParseObjectTypeDefinition(),
+                "interface" => ParseInterfaceTypeDefinition(),
+                "union" => ParseUnionTypeDefinition(),
+                "enum" => ParseEnumTypeDefinition(),
+                "input" => ParseInputObjectTypeDefinition(),
+                "extend" => ParseTypeExtensionDefinition(),
+                "directive" => ParseDirectiveDefinition(),
+                _ => null
+            };
         }
 
         private GraphQLNamedType ParseNamedType()
@@ -859,7 +854,7 @@
 
         private GraphQLType ParseType()
         {
-            GraphQLType type = null;
+            GraphQLType type;
             var start = currentToken.Start;
             if (Skip(TokenKind.BRACKET_L))
             {


### PR DESCRIPTION
This is in order to be able to write `GraphQLTypeDefinition.Name`.