### PR TITLE
Heap allocation optimizations

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.2.1.{build}
+version: 4.2.2.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-parser",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "main": "index.js",
   "repository": "git@github.com:graphql-dotnet/parser.git",
   "author": "Joe McBride",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   
   <PropertyGroup>
-    <VersionPrefix>4.2.1</VersionPrefix>
+    <VersionPrefix>4.2.2</VersionPrefix>
     <Authors>Marek Magdziak</Authors>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Copyright>Copyright 2016-2019 Marek Magdziak et al. All rights reserved.</Copyright>

--- a/src/GraphQLParser.Benchmarks/GraphQLParser.Benchmarks.csproj
+++ b/src/GraphQLParser.Benchmarks/GraphQLParser.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/GraphQLParser.Benchmarks/Program.cs
+++ b/src/GraphQLParser.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Running;
+using System;
 
 namespace GraphQLParser.Benchmarks
 {
@@ -9,6 +10,8 @@ namespace GraphQLParser.Benchmarks
 //            var bench = new LexerBenchmark();
 //            bench.LexKitchenSink();
             BenchmarkRunner.Run<LexerBenchmark>();
+            Console.WriteLine("===DONE===");
+            Console.ReadLine();
         }
     }
 }

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -49,7 +49,7 @@
 
             ParseComment();
 
-            var nodes = new List<T>();
+            var nodes = new SmallSizeOptimizedList<T>();
             while (!Skip(close))
                 nodes.Add(next());
 
@@ -126,7 +126,7 @@
             {
                 Comment = comment,
                 Operation = OperationType.Query,
-                Directives = new GraphQLDirective[] { },
+                Directives = Array.Empty<GraphQLDirective>(),
                 SelectionSet = ParseSelectionSet(),
                 Location = GetLocation(start)
             };
@@ -212,7 +212,7 @@
 
             ParseComment();
 
-            var nodes = new List<T> { next() };
+            var nodes = new SmallSizeOptimizedList<T> { next() };
             while (!Skip(close))
                 nodes.Add(next());
 
@@ -237,7 +237,7 @@
         {
             if (!Peek(TokenKind.PAREN_L))
             {
-                return new GraphQLInputValueDefinition[] { };
+                return Array.Empty<GraphQLInputValueDefinition>();
             }
 
             return Many(TokenKind.PAREN_L, () => ParseInputValueDef(), TokenKind.PAREN_R);
@@ -247,7 +247,7 @@
         {
             return Peek(TokenKind.PAREN_L) ?
                 Many(TokenKind.PAREN_L, () => ParseArgument(), TokenKind.PAREN_R) :
-                new GraphQLArgument[] { };
+                Array.Empty<GraphQLArgument>();
         }
 
         private GraphQLValue ParseBooleanValue(Token token)
@@ -301,7 +301,7 @@
                 return null;
             }
 
-            var text = new List<string>();
+            var text = new SmallSizeOptimizedList<string>();
             var start = currentToken.Start;
             int end;
 
@@ -364,7 +364,7 @@
 
         private IEnumerable<GraphQLName> ParseDirectiveLocations()
         {
-            var locations = new List<GraphQLName>();
+            var locations = new SmallSizeOptimizedList<GraphQLName>();
 
             // Directive locations may be defined with an optional leading | character
             // to aid formatting when representing a longer list of possible locations
@@ -376,16 +376,16 @@
             }
             while (Skip(TokenKind.PIPE));
 
-            return locations;
+            return locations.AsEnumerable();
         }
 
         private IEnumerable<GraphQLDirective> ParseDirectives()
         {
-            var directives = new List<GraphQLDirective>();
+            var directives = new SmallSizeOptimizedList<GraphQLDirective>();
             while (Peek(TokenKind.AT))
                 directives.Add(ParseDirective());
 
-            return directives;
+            return directives.AsEnumerable();
         }
 
         private GraphQLDocument ParseDocument()
@@ -531,7 +531,7 @@
 
         private IEnumerable<GraphQLNamedType> ParseImplementsInterfaces()
         {
-            var types = new List<GraphQLNamedType>();
+            var types = new SmallSizeOptimizedList<GraphQLNamedType>();
             if (currentToken.Value?.Equals("implements") == true)
             {
                 Advance();
@@ -543,7 +543,7 @@
                 while (Peek(TokenKind.NAME));
             }
 
-            return types;
+            return types.AsEnumerable();
         }
 
         private GraphQLInputObjectTypeDefinition ParseInputObjectTypeDefinition()
@@ -723,15 +723,15 @@
             };
         }
 
-        private List<GraphQLObjectField> ParseObjectFields(bool isConstant)
+        private IEnumerable<GraphQLObjectField> ParseObjectFields(bool isConstant)
         {
-            var fields = new List<GraphQLObjectField>();
+            var fields = new SmallSizeOptimizedList<GraphQLObjectField>();
 
             Expect(TokenKind.BRACE_L);
             while (!Skip(TokenKind.BRACE_R))
                 fields.Add(ParseObjectField(isConstant));
 
-            return fields;
+            return fields.AsEnumerable();
         }
 
         private GraphQLObjectTypeDefinition ParseObjectTypeDefinition()
@@ -903,7 +903,7 @@
 
         private IEnumerable<GraphQLNamedType> ParseUnionMembers()
         {
-            var members = new List<GraphQLNamedType>();
+            var members = new SmallSizeOptimizedList<GraphQLNamedType>();
 
             // Union members may be defined with an optional leading | character
             // to aid formatting when representing a longer list of possible types
@@ -915,7 +915,7 @@
             }
             while (Skip(TokenKind.PIPE));
 
-            return members;
+            return members.AsEnumerable();
         }
 
         private GraphQLUnionTypeDefinition ParseUnionTypeDefinition()
@@ -980,7 +980,7 @@
         {
             return Peek(TokenKind.PAREN_L) ?
                 Many(TokenKind.PAREN_L, () => ParseVariableDefinition(), TokenKind.PAREN_R) :
-                new GraphQLVariableDefinition[] { };
+                Array.Empty<GraphQLVariableDefinition>();
         }
 
         private bool Peek(TokenKind kind) => currentToken.Kind == kind;

--- a/src/GraphQLParser/SmallSizeOptimizedList.cs
+++ b/src/GraphQLParser/SmallSizeOptimizedList.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace GraphQLParser
+{
+    /// <summary>
+    /// Optimized for memory allocation list for a small number of elements - from 0 to 5.
+    /// </summary>
+    /// <typeparam name="T"> Element type. </typeparam>
+    internal struct SmallSizeOptimizedList<T> : IEnumerable<T>
+    {
+        private int _firstElementsCount;
+        
+        // stack allocated for 0-5 elements
+        private T _elem1;
+        private T _elem2;
+        private T _elem3;
+        private T _elem4;
+        private T _elem5;
+
+        // if more than 5 elements then heap allocated
+        private List<T> _items;
+
+        public int Count => _items?.Count ?? _firstElementsCount;
+
+        public void Add(T item)
+        {
+            if (_firstElementsCount == 0)
+            {
+                _firstElementsCount = 1;
+                _elem1 = item;
+            }
+            else if (_firstElementsCount == 1)
+            {
+                _firstElementsCount = 2;
+                _elem2 = item;
+            }
+            else if (_firstElementsCount == 2)
+            {
+                _firstElementsCount = 3;
+                _elem3 = item;
+            }
+            else if (_firstElementsCount == 3)
+            {
+                _firstElementsCount = 4;
+                _elem4 = item;
+            }
+            else if (_firstElementsCount == 4)
+            {
+                _firstElementsCount = 5;
+                _elem5 = item;
+            }
+            else
+            {
+                if (_items == null)
+                    _items = new List<T> { _elem1, _elem2, _elem3, _elem4, _elem5, item };
+                else
+                    _items.Add(item);
+            }
+
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (_items != null)
+            {
+                foreach (var item in _items)
+                    yield return item;
+            }
+            else
+            {
+                if (_firstElementsCount > 0)
+                    yield return _elem1;
+                if (_firstElementsCount > 1)
+                    yield return _elem2;
+                if (_firstElementsCount > 2)
+                    yield return _elem3;
+                if (_firstElementsCount > 3)
+                    yield return _elem4;
+                if (_firstElementsCount > 4)
+                    yield return _elem5;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// This method avoids boxing if the list is empty.
+        /// </summary>
+        public IEnumerable<T> AsEnumerable() => Count == 0 ? Array.Empty<T>() : (IEnumerable<T>)this;
+    }
+}


### PR DESCRIPTION
```c#
        [Benchmark]
        public void Parse()
        {
            try
            {
                var parser = new Parser(new Lexer());
                parser.Parse(new Source(@"query { field1 field2 field3 }"));
            }
            catch (GraphQLSyntaxErrorException)
            {
            }
        }
```
``` ini

BenchmarkDotNet=v0.11.4, OS=Windows 10.0.17134.1130 (1803/April2018Update/Redstone4)
Intel Core i5-6200U CPU 2.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
Frequency=2343750 Hz, Resolution=426.6667 ns, Timer=TSC
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 32bit RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 32bit RyuJIT
```
It should be noted that the measurement was not accurate, so attention should first be paid to the amount of allocated memory.

Before:

| Method |     Mean |     Error |    StdDev |   Median | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------- |---------:|----------:|----------:|---------:|------------:|------------:|------------:|--------------------:|
|  Parse | 1.814 us | 0.0362 us | 0.0915 us | 1.775 us |      0.7496 |           - |           - |             1.15 KB |

After:

| Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|  Parse | 1.922 us | 0.0349 us | 0.0309 us |      0.6599 |           - |           - |             1.02 KB |


