### PR TITLE
Repeatable directives support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.0.1.{build}
+version: 5.1.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-parser",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "main": "index.js",
   "repository": "git@github.com:graphql-dotnet/parser.git",
   "author": "Joe McBride",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   
   <PropertyGroup>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
     <Authors>Marek Magdziak</Authors>
     <NoWarn>$(NoWarn);1591</NoWarn>
-    <Copyright>Copyright 2016-2019 Marek Magdziak et al. All rights reserved.</Copyright>
+    <Copyright>Copyright 2016-2020 Marek Magdziak et al. All rights reserved.</Copyright>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
@@ -11,5 +11,7 @@
         public override ASTNodeKind Kind => ASTNodeKind.DirectiveDefinition;
 
         public List<GraphQLName> Locations { get; set; }
+
+        public bool Repeatable { get; set; }
     }
 }

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -349,6 +349,12 @@
             };
         }
 
+        /// <summary>
+        /// http://spec.graphql.org/draft/#DirectiveDefinition
+        /// DirectiveDefinition:
+        ///     Description(opt) directive @ Name ArgumentsDefinition(opt) repeatable(opt) on DirectiveLocations
+        /// </summary>
+        /// <returns></returns>
         private GraphQLDirectiveDefinition ParseDirectiveDefinition()
         {
             var comment = GetComment();
@@ -358,6 +364,7 @@
 
             var name = ParseName();
             var args = ParseArgumentDefs();
+            var repeatable = ParseRepeatable();
 
             ExpectKeyword("on");
             var locations = ParseDirectiveLocations();
@@ -366,10 +373,30 @@
             {
                 Comment = comment,
                 Name = name,
+                Repeatable = repeatable,
                 Arguments = args,
                 Locations = locations,
                 Location = GetLocation(start)
             };
+        }
+
+        private bool ParseRepeatable()
+        {
+            if (Peek(TokenKind.NAME))
+            {
+                switch (currentToken.Value)
+                {
+                    case "repeatable":
+                        Advance();
+                        return true;
+                    case "on":
+                        return false;
+                    default:
+                        throw new GraphQLSyntaxErrorException($"Unexpected {currentToken}", source, currentToken.Start);
+                }
+            }
+
+            return false;
         }
 
         private List<GraphQLName> ParseDirectiveLocations()


### PR DESCRIPTION
Fixes #56 

@joemcbride `repeatable` is still in the draft specification graphql/graphql-spec#472 (although already in master), but sooner or later the draft will become the official specification. Is it worth the wait or can we add `repeatable` support now?