### PR TITLE
add support for comments on fragments and variables

### DIFF
--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -83,6 +83,7 @@ query _(
             var def = document.Definitions.First() as GraphQLOperationDefinition;
             def.VariableDefinitions.Count().ShouldBe(3);
             def.VariableDefinitions.First().Comment.Text.ShouldBe("comment1");
+            def.VariableDefinitions.Skip(1).First().Comment.ShouldBeNull();
             def.VariableDefinitions.Skip(2).First().Comment.Text.ShouldBe("comment3");
         }
 

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -91,8 +91,8 @@
         {
             return new GraphQLFragmentSpread
             {
-                Comment = comment,
                 Name = ParseFragmentName(),
+                Comment = comment,
                 Directives = ParseDirectives(),
                 Location = GetLocation(start)
             };

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -91,8 +91,8 @@
         {
             return new GraphQLFragmentSpread
             {
-                Name = ParseFragmentName(),
                 Comment = comment,
+                Name = ParseFragmentName(),
                 Directives = ParseDirectives(),
                 Location = GetLocation(start)
             };

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -91,8 +91,8 @@
         {
             return new GraphQLFragmentSpread
             {
-                Name = ParseFragmentName(),
                 Comment = comment,
+                Name = ParseFragmentName(),
                 Directives = ParseDirectives(),
                 Location = GetLocation(start)
             };
@@ -1008,10 +1008,12 @@
 
         private GraphQLVariableDefinition ParseVariableDefinition()
         {
+            var comment = GetComment();
             int start = currentToken.Start;
+
             return new GraphQLVariableDefinition
             {
-                Comment = GetComment(),
+                Comment = comment,
                 Variable = ParseVariable(),
                 Type = AdvanceThroughColonAndParseType(),
                 DefaultValue = SkipEqualsAndParseValueLiteral(),

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -87,20 +87,22 @@
             };
         }
 
-        private ASTNode CreateGraphQLFragmentSpread(int start)
+        private ASTNode CreateGraphQLFragmentSpread(int start, GraphQLComment? comment)
         {
             return new GraphQLFragmentSpread
             {
                 Name = ParseFragmentName(),
+                Comment = comment,
                 Directives = ParseDirectives(),
                 Location = GetLocation(start)
             };
         }
 
-        private ASTNode CreateInlineFragment(int start)
+        private ASTNode CreateInlineFragment(int start, GraphQLComment? comment)
         {
             return new GraphQLInlineFragment
             {
+                Comment = comment,
                 TypeCondition = GetTypeCondition(),
                 Directives = ParseDirectives(),
                 SelectionSet = ParseSelectionSet(),
@@ -527,15 +529,16 @@
 
         private ASTNode ParseFragment()
         {
+            var comment = GetComment();
             var start = currentToken.Start;
             Expect(TokenKind.SPREAD);
 
             if (Peek(TokenKind.NAME) && !"on".Equals(currentToken.Value))
             {
-                return CreateGraphQLFragmentSpread(start);
+                return CreateGraphQLFragmentSpread(start, comment);
             }
 
-            return CreateInlineFragment(start);
+            return CreateInlineFragment(start, comment);
         }
 
         private GraphQLFragmentDefinition ParseFragmentDefinition()
@@ -1008,6 +1011,7 @@
             int start = currentToken.Start;
             return new GraphQLVariableDefinition
             {
+                Comment = GetComment(),
                 Variable = ParseVariable(),
                 Type = AdvanceThroughColonAndParseType(),
                 DefaultValue = SkipEqualsAndParseValueLiteral(),


### PR DESCRIPTION
@sungam3r I have fixed the issues for comment on fragments (spread and inline) and variables.
It should allow to uncomment the corresponding 3 tests in #1617