### PR TITLE
Add support for descriptions to all AST nodes according to the draft specification

### DIFF
--- a/src/GraphQLParser.ApiTests/ApiApprovalTests.Public_Api_Should_Not_Change_Inadvertently.approved.txt
+++ b/src/GraphQLParser.ApiTests/ApiApprovalTests.Public_Api_Should_Not_Change_Inadvertently.approved.txt
@@ -261,7 +261,7 @@ namespace GraphQLParser.AST
     public class GraphQLSchemaDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHaveDescription
     {
         public GraphQLSchemaDefinition() { }
-        public GraphQLParser.AST.GraphQLDescription Description { get; set; }
+        public GraphQLParser.AST.GraphQLDescription? Description { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLOperationTypeDefinition>? OperationTypes { get; set; }

--- a/src/GraphQLParser.ApiTests/ApiApprovalTests.Public_Api_Should_Not_Change_Inadvertently.approved.txt
+++ b/src/GraphQLParser.ApiTests/ApiApprovalTests.Public_Api_Should_Not_Change_Inadvertently.approved.txt
@@ -214,7 +214,7 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.GraphQLValue? Value { get; set; }
     }
-    public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHaveDescription
+    public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDescriptionNode, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLObjectTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
@@ -258,7 +258,7 @@ namespace GraphQLParser.AST
         public string? Value { get; set; }
         public override string? ToString() { }
     }
-    public class GraphQLSchemaDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHaveDescription
+    public class GraphQLSchemaDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDescriptionNode, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLSchemaDefinition() { }
         public GraphQLParser.AST.GraphQLDescription? Description { get; set; }
@@ -276,7 +276,7 @@ namespace GraphQLParser.AST
     {
         protected GraphQLType() { }
     }
-    public abstract class GraphQLTypeDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHaveDescription, GraphQLParser.AST.INamedNode
+    public abstract class GraphQLTypeDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDescriptionNode, GraphQLParser.AST.INamedNode
     {
         protected GraphQLTypeDefinition() { }
         public GraphQLParser.AST.GraphQLDescription? Description { get; set; }
@@ -313,13 +313,13 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
         public GraphQLParser.AST.GraphQLVariable? Variable { get; set; }
     }
+    public interface IHasDescriptionNode
+    {
+        GraphQLParser.AST.GraphQLDescription? Description { get; set; }
+    }
     public interface IHasDirectivesNode
     {
         System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
-    }
-    public interface IHaveDescription
-    {
-        GraphQLParser.AST.GraphQLDescription? Description { get; set; }
     }
     public interface INamedNode
     {

--- a/src/GraphQLParser.ApiTests/ApiApprovalTests.Public_Api_Should_Not_Change_Inadvertently.approved.txt
+++ b/src/GraphQLParser.ApiTests/ApiApprovalTests.Public_Api_Should_Not_Change_Inadvertently.approved.txt
@@ -47,6 +47,7 @@ namespace GraphQLParser.AST
         TypeExtensionDefinition = 35,
         DirectiveDefinition = 36,
         Comment = 37,
+        Description = 38,
     }
     public class GraphQLArgument : GraphQLParser.AST.ASTNode, GraphQLParser.AST.INamedNode
     {
@@ -60,6 +61,12 @@ namespace GraphQLParser.AST
         public GraphQLComment(string text) { }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public string Text { get; set; }
+    }
+    public class GraphQLDescription : GraphQLParser.AST.ASTNode
+    {
+        public GraphQLDescription(string value) { }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+        public string Value { get; set; }
     }
     public class GraphQLDirective : GraphQLParser.AST.ASTNode, GraphQLParser.AST.INamedNode
     {
@@ -207,7 +214,7 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.GraphQLValue? Value { get; set; }
     }
-    public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHaveDescription
     {
         public GraphQLObjectTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
@@ -251,9 +258,10 @@ namespace GraphQLParser.AST
         public string? Value { get; set; }
         public override string? ToString() { }
     }
-    public class GraphQLSchemaDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLSchemaDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHaveDescription
     {
         public GraphQLSchemaDefinition() { }
+        public GraphQLParser.AST.GraphQLDescription Description { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLOperationTypeDefinition>? OperationTypes { get; set; }
@@ -268,9 +276,10 @@ namespace GraphQLParser.AST
     {
         protected GraphQLType() { }
     }
-    public abstract class GraphQLTypeDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.INamedNode
+    public abstract class GraphQLTypeDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHaveDescription, GraphQLParser.AST.INamedNode
     {
         protected GraphQLTypeDefinition() { }
+        public GraphQLParser.AST.GraphQLDescription? Description { get; set; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
     public class GraphQLTypeExtensionDefinition : GraphQLParser.AST.GraphQLTypeDefinition
@@ -307,6 +316,10 @@ namespace GraphQLParser.AST
     public interface IHasDirectivesNode
     {
         System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+    }
+    public interface IHaveDescription
+    {
+        GraphQLParser.AST.GraphQLDescription? Description { get; set; }
     }
     public interface INamedNode
     {

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -543,7 +543,7 @@ Cat
         public void Should_Parse_TypeDefinition_Description(string text, string expectedDescription)
         {
             var document = new Parser(new Lexer()).Parse(new Source(text));
-            ((IHaveDescription)document.Definitions[0]).Description.Value.ShouldBe(expectedDescription);
+            ((IHasDescriptionNode)document.Definitions[0]).Description.Value.ShouldBe(expectedDescription);
         }
 
         [Fact]

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -575,6 +575,5 @@ Cat
                 .Select(v=>v.Description.Value)
                 .ShouldBe(new []{"EUR value description", "USD value description"});
         }
-
     }
 }

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -533,7 +533,7 @@ Cat
 
         [Theory]
         [InlineData("\"schema description\" schema { query : Query }", "schema description")]
-        [InlineData("\"scalar description\" scalar DateTiem", "scalar description")]
+        [InlineData("\"scalar description\" scalar DateTime", "scalar description")]
         [InlineData("\"type description\" type Query { name : String }", "type description")]
         [InlineData("\"interface description\" interface Person { name : String }", "interface description")]
         [InlineData("\"union description\" union Person = He | She", "union description")]

--- a/src/GraphQLParser/AST/Enums.cs
+++ b/src/GraphQLParser/AST/Enums.cs
@@ -40,6 +40,7 @@
         TypeExtensionDefinition,
         DirectiveDefinition,
         Comment,
+        Description
     }
 
     public enum OperationType

--- a/src/GraphQLParser/AST/GraphQLDescription.cs
+++ b/src/GraphQLParser/AST/GraphQLDescription.cs
@@ -1,0 +1,14 @@
+namespace GraphQLParser.AST
+{
+    public class GraphQLDescription : ASTNode
+    {
+        public GraphQLDescription(string value)
+        {
+            Value = value;
+        }
+
+        public override ASTNodeKind Kind => ASTNodeKind.Description;
+
+        public string Value { get; set; }
+    }
+}

--- a/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, IHaveDescription
     {
         public List<GraphQLDirective>? Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, IHaveDescription
+    public class GraphQLObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, IHasDescriptionNode
     {
         public List<GraphQLDirective>? Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
@@ -2,12 +2,14 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLSchemaDefinition : ASTNode, IHasDirectivesNode
+    public class GraphQLSchemaDefinition : ASTNode, IHasDirectivesNode, IHaveDescription
     {
         public List<GraphQLDirective>? Directives { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.SchemaDefinition;
 
         public List<GraphQLOperationTypeDefinition>? OperationTypes { get; set; }
+
+        public GraphQLDescription Description { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLSchemaDefinition : ASTNode, IHasDirectivesNode, IHaveDescription
+    public class GraphQLSchemaDefinition : ASTNode, IHasDirectivesNode, IHasDescriptionNode
     {
         public List<GraphQLDirective>? Directives { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
@@ -10,6 +10,6 @@ namespace GraphQLParser.AST
 
         public List<GraphQLOperationTypeDefinition>? OperationTypes { get; set; }
 
-        public GraphQLDescription Description { get; set; }
+        public GraphQLDescription? Description { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
@@ -1,7 +1,9 @@
 ﻿namespace GraphQLParser.AST
 {
-    public abstract class GraphQLTypeDefinition : ASTNode, INamedNode
+    public abstract class GraphQLTypeDefinition : ASTNode, INamedNode, IHaveDescription
     {
         public GraphQLName? Name { get; set; }
+
+        public GraphQLDescription? Description { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
@@ -1,6 +1,6 @@
 ﻿namespace GraphQLParser.AST
 {
-    public abstract class GraphQLTypeDefinition : ASTNode, INamedNode, IHaveDescription
+    public abstract class GraphQLTypeDefinition : ASTNode, INamedNode, IHasDescriptionNode
     {
         public GraphQLName? Name { get; set; }
 

--- a/src/GraphQLParser/AST/IHasDescriptionNode.cs
+++ b/src/GraphQLParser/AST/IHasDescriptionNode.cs
@@ -1,6 +1,6 @@
 namespace GraphQLParser.AST
 {
-    public interface IHaveDescription
+    public interface IHasDescriptionNode
     {
         GraphQLDescription? Description { get; set; }
     }

--- a/src/GraphQLParser/AST/IHaveDescription.cs
+++ b/src/GraphQLParser/AST/IHaveDescription.cs
@@ -1,0 +1,7 @@
+namespace GraphQLParser.AST
+{
+    public interface IHaveDescription
+    {
+        GraphQLDescription? Description { get; set; }
+    }
+}

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -355,6 +355,7 @@ namespace GraphQLParser
                 Arguments = ParseArguments(),
                 Location = GetLocation(start)
             };
+        /// <param name="description"></param>
         }
 
         /// <summary>
@@ -362,7 +363,6 @@ namespace GraphQLParser
         /// DirectiveDefinition:
         ///     Description(opt) directive @ Name ArgumentsDefinition(opt) repeatable(opt) on DirectiveLocations
         /// </summary>
-        /// <param name="description"></param>
         /// <returns></returns>
         private GraphQLDirectiveDefinition ParseDirectiveDefinition(GraphQLDescription? description)
         {


### PR DESCRIPTION
Fixes #33 
Description parsing added to the following AST Nodes (matches the current draft specification)::

- GraphQLSchemaDefinition
- GraphQLScalarTypeDefinition
- GraphQLObjectTypeDefinition
- GraphQLFieldDefinition
- GraphQLInputValueDefinition
- GraphQLInterfaceTypeDefinition
- GraphQLUnionTypeDefinition
- GraphQLEnumTypeDefinition
- GraphQLEnumValueDefinition
- GraphQLInputObjectTypeDefinition
- GraphQLDirectiveDefinition

This pull request doesn't add the [Block Strings](https://spec.graphql.org/draft/#sec-String-Value.Block-Strings) descriptions as that should be done on lex parsing level