### PR TITLE
Fix some source location bugs

### DIFF
--- a/src/GraphQLParser.Tests/LexerTests.cs
+++ b/src/GraphQLParser.Tests/LexerTests.cs
@@ -6,7 +6,9 @@ namespace GraphQLParser.Tests
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0022:Use expression body for methods", Justification = "Tests")]
     public class LexerTests
     {
-        private static readonly string NL = Environment.NewLine;
+        // Use a constant newline instead of Environment.NewLine to make sure the tests are
+        // consistently executed between Windows and *nix.
+        private static readonly string NL = "\n";
 
         [Fact]
         public void Lex_ATPunctuation_HasCorrectEnd()

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -295,9 +295,39 @@ scalar JSON
         }
 
         [Fact]
+        public void Parse_Fields_Object_LocationCorrect()
+        {
+            var document = ParseGraphQLFieldsSource();
+            var query = GetSingleOperationDefinition(document);
+            var field = GetSingleFieldSelection(query.SelectionSet, "object");
+
+            Assert.Equal(2, field.Location.Start);
+            Assert.Equal(22, field.Location.End);
+        }
+
+        [Fact]
+        public void Parse_Fields_Scalar_LocationCorrect()
+        {
+            var document = ParseGraphQLFieldsSource();
+            var query = GetSingleOperationDefinition(document);
+            var field = GetSingleFieldSelection(query.SelectionSet, "scalar");
+
+            Assert.Equal(22, field.Location.Start);
+            Assert.Equal(29, field.Location.End);
+        }
+
+        [Fact]
         public void Parse_VariableInlineValues_DoesNotThrowError()
         {
             new Parser(new Lexer()).Parse(new Source("{ field(complex: { a: { b: [ $var ] } }) }"));
+        }
+
+        private static GraphQLFieldSelection GetSingleFieldSelection(GraphQLSelectionSet selectionSet, string name)
+        {
+            return selectionSet
+                .Selections
+                .OfType<GraphQLFieldSelection>()
+                .First(x => x.Name?.Value == name);
         }
 
         private static GraphQLOperationDefinition GetSingleOperationDefinition(GraphQLDocument document)
@@ -469,6 +499,11 @@ directive @include(if: Boolean!)
         private static GraphQLDocument ParseGraphQLFieldSource()
         {
             return new Parser(new Lexer()).Parse(new Source("{ field }"));
+        }
+
+        private static GraphQLDocument ParseGraphQLFieldsSource()
+        {
+            return new Parser(new Lexer()).Parse(new Source("{ object { subfield } scalar }"));
         }
 
         private static GraphQLDocument ParseGraphQLFieldWithOperationTypeAndNameSource()

--- a/src/GraphQLParser.Tests/Validation/LexerValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/LexerValidationTests.cs
@@ -13,11 +13,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"multi\rline\"")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:7) Unterminated string.
-1: " + "\"multi" + @"
-         ^
-2: line" + "\"" + @"
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:7) Unterminated string.\n" +
+                "1: \"multi\rline\"\n" +
+                "         ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -33,10 +33,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("a-b"), token.End));
 
-            Assert.Equal(("Syntax Error GraphQL (1:3) Invalid number, expected digit but got: \"b\"" + @"
-1: a-b
-     ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:3) Invalid number, expected digit but got: \"b\"\n" +
+                "1: a-b\n" +
+                "     ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -45,10 +46,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("..")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:1) Unexpected character \".\"" + @"
-1: ..
-   ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:1) Unexpected character \".\"\n" +
+                "1: ..\n" +
+                "   ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -57,10 +59,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\u0007")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:1) Invalid character " + "\"\\u0007\"" + @".
-1: \u0007
-   ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:1) Invalid character \"\\u0007\".\n" +
+                "1: \\u0007\n" +
+                "   ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -69,10 +72,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\x esc\"")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \x.
-1: " + "\"bad \\x esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\x.\n" +
+                "1: \"bad \\x esc\"\n" +
+                "         ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -81,10 +85,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\z esc\"")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \z.
-1: " + "\"bad \\z esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\z.\n" +
+                "1: \"bad \\z esc\"\n" +
+                "         ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -93,10 +98,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\u1 esc\"")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \u1 es.
-1: " + "\"bad \\u1 esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\u1 es.\n" +
+                "1: \"bad \\u1 esc\"\n" +
+                "         ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -105,10 +111,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\u0XX1 esc\"")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \u0XX1.
-1: " + "\"bad \\u0XX1 esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\u0XX1.\n" +
+                "1: \"bad \\u0XX1 esc\"\n" +
+                "         ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -117,10 +124,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\uFXXX esc\"")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \uFXXX.
-1: " + "\"bad \\uFXXX esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\uFXXX.\n" +
+                "1: \"bad \\uFXXX esc\"\n" +
+                "         ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -129,10 +137,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\uXXXX esc\"")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \uXXXX.
-1: " + "\"bad \\uXXXX esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\uXXXX.\n" +
+                "1: \"bad \\uXXXX esc\"\n" +
+                "         ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -141,10 +150,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\uXXXF esc\"")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \uXXXF.
-1: " + "\"bad \\uXXXF esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\uXXXF.\n" +
+                "1: \"bad \\uXXXF esc\"\n" +
+                "         ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -153,11 +163,12 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"multi\nline\"")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:7) Unterminated string.
-1: " + "\"multi" + @"
-         ^
-2: line" + "\"" + @"
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:7) Unterminated string.\n" +
+                "1: \"multi\n" +
+                "         ^\n" +
+                "2: line\"\n",
+                exception.Message);
         }
 
         [Fact]
@@ -166,10 +177,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("?")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:1) Unexpected character \"?\"" + @"
-1: ?
-   ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:1) Unexpected character \"?\"\n" +
+                "1: ?\n" +
+                "   ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -178,10 +190,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("1.0e")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:5) Invalid number, expected digit but got: <EOF>" + @"
-1: 1.0e
-       ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:5) Invalid number, expected digit but got: <EOF>\n" +
+                "1: 1.0e\n" +
+                "       ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -190,10 +203,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("1.0eA")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:5) Invalid number, expected digit but got: \"A\"" + @"
-1: 1.0eA
-       ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:5) Invalid number, expected digit but got: \"A\"\n" +
+                "1: 1.0eA\n" +
+                "       ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -202,10 +216,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("1.A")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:3) Invalid number, expected digit but got: \"A\"" + @"
-1: 1.A
-     ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:3) Invalid number, expected digit but got: \"A\"\n" +
+                "1: 1.A\n" +
+                "     ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -214,10 +229,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("-A")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:2) Invalid number, expected digit but got: \"A\"" + @"
-1: -A
-    ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:2) Invalid number, expected digit but got: \"A\"\n" +
+                "1: -A\n" +
+                "    ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -226,10 +242,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\\u203B")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:1) Unexpected character \"\\u203B\"" + @"
-1: \u203B
-   ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:1) Unexpected character \"\\u203B\"\n" +
+                "1: \\u203B\n" +
+                "   ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -238,10 +255,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\\u200b")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:1) Unexpected character \"\\u200b\"" + @"
-1: \u200b
-   ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:1) Unexpected character \"\\u200b\"\n" +
+                "1: \\u200b\n" +
+                "   ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -250,10 +268,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"null-byte is not \u0000 end of file")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:19) Invalid character within String: \u0000.
-1: " + "\"null-byte is not \\u0000 end of file" + @"
-                     ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:19) Invalid character within String: \\u0000.\n" +
+                "1: \"null-byte is not \\u0000 end of file\n" +
+                "                     ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -262,10 +281,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("00")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:2) Invalid number, unexpected digit after 0: " + "\"0\"" + @"
-1: 00
-    ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:2) Invalid number, unexpected digit after 0: \"0\"\n" +
+                "1: 00\n" +
+                "    ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -274,10 +294,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("1.")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:3) Invalid number, expected digit but got: <EOF>" + @"
-1: 1.
-     ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:3) Invalid number, expected digit but got: <EOF>\n" +
+                "1: 1.\n" +
+                "     ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -286,10 +307,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("+1")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:1) Unexpected character \"+\"" + @"
-1: +1
-   ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:1) Unexpected character \"+\"\n" +
+                "1: +1\n" +
+                "   ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -298,10 +320,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source(".123")));
 
-            Assert.Equal(("Syntax Error GraphQL (1:1) Unexpected character \".\"" + @"
-1: .123
-   ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:1) Unexpected character \".\"\n" +
+                "1: .123\n" +
+                "   ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -310,10 +333,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"contains unescaped \u0007 control char")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:21) Invalid character within String: \u0007.
-1: " + "\"contains unescaped \\u0007 control char" + @"
-                       ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:21) Invalid character within String: \\u0007.\n" +
+                "1: \"contains unescaped \\u0007 control char\n" +
+                "                       ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -322,10 +346,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:2) Unterminated string.
-1: " + "\"" + @"
-    ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:2) Unterminated string.\n" +
+                "1: \"\n" +
+                "    ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -334,10 +359,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"no end quote")));
 
-            Assert.Equal((@"Syntax Error GraphQL (1:14) Unterminated string.
-1: " + "\"no end quote" + @"
-                ^
-").Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:14) Unterminated string.\n" +
+                "1: \"no end quote\n" +
+                "                ^\n",
+                exception.Message);
         }
     }
 }

--- a/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
@@ -13,10 +13,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("fragment on on on { on }")));
 
-            Assert.Equal(@"Syntax Error GraphQL (1:10) Unexpected Name " + "\"on\"" + @"
-1: fragment on on on { on }
-            ^
-".Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:10) Unexpected Name \"on\"\n" +
+                "1: fragment on on on { on }\n" +
+                "            ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -25,10 +26,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("query Foo($x: Complex = { a: { b: [ $var ] } }) { field }")));
 
-            Assert.Equal(@"Syntax Error GraphQL (1:37) Unexpected $
-1: query Foo($x: Complex = { a: { b: [ $var ] } }) { field }
-                                       ^
-".Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:37) Unexpected $\n" +
+                "1: query Foo($x: Complex = { a: { b: [ $var ] } }) { field }\n" +
+                "                                       ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -37,10 +39,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("{ ...on }")));
 
-            Assert.Equal(@"Syntax Error GraphQL (1:9) Expected Name, found }
-1: { ...on }
-           ^
-".Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:9) Expected Name, found }\n" +
+                "1: { ...on }\n" +
+                "           ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -49,10 +52,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("...")));
 
-            Assert.Equal(@"Syntax Error GraphQL (1:1) Unexpected ...
-1: ...
-   ^
-".Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:1) Unexpected ...\n" +
+                "1: ...\n" +
+                "   ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -61,10 +65,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("{")));
 
-            Assert.Equal(@"Syntax Error GraphQL (1:2) Expected Name, found EOF
-1: {
-    ^
-".Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:2) Expected Name, found EOF\n" +
+                "1: {\n" +
+                "    ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -73,24 +78,25 @@ namespace GraphQLParser.Tests.Validation
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("{ field: {} }")));
 
-            Assert.Equal(@"Syntax Error GraphQL (1:10) Expected Name, found {
-1: { field: {} }
-            ^
-".Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:10) Expected Name, found {\n" +
+                "1: { field: {} }\n" +
+                "            ^\n",
+                exception.Message);
         }
 
         [Fact]
         public void Parse_MissingFragmentType_ThrowsExceptionWithCorrectMessage()
         {
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
-                () => new Parser(new Lexer()).Parse(new Source(@"{ ...MissingOn }
-fragment MissingOn Type")));
+                () => new Parser(new Lexer()).Parse(new Source("{ ...MissingOn }\nfragment MissingOn Type")));
 
-            Assert.Equal(@"Syntax Error GraphQL (2:20) Expected " + "\"on\"" + @", found Name " + "\"Type\"" + @"
-1: { ...MissingOn }
-2: fragment MissingOn Type
-                      ^
-".Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (2:20) Expected \"on\", found Name " + "\"Type\"\n" +
+                "1: { ...MissingOn }\n" +
+                "2: fragment MissingOn Type\n" +
+                "                      ^\n",
+                exception.Message);
         }
 
         [Fact]
@@ -99,10 +105,11 @@ fragment MissingOn Type")));
             var exception = Assert.Throws<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("notanoperation Foo { field }")));
 
-            Assert.Equal(@"Syntax Error GraphQL (1:1) Unexpected Name " + "\"notanoperation\"" + @"
-1: notanoperation Foo { field }
-   ^
-".Replace(Environment.NewLine, "\n"), exception.Message);
+            Assert.Equal(
+                "Syntax Error GraphQL (1:1) Unexpected Name " + "\"notanoperation\"\n" +
+                "1: notanoperation Foo { field }\n" +
+                "   ^\n",
+                exception.Message);
         }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLLocation.cs
+++ b/src/GraphQLParser/AST/GraphQLLocation.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace GraphQLParser.AST
 {
@@ -11,8 +11,22 @@ namespace GraphQLParser.AST
             End = end;
         }
 
+        /// <summary>
+        /// The index for the character immediately after the node in the source (i.e. it's exclusive).
+        ///
+        /// For example,
+        ///     {field{subfield}}
+        ///                     ^ field.Location.End = 16
+        /// </summary>
         public int End { get; }
 
+        /// <summary>
+        /// The index for the start of the node in the source (i.e. it's inclusive).
+        ///
+        /// For example,
+        ///     {field{subfield}}
+        ///      ^ field.Location.Start = 1
+        /// </summary>
         public int Start { get; }
     }
 }

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -190,10 +190,12 @@ namespace GraphQLParser
 
         private GraphQLLocation GetLocation(int start)
         {
+            // The "_currentToken" represents the next token after the one for which the location should be evaluated, so the value
+            // for "end" needs to be the "_currentToken.Start".
             return new GraphQLLocation
             (
                 start,
-                _currentToken.End
+                _currentToken.Start
             );
         }
 

--- a/src/GraphQLParser/Source.cs
+++ b/src/GraphQLParser/Source.cs
@@ -1,4 +1,4 @@
-﻿namespace GraphQLParser
+namespace GraphQLParser
 {
     public class Source : ISource
     {
@@ -9,18 +9,11 @@
         public Source(string body, string name)
         {
             Name = name;
-            Body = MonetizeLineBreaks(body);
+            Body = body ?? string.Empty;
         }
 
         public string Body { get; set; }
 
         public string Name { get; set; }
-
-        private static string MonetizeLineBreaks(string input)
-        {
-            return (input ?? string.Empty)
-                .Replace("\r\n", "\n")
-                .Replace("\r", "\n");
-        }
     }
 }


### PR DESCRIPTION
While developing in `graphql-dotnet` I noticed a couple of issues related to the values for node locations in the original query:
1. The indexes were plain wrong because the constructor of `Source` performs some replace operations before parsing and so the indexes are not relative to the original query.
2. The value for `End` for a lot of nodes actually includes the first token immediately following the node. For example, if I have the following:
```
fragment f1 on type {
  ...
}

fragment f2 on type {
  ...
}
```
Using the location data for the first fragment to drive a substring of the original query (ignoring issue 1) results in:
```
fragment f1 on type {
  ...
}

fragment
```

The parser already treats `\r` and `\n` as expected, so fixing the first issue appears to be as simple as not string replacing. As a bonus this avoids potentially expensive allocations for large queries.

The second issue also has a relatively simple fix, as long as my understanding of the state of the parser holds true. At the time the location indices are evaluated the `_currentToken` has progressed to the token after the node of interest, and so the value for `End` should simply be `_currentToken.Start`.