### PR TITLE
Add properties to exception

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.1.2.{build}
+version: 5.1.3.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.1.3.{build}
+version: 5.2.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-parser",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "main": "index.js",
   "repository": "git@github.com:graphql-dotnet/parser.git",
   "author": "Joe McBride",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-parser",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "main": "index.js",
   "repository": "git@github.com:graphql-dotnet/parser.git",
   "author": "Joe McBride",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   
   <PropertyGroup>
-    <VersionPrefix>5.1.3</VersionPrefix>
+    <VersionPrefix>5.2.0</VersionPrefix>
     <Authors>Marek Magdziak</Authors>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Copyright>Copyright 2016-2020 Marek Magdziak et al. All rights reserved.</Copyright>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   
   <PropertyGroup>
-    <VersionPrefix>5.1.2</VersionPrefix>
+    <VersionPrefix>5.1.3</VersionPrefix>
     <Authors>Marek Magdziak</Authors>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Copyright>Copyright 2016-2020 Marek Magdziak et al. All rights reserved.</Copyright>

--- a/src/GraphQLParser.ApiTests/ApiApprovalTests.Public_Api_Should_Not_Change_Inadvertently.approved.txt
+++ b/src/GraphQLParser.ApiTests/ApiApprovalTests.Public_Api_Should_Not_Change_Inadvertently.approved.txt
@@ -461,5 +461,8 @@ namespace GraphQLParser.Exceptions
     public class GraphQLSyntaxErrorException : System.Exception
     {
         public GraphQLSyntaxErrorException(string description, GraphQLParser.ISource source, int location) { }
+        public int Column { get; }
+        public string Description { get; }
+        public int Line { get; }
     }
 }

--- a/src/GraphQLParser.Tests/Validation/LexerValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/LexerValidationTests.cs
@@ -2,6 +2,7 @@ using GraphQLParser.Exceptions;
 using GraphQLParser;
 using System;
 using Xunit;
+using Shouldly;
 
 namespace GraphQLParser.Tests.Validation
 {
@@ -18,6 +19,9 @@ namespace GraphQLParser.Tests.Validation
          ^
 2: line" + "\"" + @"
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unterminated string.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(7);
         }
 
         [Fact]
@@ -37,6 +41,9 @@ namespace GraphQLParser.Tests.Validation
 1: a-b
      ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid number, expected digit but got: \"b\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(3);
         }
 
         [Fact]
@@ -49,6 +56,9 @@ namespace GraphQLParser.Tests.Validation
 1: ..
    ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected character \".\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(1);
         }
 
         [Fact]
@@ -61,6 +71,9 @@ namespace GraphQLParser.Tests.Validation
 1: \u0007
    ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid character \"\\u0007\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(1);
         }
 
         [Fact]
@@ -73,6 +86,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"bad \\x esc\"" + @"
          ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid character escape sequence: \\x.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(7);
         }
 
         [Fact]
@@ -85,6 +101,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"bad \\z esc\"" + @"
          ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid character escape sequence: \\z.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(7);
         }
 
         [Fact]
@@ -97,6 +116,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"bad \\u1 esc\"" + @"
          ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid character escape sequence: \\u1 es.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(7);
         }
 
         [Fact]
@@ -109,6 +131,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"bad \\u0XX1 esc\"" + @"
          ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid character escape sequence: \\u0XX1.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(7);
         }
 
         [Fact]
@@ -121,6 +146,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"bad \\uFXXX esc\"" + @"
          ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid character escape sequence: \\uFXXX.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(7);
         }
 
         [Fact]
@@ -133,6 +161,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"bad \\uXXXX esc\"" + @"
          ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid character escape sequence: \\uXXXX.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(7);
         }
 
         [Fact]
@@ -145,6 +176,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"bad \\uXXXF esc\"" + @"
          ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid character escape sequence: \\uXXXF.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(7);
         }
 
         [Fact]
@@ -158,6 +192,9 @@ namespace GraphQLParser.Tests.Validation
          ^
 2: line" + "\"" + @"
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unterminated string.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(7);
         }
 
         [Fact]
@@ -170,6 +207,9 @@ namespace GraphQLParser.Tests.Validation
 1: ?
    ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected character \"?\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(1);
         }
 
         [Fact]
@@ -182,6 +222,9 @@ namespace GraphQLParser.Tests.Validation
 1: 1.0e
        ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid number, expected digit but got: <EOF>");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(5);
         }
 
         [Fact]
@@ -194,6 +237,9 @@ namespace GraphQLParser.Tests.Validation
 1: 1.0eA
        ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid number, expected digit but got: \"A\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(5);
         }
 
         [Fact]
@@ -206,6 +252,9 @@ namespace GraphQLParser.Tests.Validation
 1: 1.A
      ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid number, expected digit but got: \"A\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(3);
         }
 
         [Fact]
@@ -218,6 +267,9 @@ namespace GraphQLParser.Tests.Validation
 1: -A
     ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid number, expected digit but got: \"A\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(2);
         }
 
         [Fact]
@@ -230,6 +282,9 @@ namespace GraphQLParser.Tests.Validation
 1: \u203B
    ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected character \"\\u203B\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(1);
         }
 
         [Fact]
@@ -242,6 +297,9 @@ namespace GraphQLParser.Tests.Validation
 1: \u200b
    ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected character \"\\u200b\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(1);
         }
 
         [Fact]
@@ -254,6 +312,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"null-byte is not \\u0000 end of file" + @"
                      ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid character within String: \\u0000.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(19);
         }
 
         [Fact]
@@ -266,6 +327,9 @@ namespace GraphQLParser.Tests.Validation
 1: 00
     ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid number, unexpected digit after 0: " + "\"0\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(2);
         }
 
         [Fact]
@@ -278,6 +342,9 @@ namespace GraphQLParser.Tests.Validation
 1: 1.
      ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid number, expected digit but got: <EOF>");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(3);
         }
 
         [Fact]
@@ -290,6 +357,9 @@ namespace GraphQLParser.Tests.Validation
 1: +1
    ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected character \"+\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(1);
         }
 
         [Fact]
@@ -302,6 +372,9 @@ namespace GraphQLParser.Tests.Validation
 1: .123
    ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected character \".\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(1);
         }
 
         [Fact]
@@ -314,6 +387,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"contains unescaped \\u0007 control char" + @"
                        ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Invalid character within String: \\u0007.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(21);
         }
 
         [Fact]
@@ -326,6 +402,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"" + @"
     ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unterminated string.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(2);
         }
 
         [Fact]
@@ -338,6 +417,9 @@ namespace GraphQLParser.Tests.Validation
 1: " + "\"no end quote" + @"
                 ^
 ").Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unterminated string.");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(14);
         }
     }
 }

--- a/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
@@ -2,6 +2,7 @@ using GraphQLParser.Exceptions;
 using GraphQLParser;
 using System;
 using Xunit;
+using Shouldly;
 
 namespace GraphQLParser.Tests.Validation
 {
@@ -17,6 +18,9 @@ namespace GraphQLParser.Tests.Validation
 1: fragment on on on { on }
             ^
 ".Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected Name " + "\"on\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(10);
         }
 
         [Fact]
@@ -29,6 +33,9 @@ namespace GraphQLParser.Tests.Validation
 1: query Foo($x: Complex = { a: { b: [ $var ] } }) { field }
                                        ^
 ".Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected $");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(37);
         }
 
         [Fact]
@@ -41,6 +48,9 @@ namespace GraphQLParser.Tests.Validation
 1: { ...on }
            ^
 ".Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected Name, found }");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(9);
         }
 
         [Fact]
@@ -53,6 +63,9 @@ namespace GraphQLParser.Tests.Validation
 1: ...
    ^
 ".Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected ...");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(1);
         }
 
         [Fact]
@@ -65,6 +78,9 @@ namespace GraphQLParser.Tests.Validation
 1: {
     ^
 ".Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Expected Name, found EOF");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(2);
         }
 
         [Fact]
@@ -77,6 +93,9 @@ namespace GraphQLParser.Tests.Validation
 1: { field: {} }
             ^
 ".Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Expected Name, found {");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(10);
         }
 
         [Fact]
@@ -91,6 +110,9 @@ fragment MissingOn Type")));
 2: fragment MissingOn Type
                       ^
 ".Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Expected \"on\", found Name \"Type\"");
+            exception.Line.ShouldBe(2);
+            exception.Column.ShouldBe(20);
         }
 
         [Fact]
@@ -103,6 +125,9 @@ fragment MissingOn Type")));
 1: notanoperation Foo { field }
    ^
 ".Replace(Environment.NewLine, "\n"), exception.Message);
+            exception.Description.ShouldBe("Unexpected Name \"notanoperation\"");
+            exception.Line.ShouldBe(1);
+            exception.Column.ShouldBe(1);
         }
     }
 }

--- a/src/GraphQLParser/Exceptions/GraphQLSyntaxErrorException.cs
+++ b/src/GraphQLParser/Exceptions/GraphQLSyntaxErrorException.cs
@@ -6,9 +6,17 @@ namespace GraphQLParser.Exceptions
 {
     public class GraphQLSyntaxErrorException : Exception
     {
+        public string Description { get; private set; }
+        public int Line { get; private set; }
+        public int Column { get; private set; }
+
         public GraphQLSyntaxErrorException(string description, ISource source, int location)
             : base(ComposeMessage(description, source, location))
         {
+            Description = description;
+            var locationInfo = new Location(source, location);
+            Line = locationInfo.Line;
+            Column = locationInfo.Column;
         }
 
         private static string ComposeMessage(string description, ISource source, int loc)

--- a/src/GraphQLParser/Exceptions/GraphQLSyntaxErrorException.cs
+++ b/src/GraphQLParser/Exceptions/GraphQLSyntaxErrorException.cs
@@ -11,18 +11,20 @@ namespace GraphQLParser.Exceptions
         public int Column { get; private set; }
 
         public GraphQLSyntaxErrorException(string description, ISource source, int location)
+            : this(description, source, new Location(source, location))
+        {
+        }
+
+        private GraphQLSyntaxErrorException(string description, ISource source, Location location)
             : base(ComposeMessage(description, source, location))
         {
             Description = description;
-            var locationInfo = new Location(source, location);
-            Line = locationInfo.Line;
-            Column = locationInfo.Column;
+            Line = location.Line;
+            Column = location.Column;
         }
 
-        private static string ComposeMessage(string description, ISource source, int loc)
+        private static string ComposeMessage(string description, ISource source, Location location)
         {
-            var location = new Location(source, loc);
-
             return $"Syntax Error GraphQL ({location.Line}:{location.Column}) {description}" +
                 "\n" + HighlightSourceAtLocation(source, location);
         }


### PR DESCRIPTION
This PR adds 3 new properties to the `GraphQLSyntaxErrorException` class:
* Description
* Line
* Column

The `Message` property will not change.  All tests that verify the `Message` property have been updated to verify the values in these new fields.