### PR TITLE
String.concat optimization for STRING and COMMENT tokens

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.3.0.{build}
+version: 5.3.1.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-parser",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "main": "index.js",
   "repository": "git@github.com:graphql-dotnet/parser.git",
   "author": "Joe McBride",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   
   <PropertyGroup>
-    <VersionPrefix>5.3.0</VersionPrefix>
+    <VersionPrefix>5.3.1</VersionPrefix>
     <Authors>Marek Magdziak</Authors>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Copyright>Copyright 2016-2020 Marek Magdziak et al. All rights reserved.</Copyright>

--- a/src/GraphQLParser.ApiTests/GraphQLParser.ApiTests.csproj
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.ApiTests.csproj
@@ -6,7 +6,7 @@
   
   <ItemGroup>
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Shouldly" Version="4.0.0-beta0002" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/src/GraphQLParser.Tests/GraphQLParser.Tests.csproj
+++ b/src/GraphQLParser.Tests/GraphQLParser.Tests.csproj
@@ -11,12 +11,12 @@
 
   <ItemGroup>
     <PackageReference Include="Shouldly" Version="4.0.0-beta0002" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="xunit.runner.reporters" Version="2.4.1" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="ReportGenerator" Version="4.6.4" />
+    <PackageReference Include="ReportGenerator" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/GraphQLParser/GraphQLParser.csproj
+++ b/src/GraphQLParser/GraphQLParser.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Library containing lexer and parser for GraphQL syntax</Description>


### PR DESCRIPTION
I came across the fact that the parser was processing some requests for a very long time and with the allocation of a huge amount (tens, hundreds of megabytes) of memory. It turned out that this happens when parsing strings (for example, in arguments represented by large objects with many properties, including nested ones), when the string contains escape sequences, i.e. `\"`. I saw that the code was doing many string concatenations, forming the final string from small chunks. The algorithm now uses a buffer. The parser processed one of my requests for more than 10 seconds, now it happens almost instantly. The memory consumption has been reduced many times over.