### PR TITLE
Stop query Normalization

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.3.2.{build}
+version: 5.3.3.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-parser",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "main": "index.js",
   "repository": "git@github.com:graphql-dotnet/parser.git",
   "author": "Joe McBride",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   
   <PropertyGroup>
-    <VersionPrefix>5.3.2</VersionPrefix>
+    <VersionPrefix>5.3.3</VersionPrefix>
     <Authors>Marek Magdziak</Authors>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Copyright>Copyright 2016-2020 Marek Magdziak et al. All rights reserved.</Copyright>

--- a/src/GraphQLParser.Tests/LexerTests.cs
+++ b/src/GraphQLParser.Tests/LexerTests.cs
@@ -7,7 +7,9 @@ namespace GraphQLParser.Tests
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0022:Use expression body for methods", Justification = "Tests")]
     public class LexerTests
     {
-        private static readonly string NL = Environment.NewLine;
+        // Use a constant newline instead of Environment.NewLine to make sure the tests are
+        // consistently executed between Windows and *nix.
+        private static readonly string NL = "\n";
 
         [Fact]
         public void Lex_ATPunctuation_HasCorrectEnd()

--- a/src/GraphQLParser.Tests/Validation/LexerValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/LexerValidationTests.cs
@@ -35,10 +35,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("a-b"), token.End));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:3) Invalid number, expected digit but got: \"b\"" + @"
-1: a-b
-     ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:3) Invalid number, expected digit but got: \"b\"\n" +
+                "1: a-b\n" +
+                "     ^\n");
             exception.Description.ShouldBe("Invalid number, expected digit but got: \"b\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(3);
@@ -50,10 +50,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("..")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:1) Unexpected character \".\"" + @"
-1: ..
-   ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:1) Unexpected character \".\"\n" +
+                "1: ..\n" +
+                "   ^\n");
             exception.Description.ShouldBe("Unexpected character \".\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(1);
@@ -65,10 +65,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\u0007")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:1) Invalid character " + "\"\\u0007\"" + @".
-1: \u0007
-   ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:1) Invalid character \"\\u0007\".\n" +
+                "1: \\u0007\n" +
+                "   ^\n");
             exception.Description.ShouldBe("Invalid character \"\\u0007\".");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(1);
@@ -80,10 +80,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\x esc\"")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \x.
-1: " + "\"bad \\x esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\x.\n" +
+                "1: \"bad \\x esc\"\n" +
+                "         ^\n");
             exception.Description.ShouldBe("Invalid character escape sequence: \\x.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(7);
@@ -95,10 +95,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\z esc\"")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \z.
-1: " + "\"bad \\z esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\z.\n" +
+                "1: \"bad \\z esc\"\n" +
+                "         ^\n");
             exception.Description.ShouldBe("Invalid character escape sequence: \\z.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(7);
@@ -110,10 +110,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\u1 esc\"")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \u1 es.
-1: " + "\"bad \\u1 esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\u1 es.\n" +
+                "1: \"bad \\u1 esc\"\n" +
+                "         ^\n");
             exception.Description.ShouldBe("Invalid character escape sequence: \\u1 es.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(7);
@@ -125,10 +125,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\u0XX1 esc\"")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \u0XX1.
-1: " + "\"bad \\u0XX1 esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\u0XX1.\n" +
+                "1: \"bad \\u0XX1 esc\"\n" +
+                "         ^\n");
             exception.Description.ShouldBe("Invalid character escape sequence: \\u0XX1.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(7);
@@ -140,10 +140,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\uFXXX esc\"")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \uFXXX.
-1: " + "\"bad \\uFXXX esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\uFXXX.\n" +
+                "1: \"bad \\uFXXX esc\"\n" +
+                "         ^\n");
             exception.Description.ShouldBe("Invalid character escape sequence: \\uFXXX.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(7);
@@ -155,10 +155,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\uXXXX esc\"")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \uXXXX.
-1: " + "\"bad \\uXXXX esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\uXXXX.\n" +
+                "1: \"bad \\uXXXX esc\"\n" +
+                "         ^\n");
             exception.Description.ShouldBe("Invalid character escape sequence: \\uXXXX.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(7);
@@ -170,10 +170,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"bad \\uXXXF esc\"")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:7) Invalid character escape sequence: \uXXXF.
-1: " + "\"bad \\uXXXF esc\"" + @"
-         ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:7) Invalid character escape sequence: \\uXXXF.\n" +
+                "1: \"bad \\uXXXF esc\"\n" +
+                "         ^\n");
             exception.Description.ShouldBe("Invalid character escape sequence: \\uXXXF.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(7);
@@ -185,11 +185,11 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"multi\nline\"")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:7) Unterminated string.
-1: " + "\"multi" + @"
-         ^
-2: line" + "\"" + @"
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:7) Unterminated string.\n" +
+                "1: \"multi\n" +
+                "         ^\n" +
+                "2: line\"\n");
             exception.Description.ShouldBe("Unterminated string.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(7);
@@ -201,10 +201,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("?")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:1) Unexpected character \"?\"" + @"
-1: ?
-   ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:1) Unexpected character \"?\"\n" +
+                "1: ?\n" +
+                "   ^\n");
             exception.Description.ShouldBe("Unexpected character \"?\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(1);
@@ -216,10 +216,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("1.0e")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:5) Invalid number, expected digit but got: <EOF>" + @"
-1: 1.0e
-       ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:5) Invalid number, expected digit but got: <EOF>\n" +
+                "1: 1.0e\n" +
+                "       ^\n");
             exception.Description.ShouldBe("Invalid number, expected digit but got: <EOF>");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(5);
@@ -231,10 +231,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("1.0eA")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:5) Invalid number, expected digit but got: \"A\"" + @"
-1: 1.0eA
-       ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:5) Invalid number, expected digit but got: \"A\"\n" +
+                "1: 1.0eA\n" +
+                "       ^\n");
             exception.Description.ShouldBe("Invalid number, expected digit but got: \"A\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(5);
@@ -246,10 +246,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("1.A")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:3) Invalid number, expected digit but got: \"A\"" + @"
-1: 1.A
-     ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:3) Invalid number, expected digit but got: \"A\"\n" +
+                "1: 1.A\n" +
+                "     ^\n");
             exception.Description.ShouldBe("Invalid number, expected digit but got: \"A\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(3);
@@ -261,10 +261,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("-A")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:2) Invalid number, expected digit but got: \"A\"" + @"
-1: -A
-    ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:2) Invalid number, expected digit but got: \"A\"\n" +
+                "1: -A\n" +
+                "    ^\n");
             exception.Description.ShouldBe("Invalid number, expected digit but got: \"A\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(2);
@@ -276,10 +276,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\\u203B")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:1) Unexpected character \"\\u203B\"" + @"
-1: \u203B
-   ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:1) Unexpected character \"\\u203B\"\n" +
+                "1: \\u203B\n" +
+                "   ^\n");
             exception.Description.ShouldBe("Unexpected character \"\\u203B\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(1);
@@ -291,10 +291,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\\u200b")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:1) Unexpected character \"\\u200b\"" + @"
-1: \u200b
-   ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:1) Unexpected character \"\\u200b\"\n" +
+                "1: \\u200b\n" +
+                "   ^\n");
             exception.Description.ShouldBe("Unexpected character \"\\u200b\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(1);
@@ -306,10 +306,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"null-byte is not \u0000 end of file")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:19) Invalid character within String: \u0000.
-1: " + "\"null-byte is not \\u0000 end of file" + @"
-                     ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:19) Invalid character within String: \\u0000.\n" +
+                "1: \"null-byte is not \\u0000 end of file\n" +
+                "                     ^\n");
             exception.Description.ShouldBe("Invalid character within String: \\u0000.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(19);
@@ -321,10 +321,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("00")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:2) Invalid number, unexpected digit after 0: " + "\"0\"" + @"
-1: 00
-    ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:2) Invalid number, unexpected digit after 0: \"0\"\n" +
+                "1: 00\n" +
+                "    ^\n");
             exception.Description.ShouldBe("Invalid number, unexpected digit after 0: " + "\"0\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(2);
@@ -336,10 +336,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("1.")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:3) Invalid number, expected digit but got: <EOF>" + @"
-1: 1.
-     ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:3) Invalid number, expected digit but got: <EOF>\n" +
+                "1: 1.\n" +
+                "     ^\n");
             exception.Description.ShouldBe("Invalid number, expected digit but got: <EOF>");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(3);
@@ -351,10 +351,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("+1")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:1) Unexpected character \"+\"" + @"
-1: +1
-   ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:1) Unexpected character \"+\"\n" +
+                "1: +1\n" +
+                "   ^\n");
             exception.Description.ShouldBe("Unexpected character \"+\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(1);
@@ -366,10 +366,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source(".123")));
 
-            exception.Message.ShouldBe(("Syntax Error GraphQL (1:1) Unexpected character \".\"" + @"
-1: .123
-   ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:1) Unexpected character \".\"\n" +
+                "1: .123\n" +
+                "   ^\n");
             exception.Description.ShouldBe("Unexpected character \".\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(1);
@@ -381,10 +381,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"contains unescaped \u0007 control char")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:21) Invalid character within String: \u0007.
-1: " + "\"contains unescaped \\u0007 control char" + @"
-                       ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:21) Invalid character within String: \\u0007.\n" +
+                "1: \"contains unescaped \\u0007 control char\n" +
+                "                       ^\n");
             exception.Description.ShouldBe("Invalid character within String: \\u0007.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(21);
@@ -396,10 +396,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:2) Unterminated string.
-1: " + "\"" + @"
-    ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:2) Unterminated string.\n" +
+                "1: \"\n" +
+                "    ^\n");
             exception.Description.ShouldBe("Unterminated string.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(2);
@@ -411,10 +411,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"no end quote")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:14) Unterminated string.
-1: " + "\"no end quote" + @"
-                ^
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:14) Unterminated string.\n" +
+                "1: \"no end quote\n" +
+                "                ^\n");
             exception.Description.ShouldBe("Unterminated string.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(14);

--- a/src/GraphQLParser.Tests/Validation/LexerValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/LexerValidationTests.cs
@@ -13,11 +13,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Lexer().Lex(new Source("\"multi\rline\"")));
 
-            exception.Message.ShouldBe((@"Syntax Error GraphQL (1:7) Unterminated string.
-1: " + "\"multi" + @"
-         ^
-2: line" + "\"" + @"
-").Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:7) Unterminated string.\n" +
+                "1: \"multi\rline\"\n" +
+                "         ^\n");
             exception.Description.ShouldBe("Unterminated string.");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(7);

--- a/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
@@ -101,14 +101,13 @@ namespace GraphQLParser.Tests.Validation
         public void Parse_MissingFragmentType_ThrowsExceptionWithCorrectMessage()
         {
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
-                () => new Parser(new Lexer()).Parse(new Source(@"{ ...MissingOn }
-fragment MissingOn Type")));
+                () => new Parser(new Lexer()).Parse(new Source("{ ...MissingOn }\nfragment MissingOn Type")));
 
-            exception.Message.ShouldBe(@"Syntax Error GraphQL (2:20) Expected " + "\"on\"" + @", found Name " + "\"Type\"" + @"
-1: { ...MissingOn }
-2: fragment MissingOn Type
-                      ^
-".Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (2:20) Expected \"on\", found Name \"Type\"\n" +
+                "1: { ...MissingOn }\n" +
+                "2: fragment MissingOn Type\n" +
+                "                      ^\n");
             exception.Description.ShouldBe("Expected \"on\", found Name \"Type\"");
             exception.Line.ShouldBe(2);
             exception.Column.ShouldBe(20);

--- a/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
@@ -13,10 +13,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("fragment on on on { on }")));
 
-            exception.Message.ShouldBe(@"Syntax Error GraphQL (1:10) Unexpected Name " + "\"on\"" + @"
-1: fragment on on on { on }
-            ^
-".Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:10) Unexpected Name \"on\"\n" +
+                "1: fragment on on on { on }\n" +
+                "            ^\n");
             exception.Description.ShouldBe("Unexpected Name " + "\"on\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(10);
@@ -28,10 +28,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("query Foo($x: Complex = { a: { b: [ $var ] } }) { field }")));
 
-            exception.Message.ShouldBe(@"Syntax Error GraphQL (1:37) Unexpected $
-1: query Foo($x: Complex = { a: { b: [ $var ] } }) { field }
-                                       ^
-".Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:37) Unexpected $\n" +
+                "1: query Foo($x: Complex = { a: { b: [ $var ] } }) { field }\n" +
+                "                                       ^\n");
             exception.Description.ShouldBe("Unexpected $");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(37);
@@ -43,10 +43,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("{ ...on }")));
 
-            exception.Message.ShouldBe(@"Syntax Error GraphQL (1:9) Expected Name, found }
-1: { ...on }
-           ^
-".Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:9) Expected Name, found }\n" +
+                "1: { ...on }\n" +
+                "           ^\n");
             exception.Description.ShouldBe("Expected Name, found }");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(9);
@@ -58,10 +58,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("...")));
 
-            exception.Message.ShouldBe(@"Syntax Error GraphQL (1:1) Unexpected ...
-1: ...
-   ^
-".Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                    "Syntax Error GraphQL (1:1) Unexpected ...\n" +
+                    "1: ...\n" +
+                    "   ^\n");
             exception.Description.ShouldBe("Unexpected ...");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(1);
@@ -73,10 +73,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("{")));
 
-            exception.Message.ShouldBe(@"Syntax Error GraphQL (1:2) Expected Name, found EOF
-1: {
-    ^
-".Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:2) Expected Name, found EOF\n" +
+                "1: {\n" +
+                "    ^\n");
             exception.Description.ShouldBe("Expected Name, found EOF");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(2);
@@ -88,10 +88,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("{ field: {} }")));
 
-            exception.Message.ShouldBe(@"Syntax Error GraphQL (1:10) Expected Name, found {
-1: { field: {} }
-            ^
-".Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:10) Expected Name, found {\n" +
+                "1: { field: {} }\n" +
+                "            ^\n");
             exception.Description.ShouldBe("Expected Name, found {");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(10);
@@ -119,10 +119,10 @@ namespace GraphQLParser.Tests.Validation
             var exception = Should.Throw<GraphQLSyntaxErrorException>(
                 () => new Parser(new Lexer()).Parse(new Source("notanoperation Foo { field }")));
 
-            exception.Message.ShouldBe(@"Syntax Error GraphQL (1:1) Unexpected Name " + "\"notanoperation\"" + @"
-1: notanoperation Foo { field }
-   ^
-".Replace(Environment.NewLine, "\n"));
+            exception.Message.ShouldBe(
+                "Syntax Error GraphQL (1:1) Unexpected Name " + "\"notanoperation\"\n" +
+                "1: notanoperation Foo { field }\n" +
+                "   ^\n");
             exception.Description.ShouldBe("Unexpected Name \"notanoperation\"");
             exception.Line.ShouldBe(1);
             exception.Column.ShouldBe(1);

--- a/src/GraphQLParser/Source.cs
+++ b/src/GraphQLParser/Source.cs
@@ -1,4 +1,4 @@
-﻿namespace GraphQLParser
+namespace GraphQLParser
 {
     public class Source : ISource
     {
@@ -9,18 +9,11 @@
         public Source(string body, string name)
         {
             Name = name;
-            Body = MonetizeLineBreaks(body);
+            Body = body ?? string.Empty;
         }
 
         public string Body { get; set; }
 
         public string Name { get; set; }
-
-        private static string MonetizeLineBreaks(string input)
-        {
-            return (input ?? string.Empty)
-                .Replace("\r\n", "\n")
-                .Replace("\r", "\n");
-        }
     }
 }


### PR DESCRIPTION
This is derived from https://github.com/graphql-dotnet/parser/pull/71 due to it being easier to resolve conflicts from a clean slate.

Specifically:
```
1. The indexes were plain wrong because the constructor of `Source` performs some replace operations before parsing and
   so the indexes are not relative to the original query

...

The parser already treats \r and \n as expected, so fixing the first issue appears to be as simple as not string replacing.
As a bonus this avoids potentially expensive allocations for large queries.
```