### PR TITLE
Fix comment parsing with unattached comments

### DIFF
--- a/src/GraphQLParser.ApiTests/ApiApprovalTests.Public_Api_Should_Not_Change_Inadvertently.approved.txt
+++ b/src/GraphQLParser.ApiTests/ApiApprovalTests.Public_Api_Should_Not_Change_Inadvertently.approved.txt
@@ -82,6 +82,7 @@ namespace GraphQLParser.AST
         public GraphQLDocument() { }
         public System.Collections.Generic.List<GraphQLParser.AST.ASTNode>? Definitions { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLComment>? UnattachedComments { get; set; }
     }
     public class GraphQLEnumTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {

--- a/src/GraphQLParser/AST/GraphQLDocument.cs
+++ b/src/GraphQLParser/AST/GraphQLDocument.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
@@ -7,5 +7,6 @@ namespace GraphQLParser.AST
         public List<ASTNode>? Definitions { get; set; }
 
         public override ASTNodeKind Kind => ASTNodeKind.Document;
+        public List<GraphQLComment>? UnattachedComments { get; set; }
     }
 }

--- a/src/GraphQLParser/Parser.cs
+++ b/src/GraphQLParser/Parser.cs
@@ -13,7 +13,7 @@ namespace GraphQLParser
 
         public GraphQLDocument Parse(ISource source)
         {
-            using var context = new ParserContext(source, _lexer);
+            var context = new ParserContext(source, _lexer);
             return context.Parse();
         }
     }

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -675,7 +675,7 @@ namespace GraphQLParser
             int start = _currentToken.Start;
             // the compiler caches these delegates in the generated code
             ParseCallback<GraphQLValue> constant = (ref ParserContext context) => context.ParseConstantValue();
-            ParseCallback<GraphQLValue > value = (ref ParserContext context) => context.ParseValueValue();
+            ParseCallback<GraphQLValue> value = (ref ParserContext context) => context.ParseValueValue();
 
             return new GraphQLListValue(ASTNodeKind.ListValue)
             {

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -6,18 +6,20 @@ using GraphQLParser.Exceptions;
 namespace GraphQLParser
 {
     // WARNING: mutable struct, pass it by reference to those methods that will change it
-    internal struct ParserContext : IDisposable
+    internal struct ParserContext
     {
         private delegate TResult ParseCallback<out TResult>(ref ParserContext context);
 
         private readonly ILexer _lexer;
         private readonly ISource _source;
-        private Stack<GraphQLComment>? _comments;
+        private GraphQLComment? _comment;
+        private List<GraphQLComment>? _comments;
         private Token _currentToken;
         private Token _prevToken;
 
         public ParserContext(ISource source, ILexer lexer)
         {
+            _comment = null;
             _comments = null;
             _source = source;
             _lexer = lexer;
@@ -32,13 +34,12 @@ namespace GraphQLParser
             );
         }
 
-        public void Dispose()
+        public GraphQLComment? GetComment()
         {
-            if (_comments?.Count > 0)
-                throw new ApplicationException($"ParserContext has {_comments.Count} not applied comments.");
+            var ret = _comment;
+            _comment = null;
+            return ret;
         }
-
-        public GraphQLComment? GetComment() => _comments?.Count > 0 ? _comments.Pop() : null;
 
         public GraphQLDocument Parse() => ParseDocument();
 
@@ -72,7 +73,7 @@ namespace GraphQLParser
             return nodes;
         }
 
-        private GraphQLDocument CreateDocument(int start, List<ASTNode> definitions)
+        private GraphQLDocument CreateDocument(int start, List<ASTNode> definitions, List<GraphQLComment>? comments)
         {
             return new GraphQLDocument
             {
@@ -84,7 +85,8 @@ namespace GraphQLParser
                     // EOF is a technical token with length = 0, _prevToken.End and _currentToken.End have the same value here.
                     _prevToken.End // equals to _currentToken.End (EOF) 
                 ),
-                Definitions = definitions
+                Definitions = definitions,
+                UnattachedComments = comments,
             };
         }
 
@@ -343,10 +345,14 @@ namespace GraphQLParser
                 )
             };
 
-            if (_comments == null)
-                _comments = new Stack<GraphQLComment>();
+            if (_comment != null)
+            {
+                if (_comments == null)
+                    _comments = new List<GraphQLComment>();
+                _comments.Add(_comment);
+            }
 
-            _comments.Push(comment);
+            _comment = comment;
 
             return comment;
         }
@@ -443,8 +449,14 @@ namespace GraphQLParser
         {
             int start = _currentToken.Start;
             var definitions = ParseDefinitionsIfNotEOF();
+            if (_comment != null)
+            {
+                if (_comments == null)
+                    _comments = new List<GraphQLComment>();
+                _comments.Add(_comment);
+            }
 
-            return CreateDocument(start, definitions);
+            return CreateDocument(start, definitions, _comments);
         }
 
         private GraphQLEnumTypeDefinition ParseEnumTypeDefinition()


### PR DESCRIPTION
Fixes #80 

* Fixes an issue where trailing comments throw an exception
* Fixes an issue where comments can be applied to an incorrect node
* Unattached comments are returned in a list attached to the document

Note: these two documents parse the same, with the comment applied to `obj2`

```gql
{
  obj1 {
    field1
    # comment
  }
  obj2 {
    field2
  }
}
```

and

```gql
{
  obj1 {
    field1
  }
  # comment
  obj2 {
    field2
  }
}
```
