### PR TITLE
allow empty object/input/interface/enum type definitions

### DIFF
--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -523,5 +523,17 @@ Cat
         {
             new Parser(new Lexer()).Parse(new Source(text)).ShouldNotBeNull();
         }
+
+        [Theory]
+        [InlineData("type Query", ASTNodeKind.ObjectTypeDefinition)]
+        [InlineData("extend type Query", ASTNodeKind.TypeExtensionDefinition)]
+        [InlineData("input Empty", ASTNodeKind.InputObjectTypeDefinition)]
+        [InlineData("extend type Type implements Interface", ASTNodeKind.TypeExtensionDefinition)]
+        public void Should_Parse_Empty_Types(string text, ASTNodeKind kind)
+        {
+            var document = new Parser(new Lexer()).Parse(new Source(text));
+            document.ShouldNotBeNull();
+            document.Definitions[0].Kind.ShouldBe(kind);
+        }
     }
 }

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -528,6 +528,8 @@ Cat
         [InlineData("type Query", ASTNodeKind.ObjectTypeDefinition)]
         [InlineData("extend type Query", ASTNodeKind.TypeExtensionDefinition)]
         [InlineData("input Empty", ASTNodeKind.InputObjectTypeDefinition)]
+        [InlineData("interface Empty", ASTNodeKind.InterfaceTypeDefinition)]
+        [InlineData("enum Empty", ASTNodeKind.EnumTypeDefinition)]
         [InlineData("extend type Type implements Interface", ASTNodeKind.TypeExtensionDefinition)]
         public void Should_Parse_Empty_Types(string text, ASTNodeKind kind)
         {

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -458,7 +458,9 @@ namespace GraphQLParser
                 Comment = comment,
                 Name = ParseName(),
                 Directives = ParseDirectives(),
-                Values = Many(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseEnumValueDefinition(), TokenKind.BRACE_R),
+                Values = Peek(TokenKind.BRACE_L)
+                    ? Many(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseEnumValueDefinition(), TokenKind.BRACE_R)
+                    : new List<GraphQLEnumValueDefinition>(),
                 Location = GetLocation(start)
             };
         }
@@ -655,7 +657,9 @@ namespace GraphQLParser
                 Comment = comment,
                 Name = ParseName(),
                 Directives = ParseDirectives(),
-                Fields = Any(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseFieldDefinition(), TokenKind.BRACE_R),
+                Fields = Peek(TokenKind.BRACE_L)
+                    ? Any(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseFieldDefinition(), TokenKind.BRACE_R)
+                    : new List<GraphQLFieldDefinition>(),
                 Location = GetLocation(start)
             };
         }

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -607,7 +607,9 @@ namespace GraphQLParser
                 Comment = comment,
                 Name = ParseName(),
                 Directives = ParseDirectives(),
-                Fields = Any(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.BRACE_R),
+                Fields = Peek(TokenKind.BRACE_L)
+                    ? Any(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.BRACE_R)
+                    : new List<GraphQLInputValueDefinition>(),
                 Location = GetLocation(start)
             };
         }
@@ -797,7 +799,9 @@ namespace GraphQLParser
                 Name = ParseName(),
                 Interfaces = ParseImplementsInterfaces(),
                 Directives = ParseDirectives(),
-                Fields = Any(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseFieldDefinition(), TokenKind.BRACE_R),
+                Fields = Peek(TokenKind.BRACE_L)
+                    ? Any(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseFieldDefinition(), TokenKind.BRACE_R)
+                    : new List<GraphQLFieldDefinition>(),
                 Location = GetLocation(start)
             };
         }


### PR DESCRIPTION
A schema definition such as:

```
type Query
```

with no `FieldsDefinition` was rejected: 

```
   GraphQLParser.Exceptions.GraphQLSyntaxErrorException : Syntax Error GraphQL (1:11) Expected {, found EOF
1: type Query
```

The GraphQL spec indicates that for [object types](https://spec.graphql.org/June2018/#ObjectTypeDefinition), [input object types](https://spec.graphql.org/June2018/#InputObjectTypeDefinition), [interfaces](https://spec.graphql.org/June2018/#InterfaceTypeDefinition), and [enums](https://spec.graphql.org/June2018/#EnumTypeDefinition) the curly-brace enclosed field set is optional, and notes that for [type extensions](https://spec.graphql.org/June2018/#ObjectTypeExtension) you may wish to extend a type just to add a directive or to indicate that it implements an interface without declaring any new fields.

The reference implementation has some test cases for these rules [here](https://github.com/graphql/graphql-js/blob/dc89262a5ecca0d48b3d5e54d5cb726762e358fd/src/language/__tests__/schema-parser-test.js#L202). Note that the reference implementation rejects type definitions which include curlies but do not declare fields, e.g. `type Query { }`, which the graphql-dotnet parser accepts. Currently this means that there is no way to write "forward declarations" of object types in a way that both the graphql-js and graphql-dotnet parsers will allow. See some discussion [here](https://github.com/graphql/graphql-spec/issues/568).