### PR TITLE
Add support for '&' syntax token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup .NET Core 5.0 SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '5.0.201'
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,9 @@ jobs:
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: List feeds
-        run: dotnet nuget list source
+      - name: Disable MSVS Nuget Source # see https://github.com/graphql-dotnet/graphql-dotnet/issues/2422
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: dotnet nuget disable source 'Microsoft Visual Studio Offline Packages'
       - name: Install dependencies
         working-directory: src
         run: dotnet restore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,6 @@ jobs:
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Disable MSVS Nuget Source # see https://github.com/graphql-dotnet/graphql-dotnet/issues/2422
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        run: dotnet nuget disable source 'Microsoft Visual Studio Offline Packages'
       - name: Install dependencies
         working-directory: src
         run: dotnet restore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: List feeds
+        run: dotnet nuget list source
       - name: Install dependencies
         working-directory: src
         run: dotnet restore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Disable MSVS Nuget Source # see https://github.com/graphql-dotnet/graphql-dotnet/issues/2422
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: dotnet nuget disable source 'Microsoft Visual Studio Offline Packages'
       - name: Install dependencies
         working-directory: src
         run: dotnet restore

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>7.0.1-preview</VersionPrefix>
+    <VersionPrefix>7.1.0-preview</VersionPrefix>
     <LangVersion>8.0</LangVersion>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/GraphQLParser.ApiTests/GraphQL-Parser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQL-Parser.approved.txt
@@ -455,5 +455,6 @@ namespace GraphQLParser
         STRING = 18,
         COMMENT = 19,
         UNKNOWN = 20,
+        AMPERSAND = 21,
     }
 }

--- a/src/GraphQLParser.Tests/Issue2478_GraphQL_NET.cs
+++ b/src/GraphQLParser.Tests/Issue2478_GraphQL_NET.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using GraphQLParser.AST;
+using Shouldly;
+using Xunit;
+
+namespace GraphQLParser.Tests
+{
+    public class Issue2478_GraphQL_NET
+    {
+        [Theory]
+        [InlineData(IgnoreOptions.None)]
+        [InlineData(IgnoreOptions.IgnoreComments)]
+        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        public void TestSchemaWithTwoInterfaceImplemented(IgnoreOptions options)
+        {
+            string query = @"
+            type Query {
+              me: Account
+            }
+
+            interface FooInterface {
+              id: String
+            }
+
+            interface BooInterface {
+              name: String
+            }
+
+            type Account implements FooInterface & BooInterface {
+              id: String
+              name: String
+            }
+        ";
+
+            using var document = query.Parse(new ParserOptions { Ignore = options });
+            document.Definitions.Count.ShouldBe(4);
+            var def = document.Definitions.Last() as GraphQLObjectTypeDefinition;
+            def.Interfaces.Count.ShouldBe(2);
+        }
+    }
+}

--- a/src/GraphQLParser/LexerContext.cs
+++ b/src/GraphQLParser/LexerContext.cs
@@ -322,6 +322,7 @@ namespace GraphQLParser
             ':' => CreatePunctuationToken(TokenKind.COLON, 1),
             '=' => CreatePunctuationToken(TokenKind.EQUALS, 1),
             '@' => CreatePunctuationToken(TokenKind.AT, 1),
+            '&' => CreatePunctuationToken(TokenKind.AMPERSAND, 1),
             '[' => CreatePunctuationToken(TokenKind.BRACKET_L, 1),
             ']' => CreatePunctuationToken(TokenKind.BRACKET_R, 1),
             '{' => CreatePunctuationToken(TokenKind.BRACE_L, 1),

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -567,11 +567,15 @@ namespace GraphQLParser
                 types = new List<GraphQLNamedType>();
                 Advance();
 
+                // Objects that implement interfaces may be defined with an optional leading & character
+                // to aid formatting when representing a longer list of implemented interfaces
+                Skip(TokenKind.AMPERSAND);
+
                 do
                 {
                     types.Add(ParseNamedType());
                 }
-                while (Peek(TokenKind.NAME));
+                while (Skip(TokenKind.AMPERSAND));
             }
 
             return types;

--- a/src/GraphQLParser/Token.cs
+++ b/src/GraphQLParser/Token.cs
@@ -63,6 +63,7 @@ namespace GraphQLParser
             TokenKind.COLON => ":",
             TokenKind.EQUALS => "=",
             TokenKind.AT => "@",
+            TokenKind.AMPERSAND => "&",
             TokenKind.BRACKET_L => "[",
             TokenKind.BRACKET_R => "]",
             TokenKind.BRACE_L => "{",

--- a/src/GraphQLParser/TokenKind.cs
+++ b/src/GraphQLParser/TokenKind.cs
@@ -110,6 +110,11 @@ namespace GraphQLParser
         /// <summary>
         /// Unknown token. Something went wrong.
         /// </summary>
-        UNKNOWN = 20
+        UNKNOWN = 20,
+
+        /// <summary>
+        /// &amp;
+        /// </summary>
+        AMPERSAND = 21
     }
 }


### PR DESCRIPTION
Fixes https://github.com/graphql-dotnet/graphql-dotnet/issues/2478

This is nonsense. I can not imagine how all this time this obvious error remained unnoticed. Parser did not support the `&` token all this time. Ping @joemcbride  and @Shane32 . It is possible that I do not understand something, but in all apparently no one GraphQL.NET client used more than one interface on the object.