### PR TITLE
Add support for description parsing

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQL-Parser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQL-Parser.approved.txt
@@ -47,6 +47,7 @@ namespace GraphQLParser.AST
         TypeExtensionDefinition = 35,
         DirectiveDefinition = 36,
         Comment = 37,
+        Description = 38,
     }
     public class GraphQLArgument : GraphQLParser.AST.ASTNode, GraphQLParser.AST.INamedNode
     {
@@ -61,6 +62,12 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.ROM Text { get; set; }
         public override GraphQLParser.AST.GraphQLLocation Location { get; set; }
+    }
+    public class GraphQLDescription : GraphQLParser.AST.ASTNode
+    {
+        public GraphQLDescription() { }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+        public GraphQLParser.ROM Value { get; set; }
     }
     public class GraphQLDirective : GraphQLParser.AST.ASTNode, GraphQLParser.AST.INamedNode
     {
@@ -280,10 +287,10 @@ namespace GraphQLParser.AST
         protected GraphQLTypeDefinition() { }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
-    public abstract class GraphQLTypeDefinitionWithDescription : GraphQLParser.AST.GraphQLTypeDefinition
+    public abstract class GraphQLTypeDefinitionWithDescription : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDescription
     {
         protected GraphQLTypeDefinitionWithDescription() { }
-        public GraphQLParser.AST.GraphQLScalarValue? Description { get; set; }
+        public GraphQLParser.AST.GraphQLDescription? Description { get; set; }
     }
     public class GraphQLTypeExtensionDefinition : GraphQLParser.AST.GraphQLTypeDefinition
     {
@@ -315,6 +322,10 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
         public GraphQLParser.AST.GraphQLVariable? Variable { get; set; }
+    }
+    public interface IHasDescription
+    {
+        GraphQLParser.AST.GraphQLDescription? Description { get; set; }
     }
     public interface IHasDirectivesNode
     {

--- a/src/GraphQLParser.ApiTests/GraphQL-Parser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQL-Parser.approved.txt
@@ -69,7 +69,7 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
-    public class GraphQLDirectiveDefinition : GraphQLParser.AST.GraphQLTypeDefinition
+    public class GraphQLDirectiveDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription
     {
         public GraphQLDirectiveDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition>? Arguments { get; set; }
@@ -86,20 +86,20 @@ namespace GraphQLParser.AST
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
     }
-    public class GraphQLEnumTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLEnumTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLEnumTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLEnumValueDefinition>? Values { get; set; }
     }
-    public class GraphQLEnumValueDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLEnumValueDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLEnumValueDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
-    public class GraphQLFieldDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLFieldDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLFieldDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition>? Arguments { get; set; }
@@ -138,14 +138,14 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
         public GraphQLParser.AST.GraphQLNamedType? TypeCondition { get; set; }
     }
-    public class GraphQLInputObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLInputObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInputObjectTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition>? Fields { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
-    public class GraphQLInputValueDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLInputValueDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInputValueDefinition() { }
         public GraphQLParser.AST.GraphQLValue? DefaultValue { get; set; }
@@ -153,7 +153,7 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
     }
-    public class GraphQLInterfaceTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLInterfaceTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInterfaceTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
@@ -214,7 +214,7 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.GraphQLValue? Value { get; set; }
     }
-    public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLObjectTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
@@ -245,7 +245,7 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.OperationType Operation { get; set; }
         public GraphQLParser.AST.GraphQLNamedType? Type { get; set; }
     }
-    public class GraphQLScalarTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLScalarTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLScalarTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
@@ -280,13 +280,18 @@ namespace GraphQLParser.AST
         protected GraphQLTypeDefinition() { }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
+    public abstract class GraphQLTypeDefinitionWithDescription : GraphQLParser.AST.GraphQLTypeDefinition
+    {
+        protected GraphQLTypeDefinitionWithDescription() { }
+        public GraphQLParser.AST.GraphQLScalarValue? Description { get; set; }
+    }
     public class GraphQLTypeExtensionDefinition : GraphQLParser.AST.GraphQLTypeDefinition
     {
         public GraphQLTypeExtensionDefinition() { }
         public GraphQLParser.AST.GraphQLObjectTypeDefinition? Definition { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
-    public class GraphQLUnionTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLUnionTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLUnionTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -89,5 +89,10 @@ namespace GraphQLParser.AST
         /// and have no significance to the semantic meaning of a GraphQL Document.
         /// </summary>
         Comment,
+
+        /// <summary>
+        /// Description of a type definition.
+        /// </summary>
+        Description,
     }
 }

--- a/src/GraphQLParser/AST/GraphQLDescription.cs
+++ b/src/GraphQLParser/AST/GraphQLDescription.cs
@@ -1,0 +1,9 @@
+namespace GraphQLParser.AST
+{
+    public class GraphQLDescription : ASTNode
+    {
+        public override ASTNodeKind Kind => ASTNodeKind.Description;
+
+        public ROM Value { get; set; }
+    }
+}

--- a/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
@@ -5,7 +5,7 @@ namespace GraphQLParser.AST
     /// <summary>
     /// Represents a directive definition.
     /// </summary>
-    public class GraphQLDirectiveDefinition : GraphQLTypeDefinition
+    public class GraphQLDirectiveDefinition : GraphQLTypeDefinitionWithDescription
     {
         public List<GraphQLInputValueDefinition>? Arguments { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLEnumTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLEnumTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLEnumValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLEnumValueDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLFieldDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLFieldDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
     {
         public List<GraphQLInputValueDefinition>? Arguments { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInputObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLInputObjectTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInputValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLInputValueDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
     {
         public GraphQLValue? DefaultValue { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLObjectTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLScalarTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLScalarTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
@@ -5,4 +5,12 @@ namespace GraphQLParser.AST
         /// <inheritdoc/>
         public GraphQLName? Name { get; set; }
     }
+
+    public abstract class GraphQLTypeDefinitionWithDescription : GraphQLTypeDefinition
+    {
+        /// <summary>
+        /// Description of the node as represented by a nested node.
+        /// </summary>
+        public GraphQLScalarValue? Description { get; set; }
+    }
 }

--- a/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
@@ -6,11 +6,11 @@ namespace GraphQLParser.AST
         public GraphQLName? Name { get; set; }
     }
 
-    public abstract class GraphQLTypeDefinitionWithDescription : GraphQLTypeDefinition
+    public abstract class GraphQLTypeDefinitionWithDescription : GraphQLTypeDefinition, IHasDescription
     {
         /// <summary>
-        /// Description of the node as represented by a nested node.
+        /// Description of the node
         /// </summary>
-        public GraphQLScalarValue? Description { get; set; }
+        public GraphQLDescription? Description { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLUnionTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
+    public class GraphQLUnionTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/IHasDescription.cs
+++ b/src/GraphQLParser/AST/IHasDescription.cs
@@ -1,0 +1,7 @@
+namespace GraphQLParser.AST
+{
+    public interface IHasDescription
+    {
+        GraphQLDescription? Description { get; set; }
+    }
+}

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -825,7 +825,7 @@ namespace GraphQLParser
             //look-ahead to next token
             var token = Lexer.Lex(_source, _currentToken.End);
             //skip comments
-            while (_currentToken.Kind != TokenKind.EOF && _currentToken.Kind == TokenKind.COMMENT)
+            while (token.Kind != TokenKind.EOF && token.Kind == TokenKind.COMMENT)
             {
                 token = Lexer.Lex(_source, token.End);
             }

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -114,6 +114,13 @@ namespace GraphQLParser
                     return definition;
             }
 
+            if (Peek(TokenKind.STRING))
+            {
+                ASTNode? definition;
+                if ((definition = ParseNamedDefinitionWithDescription()) != null)
+                    return definition;
+            }
+
             return Throw_From_ParseDefinition();
         }
 
@@ -225,8 +232,14 @@ namespace GraphQLParser
         /// <returns></returns>
         private GraphQLDirectiveDefinition ParseDirectiveDefinition()
         {
-            var comment = GetComment();
             int start = _currentToken.Start;
+            GraphQLScalarValue? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseString();
+                ParseComment();
+            }
+            var comment = GetComment();
             ExpectKeyword("directive");
             Expect(TokenKind.AT);
 
@@ -244,6 +257,7 @@ namespace GraphQLParser
                     Repeatable = repeatable,
                     Arguments = args,
                     Locations = locations,
+                    Description = description,
                 }
                 : new GraphQLDirectiveDefinitionFull
                 {
@@ -252,6 +266,7 @@ namespace GraphQLParser
                     Repeatable = repeatable,
                     Arguments = args,
                     Locations = locations,
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }
@@ -333,8 +348,14 @@ namespace GraphQLParser
 
         private GraphQLEnumTypeDefinition ParseEnumTypeDefinition()
         {
-            var comment = GetComment();
             int start = _currentToken.Start;
+            GraphQLScalarValue? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseString();
+                ParseComment();
+            }
+            var comment = GetComment();
             ExpectKeyword("enum");
 
             return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
@@ -343,6 +364,7 @@ namespace GraphQLParser
                     Name = ParseName(),
                     Directives = ParseDirectives(),
                     Values = ParseEnumValueDefinitions(),
+                    Description = description,
                 }
                 : new GraphQLEnumTypeDefinitionFull
                 {
@@ -350,6 +372,7 @@ namespace GraphQLParser
                     Name = ParseName(),
                     Directives = ParseDirectives(),
                     Values = ParseEnumValueDefinitions(),
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }
@@ -371,28 +394,43 @@ namespace GraphQLParser
 
         private GraphQLEnumValueDefinition ParseEnumValueDefinition()
         {
-            var comment = GetComment();
             int start = _currentToken.Start;
+            GraphQLScalarValue? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseString();
+                ParseComment();
+            }
+            var comment = GetComment();
 
             return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
                 ? new GraphQLEnumValueDefinition
                 {
                     Name = ParseName(),
                     Directives = ParseDirectives(),
+                    Description = description,
                 }
                 : new GraphQLEnumValueDefinitionFull
                 {
                     Comment = comment,
                     Name = ParseName(),
                     Directives = ParseDirectives(),
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }
 
         private GraphQLFieldDefinition ParseFieldDefinition()
         {
-            var comment = GetComment();
             int start = _currentToken.Start;
+            GraphQLScalarValue? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseString();
+                ParseComment();
+            }
+
+            var comment = GetComment();
             var name = ParseName();
             var args = ParseArgumentDefs();
             Expect(TokenKind.COLON);
@@ -404,6 +442,7 @@ namespace GraphQLParser
                     Arguments = args,
                     Type = ParseType(),
                     Directives = ParseDirectives(),
+                    Description = description,
                 }
                 : new GraphQLFieldDefinitionFull
                 {
@@ -412,6 +451,7 @@ namespace GraphQLParser
                     Arguments = args,
                     Type = ParseType(),
                     Directives = ParseDirectives(),
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }
@@ -583,8 +623,14 @@ namespace GraphQLParser
 
         private GraphQLInputObjectTypeDefinition ParseInputObjectTypeDefinition()
         {
-            var comment = GetComment();
             int start = _currentToken.Start;
+            GraphQLScalarValue? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseString();
+                ParseComment();
+            }
+            var comment = GetComment();
             ExpectKeyword("input");
 
             return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
@@ -593,6 +639,7 @@ namespace GraphQLParser
                     Name = ParseName(),
                     Directives = ParseDirectives(),
                     Fields = ParseInputValueDefs(),
+                    Description = description,
                 }
                 : new GraphQLInputObjectTypeDefinitionFull
                 {
@@ -600,14 +647,21 @@ namespace GraphQLParser
                     Name = ParseName(),
                     Directives = ParseDirectives(),
                     Fields = ParseInputValueDefs(),
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }
 
         private GraphQLInputValueDefinition ParseInputValueDef()
         {
-            var comment = GetComment();
             int start = _currentToken.Start;
+            GraphQLScalarValue? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseString();
+                ParseComment();
+            }
+            var comment = GetComment();
             var name = ParseName();
             Expect(TokenKind.COLON);
 
@@ -618,6 +672,7 @@ namespace GraphQLParser
                     Type = ParseType(),
                     DefaultValue = Skip(TokenKind.EQUALS) ? ParseValueLiteral(true) : null,
                     Directives = ParseDirectives(),
+                    Description = description,
                 }
                 : new GraphQLInputValueDefinitionFull
                 {
@@ -626,6 +681,7 @@ namespace GraphQLParser
                     Type = ParseType(),
                     DefaultValue = Skip(TokenKind.EQUALS) ? ParseValueLiteral(true) : null,
                     Directives = ParseDirectives(),
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }
@@ -649,8 +705,14 @@ namespace GraphQLParser
 
         private GraphQLInterfaceTypeDefinition ParseInterfaceTypeDefinition()
         {
-            var comment = GetComment();
             int start = _currentToken.Start;
+            GraphQLScalarValue? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseString();
+                ParseComment();
+            }
+            var comment = GetComment();
             ExpectKeyword("interface");
 
             return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
@@ -659,6 +721,7 @@ namespace GraphQLParser
                     Name = ParseName(),
                     Directives = ParseDirectives(),
                     Fields = ParseFieldDefinitions(),
+                    Description = description,
                 }
                 : new GraphQLInterfaceTypeDefinitionFull
                 {
@@ -666,6 +729,7 @@ namespace GraphQLParser
                     Name = ParseName(),
                     Directives = ParseDirectives(),
                     Fields = ParseFieldDefinitions(),
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }
@@ -749,6 +813,46 @@ namespace GraphQLParser
 
             if (value == "extend")
                 return ParseTypeExtensionDefinition();
+
+            if (value == "directive")
+                return ParseDirectiveDefinition();
+
+            return null;
+        }
+
+        private ASTNode? ParseNamedDefinitionWithDescription()
+        {
+            //look-ahead to next token
+            var token = Lexer.Lex(_source, _currentToken.End);
+            //skip comments
+            while (_currentToken.Kind != TokenKind.EOF && _currentToken.Kind == TokenKind.COMMENT)
+            {
+                token = Lexer.Lex(_source, token.End);
+            }
+            //verify this is a NAME
+            if (token.Kind != TokenKind.NAME)
+                return null;
+
+            //retrieve the value
+            var value = token.Value;
+
+            if (value == "scalar")
+                return ParseScalarTypeDefinition();
+
+            if (value == "type")
+                return ParseObjectTypeDefinition();
+
+            if (value == "interface")
+                return ParseInterfaceTypeDefinition();
+
+            if (value == "union")
+                return ParseUnionTypeDefinition();
+
+            if (value == "enum")
+                return ParseEnumTypeDefinition();
+
+            if (value == "input")
+                return ParseInputObjectTypeDefinition();
 
             if (value == "directive")
                 return ParseDirectiveDefinition();
@@ -859,9 +963,15 @@ namespace GraphQLParser
 
         private GraphQLObjectTypeDefinition ParseObjectTypeDefinition()
         {
+            int start = _currentToken.Start;
+            GraphQLScalarValue? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseString();
+                ParseComment();
+            }
             var comment = GetComment();
 
-            int start = _currentToken.Start;
             ExpectKeyword("type");
 
             return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
@@ -871,6 +981,7 @@ namespace GraphQLParser
                     Interfaces = ParseImplementsInterfaces(),
                     Directives = ParseDirectives(),
                     Fields = ParseFieldDefinitions(),
+                    Description = description,
                 }
                 : new GraphQLObjectTypeDefinitionFull
                 {
@@ -879,6 +990,7 @@ namespace GraphQLParser
                     Interfaces = ParseImplementsInterfaces(),
                     Directives = ParseDirectives(),
                     Fields = ParseFieldDefinitions(),
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }
@@ -971,8 +1083,14 @@ namespace GraphQLParser
 
         private GraphQLScalarTypeDefinition ParseScalarTypeDefinition()
         {
-            var comment = GetComment();
             int start = _currentToken.Start;
+            GraphQLScalarValue? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseString();
+                ParseComment();
+            }
+            var comment = GetComment();
             ExpectKeyword("scalar");
             var name = ParseName();
             var directives = ParseDirectives();
@@ -982,12 +1100,14 @@ namespace GraphQLParser
                 {
                     Name = name,
                     Directives = directives,
+                    Description = description,
                 }
                 : new GraphQLScalarTypeDefinitionFull
                 {
                     Comment = comment,
                     Name = name,
                     Directives = directives,
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }
@@ -1037,7 +1157,7 @@ namespace GraphQLParser
                 };
         }
 
-        private GraphQLValue ParseString(/*bool isConstant*/)
+        private GraphQLScalarValue ParseString(/*bool isConstant*/)
         {
             var token = _currentToken;
             Advance();
@@ -1132,8 +1252,14 @@ namespace GraphQLParser
 
         private GraphQLUnionTypeDefinition ParseUnionTypeDefinition()
         {
-            var comment = GetComment();
             int start = _currentToken.Start;
+            GraphQLScalarValue? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseString();
+                ParseComment();
+            }
+            var comment = GetComment();
             ExpectKeyword("union");
             var name = ParseName();
             var directives = ParseDirectives();
@@ -1146,6 +1272,7 @@ namespace GraphQLParser
                     Name = name,
                     Directives = directives,
                     Types = types,
+                    Description = description,
                 }
                 : new GraphQLUnionTypeDefinitionFull
                 {
@@ -1153,6 +1280,7 @@ namespace GraphQLParser
                     Name = name,
                     Directives = directives,
                     Types = types,
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -233,10 +233,10 @@ namespace GraphQLParser
         private GraphQLDirectiveDefinition ParseDirectiveDefinition()
         {
             int start = _currentToken.Start;
-            GraphQLScalarValue? description = null;
+            GraphQLDescription? description = null;
             if (Peek(TokenKind.STRING))
             {
-                description = ParseString();
+                description = ParseDescription();
                 ParseComment();
             }
             var comment = GetComment();
@@ -349,10 +349,10 @@ namespace GraphQLParser
         private GraphQLEnumTypeDefinition ParseEnumTypeDefinition()
         {
             int start = _currentToken.Start;
-            GraphQLScalarValue? description = null;
+            GraphQLDescription? description = null;
             if (Peek(TokenKind.STRING))
             {
-                description = ParseString();
+                description = ParseDescription();
                 ParseComment();
             }
             var comment = GetComment();
@@ -395,10 +395,10 @@ namespace GraphQLParser
         private GraphQLEnumValueDefinition ParseEnumValueDefinition()
         {
             int start = _currentToken.Start;
-            GraphQLScalarValue? description = null;
+            GraphQLDescription? description = null;
             if (Peek(TokenKind.STRING))
             {
-                description = ParseString();
+                description = ParseDescription();
                 ParseComment();
             }
             var comment = GetComment();
@@ -423,10 +423,10 @@ namespace GraphQLParser
         private GraphQLFieldDefinition ParseFieldDefinition()
         {
             int start = _currentToken.Start;
-            GraphQLScalarValue? description = null;
+            GraphQLDescription? description = null;
             if (Peek(TokenKind.STRING))
             {
-                description = ParseString();
+                description = ParseDescription();
                 ParseComment();
             }
 
@@ -624,10 +624,10 @@ namespace GraphQLParser
         private GraphQLInputObjectTypeDefinition ParseInputObjectTypeDefinition()
         {
             int start = _currentToken.Start;
-            GraphQLScalarValue? description = null;
+            GraphQLDescription? description = null;
             if (Peek(TokenKind.STRING))
             {
-                description = ParseString();
+                description = ParseDescription();
                 ParseComment();
             }
             var comment = GetComment();
@@ -655,10 +655,10 @@ namespace GraphQLParser
         private GraphQLInputValueDefinition ParseInputValueDef()
         {
             int start = _currentToken.Start;
-            GraphQLScalarValue? description = null;
+            GraphQLDescription? description = null;
             if (Peek(TokenKind.STRING))
             {
-                description = ParseString();
+                description = ParseDescription();
                 ParseComment();
             }
             var comment = GetComment();
@@ -706,10 +706,10 @@ namespace GraphQLParser
         private GraphQLInterfaceTypeDefinition ParseInterfaceTypeDefinition()
         {
             int start = _currentToken.Start;
-            GraphQLScalarValue? description = null;
+            GraphQLDescription? description = null;
             if (Peek(TokenKind.STRING))
             {
-                description = ParseString();
+                description = ParseDescription();
                 ParseComment();
             }
             var comment = GetComment();
@@ -964,10 +964,10 @@ namespace GraphQLParser
         private GraphQLObjectTypeDefinition ParseObjectTypeDefinition()
         {
             int start = _currentToken.Start;
-            GraphQLScalarValue? description = null;
+            GraphQLDescription? description = null;
             if (Peek(TokenKind.STRING))
             {
-                description = ParseString();
+                description = ParseDescription();
                 ParseComment();
             }
             var comment = GetComment();
@@ -1084,10 +1084,10 @@ namespace GraphQLParser
         private GraphQLScalarTypeDefinition ParseScalarTypeDefinition()
         {
             int start = _currentToken.Start;
-            GraphQLScalarValue? description = null;
+            GraphQLDescription? description = null;
             if (Peek(TokenKind.STRING))
             {
-                description = ParseString();
+                description = ParseDescription();
                 ParseComment();
             }
             var comment = GetComment();
@@ -1167,6 +1167,22 @@ namespace GraphQLParser
                     Value = token.Value,
                 }
                 : new GraphQLScalarValueFull(ASTNodeKind.StringValue)
+                {
+                    Value = token.Value,
+                    Location = GetLocation(token.Start)
+                };
+        }
+
+        private GraphQLDescription ParseDescription()
+        {
+            var token = _currentToken;
+            Advance();
+            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+                ? new GraphQLDescription()
+                {
+                    Value = token.Value,
+                }
+                : new GraphQLDescription()
                 {
                     Value = token.Value,
                     Location = GetLocation(token.Start)
@@ -1253,10 +1269,10 @@ namespace GraphQLParser
         private GraphQLUnionTypeDefinition ParseUnionTypeDefinition()
         {
             int start = _currentToken.Start;
-            GraphQLScalarValue? description = null;
+            GraphQLDescription? description = null;
             if (Peek(TokenKind.STRING))
             {
-                description = ParseString();
+                description = ParseDescription();
                 ParseComment();
             }
             var comment = GetComment();


### PR DESCRIPTION
Adds support for description parsing according to spec.  Requires #131 to be merged in order for tests to pass.

Note in the case where there is a comment both before and after the description, such as in the example below, the second comment is attached to the type definition, and the first comment is added to the list of unattached comments.  If a comment only in one of the two locations, then it is attached to the type definition.  This mechanic is covered by the tests.
```gql
# comment 1
"""
This is my custom scalar
"""
# comment 2
scalar MyScalar
```

Description fields have been added only to the nodes that allow a description.  Since typical GraphQL queries and mutations cannot contain any nodes that would have a description field, and therefor no additional memory could be allocated, there is no need for an additional option to skip parsing of descriptions.