### PR TITLE
Descriptions/Comments/Locations rework

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup .NET Core 5.0 SDK
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.201'
+          dotnet-version: '5.0.x'
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>7.2.0-preview</VersionPrefix>
-    <LangVersion>8.0</LangVersion>
+    <VersionPrefix>8.0.0-preview</VersionPrefix>
+    <LangVersion>9.0</LangVersion>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/GraphQLParser.ApiTests/GraphQL-Parser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQL-Parser.approved.txt
@@ -105,6 +105,16 @@ namespace GraphQLParser.AST
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
+    public class GraphQLField : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.INamedNode
+    {
+        public GraphQLField() { }
+        public GraphQLParser.AST.GraphQLName? Alias { get; set; }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLArgument>? Arguments { get; set; }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+        public GraphQLParser.AST.GraphQLName? Name { get; set; }
+        public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
+    }
     public class GraphQLFieldDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLFieldDefinition() { }
@@ -112,16 +122,6 @@ namespace GraphQLParser.AST
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
-    }
-    public class GraphQLFieldSelection : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.INamedNode
-    {
-        public GraphQLFieldSelection() { }
-        public GraphQLParser.AST.GraphQLName? Alias { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLArgument>? Arguments { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
-        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
-        public GraphQLParser.AST.GraphQLName? Name { get; set; }
-        public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
     }
     public class GraphQLFragmentDefinition : GraphQLParser.AST.GraphQLInlineFragment, GraphQLParser.AST.INamedNode
     {
@@ -244,9 +244,9 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLVariableDefinition>? VariableDefinitions { get; set; }
     }
-    public class GraphQLOperationTypeDefinition : GraphQLParser.AST.ASTNode
+    public class GraphQLRootOperationTypeDefinition : GraphQLParser.AST.ASTNode
     {
-        public GraphQLOperationTypeDefinition() { }
+        public GraphQLRootOperationTypeDefinition() { }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.OperationType Operation { get; set; }
         public GraphQLParser.AST.GraphQLNamedType? Type { get; set; }
@@ -270,7 +270,7 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLDescription? Description { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLOperationTypeDefinition>? OperationTypes { get; set; }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLRootOperationTypeDefinition>? OperationTypes { get; set; }
     }
     public class GraphQLSelectionSet : GraphQLParser.AST.ASTNode
     {
@@ -361,7 +361,7 @@ namespace GraphQLParser
         public virtual GraphQLParser.AST.GraphQLDirective BeginVisitDirective(GraphQLParser.AST.GraphQLDirective directive) { }
         public virtual System.Collections.Generic.IEnumerable<GraphQLParser.AST.GraphQLDirective> BeginVisitDirectives(System.Collections.Generic.IEnumerable<GraphQLParser.AST.GraphQLDirective> directives) { }
         public virtual GraphQLParser.AST.GraphQLScalarValue BeginVisitEnumValue(GraphQLParser.AST.GraphQLScalarValue value) { }
-        public virtual GraphQLParser.AST.GraphQLFieldSelection BeginVisitFieldSelection(GraphQLParser.AST.GraphQLFieldSelection selection) { }
+        public virtual GraphQLParser.AST.GraphQLField BeginVisitField(GraphQLParser.AST.GraphQLField selection) { }
         public virtual GraphQLParser.AST.GraphQLScalarValue BeginVisitFloatValue(GraphQLParser.AST.GraphQLScalarValue value) { }
         public virtual GraphQLParser.AST.GraphQLFragmentDefinition BeginVisitFragmentDefinition(GraphQLParser.AST.GraphQLFragmentDefinition node) { }
         public virtual GraphQLParser.AST.GraphQLFragmentSpread BeginVisitFragmentSpread(GraphQLParser.AST.GraphQLFragmentSpread fragmentSpread) { }
@@ -379,7 +379,7 @@ namespace GraphQLParser
         public virtual GraphQLParser.AST.GraphQLVariableDefinition BeginVisitVariableDefinition(GraphQLParser.AST.GraphQLVariableDefinition node) { }
         public virtual System.Collections.Generic.IEnumerable<GraphQLParser.AST.GraphQLVariableDefinition> BeginVisitVariableDefinitions(System.Collections.Generic.IEnumerable<GraphQLParser.AST.GraphQLVariableDefinition> variableDefinitions) { }
         public virtual GraphQLParser.AST.GraphQLArgument EndVisitArgument(GraphQLParser.AST.GraphQLArgument argument) { }
-        public virtual GraphQLParser.AST.GraphQLFieldSelection EndVisitFieldSelection(GraphQLParser.AST.GraphQLFieldSelection selection) { }
+        public virtual GraphQLParser.AST.GraphQLField EndVisitField(GraphQLParser.AST.GraphQLField selection) { }
         public virtual GraphQLParser.AST.GraphQLListValue EndVisitListValue(GraphQLParser.AST.GraphQLListValue node) { }
         public virtual GraphQLParser.AST.GraphQLObjectValue EndVisitObjectValue(GraphQLParser.AST.GraphQLObjectValue node) { }
         public virtual GraphQLParser.AST.GraphQLOperationDefinition EndVisitOperationDefinition(GraphQLParser.AST.GraphQLOperationDefinition definition) { }

--- a/src/GraphQLParser.ApiTests/GraphQL-Parser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQL-Parser.approved.txt
@@ -61,7 +61,6 @@ namespace GraphQLParser.AST
         public GraphQLComment() { }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.ROM Text { get; set; }
-        public override GraphQLParser.AST.GraphQLLocation Location { get; set; }
     }
     public class GraphQLDescription : GraphQLParser.AST.ASTNode
     {
@@ -76,7 +75,7 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
-    public class GraphQLDirectiveDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription
+    public class GraphQLDirectiveDefinition : GraphQLParser.AST.GraphQLTypeDefinition
     {
         public GraphQLDirectiveDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition>? Arguments { get; set; }
@@ -93,20 +92,20 @@ namespace GraphQLParser.AST
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
     }
-    public class GraphQLEnumTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLEnumTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLEnumTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLEnumValueDefinition>? Values { get; set; }
     }
-    public class GraphQLEnumValueDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLEnumValueDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLEnumValueDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
-    public class GraphQLFieldDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLFieldDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLFieldDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition>? Arguments { get; set; }
@@ -145,14 +144,14 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
         public GraphQLParser.AST.GraphQLNamedType? TypeCondition { get; set; }
     }
-    public class GraphQLInputObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLInputObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInputObjectTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition>? Fields { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
-    public class GraphQLInputValueDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLInputValueDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInputValueDefinition() { }
         public GraphQLParser.AST.GraphQLValue? DefaultValue { get; set; }
@@ -160,7 +159,7 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
     }
-    public class GraphQLInterfaceTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLInterfaceTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInterfaceTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
@@ -221,7 +220,7 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.GraphQLValue? Value { get; set; }
     }
-    public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLObjectTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
@@ -252,7 +251,7 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.OperationType Operation { get; set; }
         public GraphQLParser.AST.GraphQLNamedType? Type { get; set; }
     }
-    public class GraphQLScalarTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLScalarTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLScalarTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
@@ -265,9 +264,10 @@ namespace GraphQLParser.AST
         public GraphQLParser.ROM Value { get; set; }
         public override string? ToString() { }
     }
-    public class GraphQLSchemaDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLSchemaDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDescriptionNode, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLSchemaDefinition() { }
+        public GraphQLParser.AST.GraphQLDescription? Description { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLOperationTypeDefinition>? OperationTypes { get; set; }
@@ -282,15 +282,11 @@ namespace GraphQLParser.AST
     {
         protected GraphQLType() { }
     }
-    public abstract class GraphQLTypeDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.INamedNode
+    public abstract class GraphQLTypeDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDescriptionNode, GraphQLParser.AST.INamedNode
     {
         protected GraphQLTypeDefinition() { }
-        public GraphQLParser.AST.GraphQLName? Name { get; set; }
-    }
-    public abstract class GraphQLTypeDefinitionWithDescription : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDescription
-    {
-        protected GraphQLTypeDefinitionWithDescription() { }
         public GraphQLParser.AST.GraphQLDescription? Description { get; set; }
+        public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
     public class GraphQLTypeExtensionDefinition : GraphQLParser.AST.GraphQLTypeDefinition
     {
@@ -298,7 +294,7 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLObjectTypeDefinition? Definition { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
-    public class GraphQLUnionTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinitionWithDescription, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLUnionTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLUnionTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
@@ -323,7 +319,7 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
         public GraphQLParser.AST.GraphQLVariable? Variable { get; set; }
     }
-    public interface IHasDescription
+    public interface IHasDescriptionNode
     {
         GraphQLParser.AST.GraphQLDescription? Description { get; set; }
     }
@@ -390,11 +386,13 @@ namespace GraphQLParser
         public virtual GraphQLParser.AST.GraphQLVariable EndVisitVariable(GraphQLParser.AST.GraphQLVariable variable) { }
         public virtual void Visit(GraphQLParser.AST.GraphQLDocument ast) { }
     }
+    [System.Flags]
     public enum IgnoreOptions
     {
-        IgnoreComments = 0,
-        IgnoreCommentsAndLocations = 1,
-        None = 2,
+        None = 0,
+        Comments = 1,
+        Locations = 2,
+        All = 3,
     }
     public static class Lexer
     {

--- a/src/GraphQLParser.Benchmarks/Benchmarks/ParserBenchmark.cs
+++ b/src/GraphQLParser.Benchmarks/Benchmarks/ParserBenchmark.cs
@@ -28,9 +28,10 @@ namespace GraphQLParser.Benchmarks
                 private static int GetOrder(object o) => o switch
                 {
                     IgnoreOptions.None => 1,
-                    IgnoreOptions.IgnoreComments => 2,
-                    IgnoreOptions.IgnoreCommentsAndLocations => 3,
-                    _ => 4
+                    IgnoreOptions.Comments => 2,
+                    IgnoreOptions.Locations => 3,
+                    IgnoreOptions.All => 4,
+                    _ => 5
                 };
 
                 public IEnumerable<BenchmarkCase> GetExecutionOrder(ImmutableArray<BenchmarkCase> benchmarksCase) => benchmarksCase;
@@ -62,32 +63,39 @@ namespace GraphQLParser.Benchmarks
         public IEnumerable<object[]> NamesAndOptions()
         {
             yield return new object[] { "hero", IgnoreOptions.None };
-            yield return new object[] { "hero", IgnoreOptions.IgnoreComments };
-            yield return new object[] { "hero", IgnoreOptions.IgnoreCommentsAndLocations };
+            yield return new object[] { "hero", IgnoreOptions.Comments };
+            yield return new object[] { "hero", IgnoreOptions.Locations };
+            yield return new object[] { "hero", IgnoreOptions.All };
 
             yield return new object[] { "escapes", IgnoreOptions.None };
-            yield return new object[] { "escapes", IgnoreOptions.IgnoreComments };
-            yield return new object[] { "escapes", IgnoreOptions.IgnoreCommentsAndLocations };
+            yield return new object[] { "escapes", IgnoreOptions.Comments };
+            yield return new object[] { "escapes", IgnoreOptions.Locations };
+            yield return new object[] { "escapes", IgnoreOptions.All };
 
             yield return new object[] { "kitchen", IgnoreOptions.None };
-            yield return new object[] { "kitchen", IgnoreOptions.IgnoreComments };
-            yield return new object[] { "kitchen", IgnoreOptions.IgnoreCommentsAndLocations };
+            yield return new object[] { "kitchen", IgnoreOptions.Comments };
+            yield return new object[] { "kitchen", IgnoreOptions.Locations };
+            yield return new object[] { "kitchen", IgnoreOptions.All };
 
             yield return new object[] { "introspection", IgnoreOptions.None };
-            yield return new object[] { "introspection", IgnoreOptions.IgnoreComments };
-            yield return new object[] { "introspection", IgnoreOptions.IgnoreCommentsAndLocations };
+            yield return new object[] { "introspection", IgnoreOptions.Comments };
+            yield return new object[] { "introspection", IgnoreOptions.Locations };
+            yield return new object[] { "introspection", IgnoreOptions.All };
 
             yield return new object[] { "params", IgnoreOptions.None };
-            yield return new object[] { "params", IgnoreOptions.IgnoreComments };
-            yield return new object[] { "params", IgnoreOptions.IgnoreCommentsAndLocations };
+            yield return new object[] { "params", IgnoreOptions.Comments };
+            yield return new object[] { "params", IgnoreOptions.Locations };
+            yield return new object[] { "params", IgnoreOptions.All };
 
             yield return new object[] { "variables", IgnoreOptions.None };
-            yield return new object[] { "variables", IgnoreOptions.IgnoreComments };
-            yield return new object[] { "variables", IgnoreOptions.IgnoreCommentsAndLocations };
+            yield return new object[] { "variables", IgnoreOptions.Comments };
+            yield return new object[] { "variables", IgnoreOptions.Locations };
+            yield return new object[] { "variables", IgnoreOptions.All };
 
             yield return new object[] { "github", IgnoreOptions.None };
-            yield return new object[] { "github", IgnoreOptions.IgnoreComments };
-            yield return new object[] { "github", IgnoreOptions.IgnoreCommentsAndLocations };
+            yield return new object[] { "github", IgnoreOptions.Comments };
+            yield return new object[] { "github", IgnoreOptions.Locations };
+            yield return new object[] { "github", IgnoreOptions.All };
         }
 
         public override void Run() => Parse("params", IgnoreOptions.None);

--- a/src/GraphQLParser.Tests/Files/CommentsOnDirective.graphql
+++ b/src/GraphQLParser.Tests/Files/CommentsOnDirective.graphql
@@ -1,0 +1,3 @@
+scalar Json
+#comment for directive
+@external

--- a/src/GraphQLParser.Tests/Files/CommentsOnNamedType.graphql
+++ b/src/GraphQLParser.Tests/Files/CommentsOnNamedType.graphql
@@ -1,0 +1,33 @@
+# aaa
+
+query _ {
+    person {
+        ... on
+        #comment for named type from TypeCondition
+        human {
+            name
+        }
+    }
+}
+
+type A implements
+  #comment for named type from ImplementsInterfaces
+  B {
+  name : String
+}
+
+schema {
+  query:
+  #comment for named type from RootOperationTypeDefinition
+  Query
+}
+
+type Query {
+  field:
+  #comment for named type from Type
+  String
+}
+
+union U = A |
+#comment for named type from UnionMemberTypes
+B

--- a/src/GraphQLParser.Tests/Files/CommentsOnRootOperationType.graphql
+++ b/src/GraphQLParser.Tests/Files/CommentsOnRootOperationType.graphql
@@ -1,0 +1,4 @@
+schema {
+  #comment for root operation type
+  query: Query
+}

--- a/src/GraphQLParser.Tests/Files/CommentsOnSelectionSet.graphql
+++ b/src/GraphQLParser.Tests/Files/CommentsOnSelectionSet.graphql
@@ -1,0 +1,5 @@
+query
+#comment on selection set
+{
+  name
+}

--- a/src/GraphQLParser.Tests/Files/CommentsOnType.graphql
+++ b/src/GraphQLParser.Tests/Files/CommentsOnType.graphql
@@ -1,0 +1,14 @@
+type Person {
+  name:
+  #comment for named type
+  String
+  age:
+  #comment for nonnull type
+  Int!
+  friends:
+  #comment for list type
+  [
+  #comment for item type
+  Person
+  ]
+}

--- a/src/GraphQLParser.Tests/Files/CommentsOnValues.graphql
+++ b/src/GraphQLParser.Tests/Files/CommentsOnValues.graphql
@@ -1,0 +1,34 @@
+query q($id: ID) {
+    person(
+    valBool:
+    #comment for bool
+    true,
+    valNull:
+    #comment for null
+    null,
+    valEnum:
+    #comment for enum
+    RED,
+    valList:
+    #comment for list
+    [1,2,3],
+    valObj:
+    #comment for object
+    { a: 1 },
+    valInt:
+    #comment for int
+    7,
+    valFloat:
+    #comment for float
+    1.4,
+    valString:
+    #comment for string
+    "!#$",
+    valVariable:
+    #comment for variable
+    $id
+    )
+    {
+      a
+    }
+}

--- a/src/GraphQLParser.Tests/Files/CommentsOnVariables.graphql
+++ b/src/GraphQLParser.Tests/Files/CommentsOnVariables.graphql
@@ -1,6 +1,8 @@
 query _(
     #comment1
-    $id: ID,
+    $id:
+    #comment on variable type
+    ID,
     $id2: String!,
     #comment3
     $id3: String) {

--- a/src/GraphQLParser.Tests/GraphQLAstVisitorTests.cs
+++ b/src/GraphQLParser.Tests/GraphQLAstVisitorTests.cs
@@ -54,8 +54,8 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_BooleanValueArgument_VisitsOneBooleanValue(IgnoreOptions options)
         {
             using var d = "{ stuff(id : true) }".Parse(new ParserOptions { Ignore = options });
@@ -66,8 +66,8 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_DefinitionWithSingleFragmentSpread_VisitsFragmentSpreadOneTime(IgnoreOptions options)
         {
             using var d = "{ foo { ...fragment } }".Parse(new ParserOptions { Ignore = options });
@@ -78,8 +78,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_DefinitionWithSingleFragmentSpread_VisitsNameOfPropertyAndFragmentSpread(IgnoreOptions options)
         {
             using var d = "{ foo { ...fragment } }".Parse(new ParserOptions { Ignore = options });
@@ -90,8 +91,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_DirectiveWithVariable_VisitsVariableOnce(IgnoreOptions options)
         {
             using var d = "{ ... @include(if : $stuff) { field } }".Parse(new ParserOptions { Ignore = options });
@@ -102,8 +104,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_EnumValueArgument_VisitsOneEnumValue(IgnoreOptions options)
         {
             using var d = "{ stuff(id : TEST_ENUM) }".Parse(new ParserOptions { Ignore = options });
@@ -114,8 +117,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_FloatValueArgument_VisitsOneFloatValue(IgnoreOptions options)
         {
             using var d = "{ stuff(id : 1.2) }".Parse(new ParserOptions { Ignore = options });
@@ -126,8 +130,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_FragmentWithTypeCondition_VisitsFragmentDefinitionOnce(IgnoreOptions options)
         {
             using var d = "fragment testFragment on Stuff { field }".Parse(new ParserOptions { Ignore = options });
@@ -138,8 +143,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_FragmentWithTypeCondition_VisitsTypeConditionOnce(IgnoreOptions options)
         {
             using var d = "fragment testFragment on Stuff { field }".Parse(new ParserOptions { Ignore = options });
@@ -150,8 +156,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_InlineFragmentWithDirectiveAndArgument_VisitsArgumentsOnce(IgnoreOptions options)
         {
             using var d = "{ ... @include(if : $stuff) { field } }".Parse(new ParserOptions { Ignore = options });
@@ -162,8 +169,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_InlineFragmentWithDirectiveAndArgument_VisitsDirectiveOnce(IgnoreOptions options)
         {
             using var d = "{ ... @include(if : $stuff) { field } }".Parse(new ParserOptions { Ignore = options });
@@ -174,8 +182,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_InlineFragmentWithDirectiveAndArgument_VisitsNameThreeTimes(IgnoreOptions options)
         {
             using var d = "{ ... @include(if : $stuff) { field } }".Parse(new ParserOptions { Ignore = options });
@@ -186,8 +195,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_InlineFragmentWithOneField_VisitsOneField(IgnoreOptions options)
         {
             using var d = "{ ... @include(if : $stuff) { field } }".Parse(new ParserOptions { Ignore = options });
@@ -198,8 +208,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_InlineFragmentWithTypeCondition_VisitsInlineFragmentOnce(IgnoreOptions options)
         {
             using var d = "{ ... on Stuff { field } }".Parse(new ParserOptions { Ignore = options });
@@ -210,8 +221,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_InlineFragmentWithTypeCondition_VisitsTypeConditionOnce(IgnoreOptions options)
         {
             using var d = "{ ... on Stuff { field } }".Parse(new ParserOptions { Ignore = options });
@@ -222,8 +234,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_IntValueArgument_VisitsOneIntValue(IgnoreOptions options)
         {
             using var d = "{ stuff(id : 1) }".Parse(new ParserOptions { Ignore = options });
@@ -234,8 +247,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_OneDefinition_CallsVisitDefinitionOnce(IgnoreOptions options)
         {
             using var d = "{ a }".Parse(new ParserOptions { Ignore = options });
@@ -246,8 +260,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_OneDefinition_ProvidesCorrectDefinitionAsParameter(IgnoreOptions options)
         {
             using var d = "{ a }".Parse(new ParserOptions { Ignore = options });
@@ -258,8 +273,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_OneDefinition_VisitsOneSelectionSet(IgnoreOptions options)
         {
             using var d = "{ a, b }".Parse(new ParserOptions { Ignore = options });
@@ -270,8 +286,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_OneDefinitionWithOneAliasedField_VisitsOneAlias(IgnoreOptions options)
         {
             using var d = "{ foo, foo : bar }".Parse(new ParserOptions { Ignore = options });
@@ -282,8 +299,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_OneDefinitionWithOneArgument_VisitsOneArgument(IgnoreOptions options)
         {
             using var d = "{ foo(id : 1) { name } }".Parse(new ParserOptions { Ignore = options });
@@ -294,8 +312,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_OneDefinitionWithOneNestedArgument_VisitsOneArgument(IgnoreOptions options)
         {
             using var d = "{ foo{ names(size: 10) } }".Parse(new ParserOptions { Ignore = options });
@@ -306,8 +325,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_StringValueArgument_VisitsOneStringValue(IgnoreOptions options)
         {
             using var d = "{ stuff(id : \"abc\") }".Parse(new ParserOptions { Ignore = options });
@@ -318,8 +338,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_TwoDefinitions_CallsVisitDefinitionTwice(IgnoreOptions options)
         {
             using var d = "{ a }\n{ b }".Parse(new ParserOptions { Ignore = options });
@@ -330,8 +351,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_TwoFieldSelections_VisitsFieldSelectionTwice(IgnoreOptions options)
         {
             using var d = "{ a, b }".Parse(new ParserOptions { Ignore = options });
@@ -342,8 +364,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_TwoFieldSelections_VisitsTwoFieldNames(IgnoreOptions options)
         {
             using var d = "{ a, b }".Parse(new ParserOptions { Ignore = options });
@@ -354,8 +377,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_TwoFieldSelections_VisitsTwoFieldNamesAndDefinitionName(IgnoreOptions options)
         {
             using var d = "query foo { a, b }".Parse(new ParserOptions { Ignore = options });
@@ -366,8 +390,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_TwoFieldSelectionsWithOneNested_VisitsFiveFieldSelections(IgnoreOptions options)
         {
             using var d = "{a, nested { x,  y }, b}".Parse(new ParserOptions { Ignore = options });
@@ -378,8 +403,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Visit_TwoFieldSelectionsWithOneNested_VisitsFiveNames(IgnoreOptions options)
         {
             using var d = "{a, nested { x,  y }, b}".Parse(new ParserOptions { Ignore = options });

--- a/src/GraphQLParser.Tests/GraphQLAstVisitorTests.cs
+++ b/src/GraphQLParser.Tests/GraphQLAstVisitorTests.cs
@@ -15,7 +15,7 @@ namespace GraphQLParser.Tests
         private readonly List<ASTNode> _visitedDefinitions;
         private readonly List<GraphQLDirective> _visitedDirectives;
         private readonly List<GraphQLScalarValue> _visitedEnumValues;
-        private readonly List<GraphQLFieldSelection> _visitedFieldSelections;
+        private readonly List<GraphQLField> _visitedFields;
         private readonly List<GraphQLScalarValue> _visitedFloatValues;
         private readonly List<GraphQLFragmentDefinition> _visitedFragmentDefinitions;
         private readonly List<GraphQLFragmentSpread> _visitedFragmentSpreads;
@@ -35,7 +35,7 @@ namespace GraphQLParser.Tests
 
             _visitedDefinitions = MockVisitMethod<ASTNode>((visitor) => visitor.BeginVisitOperationDefinition(null));
             _visitedSelectionSets = MockVisitMethod<GraphQLSelectionSet>((visitor) => visitor.BeginVisitSelectionSet(null));
-            _visitedFieldSelections = MockVisitMethod<GraphQLFieldSelection>((visitor) => visitor.BeginVisitFieldSelection(null));
+            _visitedFields = MockVisitMethod<GraphQLField>((visitor) => visitor.BeginVisitField(null));
             _visitedNames = MockVisitMethod<GraphQLName>((visitor) => visitor.BeginVisitName(null));
             _visitedArguments = MockVisitMethod<GraphQLArgument>((visitor) => visitor.BeginVisitArgument(null));
             _visitedAliases = MockVisitMethod<GraphQLName>((visitor) => visitor.BeginVisitAlias(null));
@@ -205,7 +205,7 @@ namespace GraphQLParser.Tests
             using var d = "{ ... @include(if : $stuff) { field } }".Parse(new ParserOptions { Ignore = options });
             _visitor.Visit(d);
 
-            _visitedFieldSelections.ShouldHaveSingleItem();
+            _visitedFields.ShouldHaveSingleItem();
         }
 
         [Theory]
@@ -356,12 +356,12 @@ namespace GraphQLParser.Tests
         [InlineData(IgnoreOptions.Comments)]
         [InlineData(IgnoreOptions.Locations)]
         [InlineData(IgnoreOptions.All)]
-        public void Visit_TwoFieldSelections_VisitsFieldSelectionTwice(IgnoreOptions options)
+        public void Visit_TwoFields_VisitsFieldTwice(IgnoreOptions options)
         {
             using var d = "{ a, b }".Parse(new ParserOptions { Ignore = options });
             _visitor.Visit(d);
 
-            _visitedFieldSelections.Count.ShouldBe(2);
+            _visitedFields.Count.ShouldBe(2);
         }
 
         [Theory]
@@ -369,7 +369,7 @@ namespace GraphQLParser.Tests
         [InlineData(IgnoreOptions.Comments)]
         [InlineData(IgnoreOptions.Locations)]
         [InlineData(IgnoreOptions.All)]
-        public void Visit_TwoFieldSelections_VisitsTwoFieldNames(IgnoreOptions options)
+        public void Visit_TwoFields_VisitsTwoFieldNames(IgnoreOptions options)
         {
             using var d = "{ a, b }".Parse(new ParserOptions { Ignore = options });
             _visitor.Visit(d);
@@ -382,7 +382,7 @@ namespace GraphQLParser.Tests
         [InlineData(IgnoreOptions.Comments)]
         [InlineData(IgnoreOptions.Locations)]
         [InlineData(IgnoreOptions.All)]
-        public void Visit_TwoFieldSelections_VisitsTwoFieldNamesAndDefinitionName(IgnoreOptions options)
+        public void Visit_TwoFields_VisitsTwoFieldNamesAndDefinitionName(IgnoreOptions options)
         {
             using var d = "query foo { a, b }".Parse(new ParserOptions { Ignore = options });
             _visitor.Visit(d);
@@ -395,12 +395,12 @@ namespace GraphQLParser.Tests
         [InlineData(IgnoreOptions.Comments)]
         [InlineData(IgnoreOptions.Locations)]
         [InlineData(IgnoreOptions.All)]
-        public void Visit_TwoFieldSelectionsWithOneNested_VisitsFiveFieldSelections(IgnoreOptions options)
+        public void Visit_TwoFieldsWithOneNested_VisitsFiveFields(IgnoreOptions options)
         {
             using var d = "{a, nested { x,  y }, b}".Parse(new ParserOptions { Ignore = options });
             _visitor.Visit(d);
 
-            _visitedFieldSelections.Count.ShouldBe(5);
+            _visitedFields.Count.ShouldBe(5);
         }
 
         [Theory]
@@ -408,7 +408,7 @@ namespace GraphQLParser.Tests
         [InlineData(IgnoreOptions.Comments)]
         [InlineData(IgnoreOptions.Locations)]
         [InlineData(IgnoreOptions.All)]
-        public void Visit_TwoFieldSelectionsWithOneNested_VisitsFiveNames(IgnoreOptions options)
+        public void Visit_TwoFieldsWithOneNested_VisitsFiveNames(IgnoreOptions options)
         {
             using var d = "{a, nested { x,  y }, b}".Parse(new ParserOptions { Ignore = options });
             _visitor.Visit(d);

--- a/src/GraphQLParser.Tests/GraphQLAstVisitorTests.cs
+++ b/src/GraphQLParser.Tests/GraphQLAstVisitorTests.cs
@@ -55,6 +55,7 @@ namespace GraphQLParser.Tests
         [Theory]
         [InlineData(IgnoreOptions.None)]
         [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
         [InlineData(IgnoreOptions.All)]
         public void Visit_BooleanValueArgument_VisitsOneBooleanValue(IgnoreOptions options)
         {
@@ -67,6 +68,7 @@ namespace GraphQLParser.Tests
         [Theory]
         [InlineData(IgnoreOptions.None)]
         [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
         [InlineData(IgnoreOptions.All)]
         public void Visit_DefinitionWithSingleFragmentSpread_VisitsFragmentSpreadOneTime(IgnoreOptions options)
         {

--- a/src/GraphQLParser.Tests/Issue2478_GraphQL_NET.cs
+++ b/src/GraphQLParser.Tests/Issue2478_GraphQL_NET.cs
@@ -9,8 +9,9 @@ namespace GraphQLParser.Tests
     {
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void TestSchemaWithTwoInterfaceImplemented(IgnoreOptions options)
         {
             string query = @"

--- a/src/GraphQLParser.Tests/Issue82.cs
+++ b/src/GraphQLParser.Tests/Issue82.cs
@@ -27,7 +27,7 @@ namespace GraphQLParser.Tests
             def.VariableDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
             def.VariableDefinitions[0].Variable.Name.Value.ShouldBe("username");
 
-            var selection = def.SelectionSet.Selections[0].ShouldBeAssignableTo<GraphQLFieldSelection>();
+            var selection = def.SelectionSet.Selections[0].ShouldBeAssignableTo<GraphQLField>();
             selection.Arguments.Count.ShouldBe(2);
             selection.Arguments[0].Value.ShouldBeAssignableTo<GraphQLVariable>().Name.Value.ShouldBe("username");
             selection.Arguments[1].Value.ShouldBeAssignableTo<GraphQLScalarValue>().Value.ShouldBe("Pete");

--- a/src/GraphQLParser.Tests/Issue82.cs
+++ b/src/GraphQLParser.Tests/Issue82.cs
@@ -15,8 +15,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_Named_And_Literal_Variables(IgnoreOptions options)
         {
             using var document = _query.Parse(new ParserOptions { Ignore = options });

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -47,8 +47,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         //[InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        //[InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Comments_Can_Be_Ignored(IgnoreOptions options)
         {
             const string query = @"
@@ -188,8 +189,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_Unicode_Char_At_EOF_Should_Throw(IgnoreOptions options)
         {
             Should.Throw<GraphQLSyntaxErrorException>(() => "{\"\\ue }".Parse(new ParserOptions { Ignore = options }));
@@ -197,8 +199,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        //[InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        //[InlineData(IgnoreOptions.Locations)]
+        //[InlineData(IgnoreOptions.All)]
         public void Parse_FieldInput_HasCorrectLocations(IgnoreOptions options)
         {
             // { field }
@@ -212,8 +215,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FieldInput_HasOneOperationDefinition(IgnoreOptions options)
         {
             using var document = ParseGraphQLFieldSource(options);
@@ -223,8 +227,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FieldInput_NameIsNull(IgnoreOptions options)
         {
             using var document = ParseGraphQLFieldSource(options);
@@ -234,8 +239,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FieldInput_OperationIsQuery(IgnoreOptions options)
         {
             using var document = ParseGraphQLFieldSource(options);
@@ -245,8 +251,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FieldInput_ReturnsDocumentNode(IgnoreOptions options)
         {
             using var document = ParseGraphQLFieldSource(options);
@@ -256,8 +263,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FieldInput_SelectionSetContainsSingleFieldSelection(IgnoreOptions options)
         {
             using var document = ParseGraphQLFieldSource(options);
@@ -267,8 +275,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        //[InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        //[InlineData(IgnoreOptions.Locations)]
+        //[InlineData(IgnoreOptions.All)]
         public void Parse_FieldWithOperationTypeAndNameInput_HasCorrectLocations(IgnoreOptions options)
         {
             // mutation Foo { field }
@@ -283,8 +292,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FieldWithOperationTypeAndNameInput_HasOneOperationDefinition(IgnoreOptions options)
         {
             using var document = ParseGraphQLFieldWithOperationTypeAndNameSource(options);
@@ -294,8 +304,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FieldWithOperationTypeAndNameInput_NameIsNull(IgnoreOptions options)
         {
             using var document = ParseGraphQLFieldWithOperationTypeAndNameSource(options);
@@ -305,8 +316,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FieldWithOperationTypeAndNameInput_OperationIsQuery(IgnoreOptions options)
         {
             using var document = ParseGraphQLFieldWithOperationTypeAndNameSource(options);
@@ -316,8 +328,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FieldWithOperationTypeAndNameInput_ReturnsDocumentNode(IgnoreOptions options)
         {
             using var document = ParseGraphQLFieldWithOperationTypeAndNameSource(options);
@@ -327,8 +340,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FieldWithOperationTypeAndNameInput_SelectionSetContainsSingleFieldWithOperationTypeAndNameSelection(IgnoreOptions options)
         {
             using var document = ParseGraphQLFieldWithOperationTypeAndNameSource(options);
@@ -356,8 +370,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_NullInput_EmptyDocument(IgnoreOptions options)
         {
             using var document = ((string)null).Parse(new ParserOptions { Ignore = options });
@@ -367,8 +382,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_VariableInlineValues_DoesNotThrowError(IgnoreOptions options)
         {
             using ("{ field(complex: { a: { b: [ $var ] } }) }".Parse(new ParserOptions { Ignore = options }))
@@ -378,8 +394,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_Empty_Field_Arguments_Should_Throw(IgnoreOptions options)
         {
             Should.Throw<GraphQLSyntaxErrorException>(() => "{ a() }".Parse(new ParserOptions { Ignore = options }));
@@ -387,8 +404,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_Empty_Directive_Arguments_Should_Throw(IgnoreOptions options)
         {
             Should.Throw<GraphQLSyntaxErrorException>(() => "directive @dir() on FIELD_DEFINITION".Parse(new ParserOptions { Ignore = options }));
@@ -396,8 +414,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_Empty_Enum_Values_Should_Throw(IgnoreOptions options)
         {
             Should.Throw<GraphQLSyntaxErrorException>(() => "enum Empty { }".Parse(new ParserOptions { Ignore = options }));
@@ -405,8 +424,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_Empty_SelectionSet_Should_Throw(IgnoreOptions options)
         {
             Should.Throw<GraphQLSyntaxErrorException>(() => "{ a { } }".Parse(new ParserOptions { Ignore = options }));
@@ -414,8 +434,9 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_Empty_VariableDefinitions_Should_Throw(IgnoreOptions options)
         {
             Should.Throw<GraphQLSyntaxErrorException>(() => "query test() { a }".Parse(new ParserOptions { Ignore = options }));
@@ -522,11 +543,17 @@ Cat
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Descriptions_Should_Read_Correctly(IgnoreOptions options)
         {
             using var document = @"
+""Super schema""
+schema {
+  query: String
+}
+
 ""A JSON scalar""
 scalar JSON
 
@@ -582,7 +609,10 @@ directive @TestDirective (
 ) on QUERY
 ".Parse(new ParserOptions { Ignore = options });
             var defs = document.Definitions;
-            defs.Count.ShouldBe(7);
+            defs.Count.ShouldBe(8);
+
+            var schemaDef = defs.Single(x => x is GraphQLSchemaDefinition) as GraphQLSchemaDefinition;
+            schemaDef.Description.Value.ShouldBe("Super schema");
 
             var scalarDef = defs.Single(x => x is GraphQLScalarTypeDefinition) as GraphQLScalarTypeDefinition;
             scalarDef.Name.Value.ShouldBe("JSON");
@@ -646,11 +676,19 @@ directive @TestDirective (
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Descriptions_WithComments_Should_Read_Correctly_1(IgnoreOptions options)
         {
             using var document = @"
+# comment -1
+""Super schema""
+# comment 0
+schema {
+  query: String
+}
+
 # comment 1
 ""A JSON scalar""
 # comment 2
@@ -738,8 +776,13 @@ directive @TestDirective (
 ) on QUERY
 ".Parse(new ParserOptions { Ignore = options });
             var defs = document.Definitions;
-            defs.Count.ShouldBe(7);
+            defs.Count.ShouldBe(8);
             var parseComments = options == IgnoreOptions.None;
+
+            var schemaDef = defs.Single(x => x is GraphQLSchemaDefinition) as GraphQLSchemaDefinition;
+            schemaDef.Description.Value.ShouldBe("Super schema");
+            if (parseComments)
+                schemaDef.Comment.Text.ShouldBe(" comment 0");
 
             var scalarDef = defs.Single(x => x is GraphQLScalarTypeDefinition) as GraphQLScalarTypeDefinition;
             scalarDef.Name.Value.ShouldBe("JSON");
@@ -833,11 +876,18 @@ directive @TestDirective (
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Descriptions_WithComments_Should_Read_Correctly_2(IgnoreOptions options)
         {
             using var document = @"
+""Super schema""
+# comment 1
+schema {
+  query: String
+}
+
 ""A JSON scalar""
 # comment 2
 scalar JSON
@@ -910,8 +960,13 @@ directive @TestDirective (
 ) on QUERY
 ".Parse(new ParserOptions { Ignore = options });
             var defs = document.Definitions;
-            defs.Count.ShouldBe(7);
+            defs.Count.ShouldBe(8);
             var parseComments = options == IgnoreOptions.None;
+
+            var schemaDef = defs.Single(x => x is GraphQLSchemaDefinition) as GraphQLSchemaDefinition;
+            schemaDef.Description.Value.ShouldBe("Super schema");
+            if (parseComments)
+                schemaDef.Comment.Text.ShouldBe(" comment 1");
 
             var scalarDef = defs.Single(x => x is GraphQLScalarTypeDefinition) as GraphQLScalarTypeDefinition;
             scalarDef.Name.Value.ShouldBe("JSON");
@@ -1005,11 +1060,18 @@ directive @TestDirective (
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Descriptions_WithComments_Should_Read_Correctly_3(IgnoreOptions options)
         {
             using var document = @"
+# comment 0
+""Super schema""
+schema {
+  query: String
+}
+
 # comment 1
 ""A JSON scalar""
 scalar JSON
@@ -1082,8 +1144,13 @@ directive @TestDirective (
 ) on QUERY
 ".Parse(new ParserOptions { Ignore = options });
             var defs = document.Definitions;
-            defs.Count.ShouldBe(7);
+            defs.Count.ShouldBe(8);
             var parseComments = options == IgnoreOptions.None;
+
+            var schemaDef = defs.Single(x => x is GraphQLSchemaDefinition) as GraphQLSchemaDefinition;
+            schemaDef.Description.Value.ShouldBe("Super schema");
+            if (parseComments)
+                schemaDef.Comment.Text.ShouldBe(" comment 0");
 
             var scalarDef = defs.Single(x => x is GraphQLScalarTypeDefinition) as GraphQLScalarTypeDefinition;
             scalarDef.Name.Value.ShouldBe("JSON");

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -14,8 +14,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        //[InlineData(IgnoreOptions.IgnoreComments)]
-        //[InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        //[InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        //[InlineData(IgnoreOptions.All)]
         public void Extra_Comments_Should_Read_Correctly(IgnoreOptions options)
         {
             string query = "ExtraComments".ReadGraphQLFile();
@@ -71,9 +72,10 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        //[InlineData(IgnoreOptions.IgnoreComments)]
-        //[InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
-        public void Comments_on_FragmentSpread_Should_Read_Correclty(IgnoreOptions options)
+        //[InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        //[InlineData(IgnoreOptions.All)]
+        public void Comments_on_FragmentSpread_Should_Read_Correctly(IgnoreOptions options)
         {
             string query = "CommentsOnFragmentSpread".ReadGraphQLFile();
 
@@ -89,9 +91,55 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        //[InlineData(IgnoreOptions.IgnoreComments)]
-        //[InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
-        public void Comments_on_FragmentInline_Should_Read_Correclty(IgnoreOptions options)
+        //[InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        //[InlineData(IgnoreOptions.All)]
+        public void Comments_on_Values_Should_Read_Correctly(IgnoreOptions options)
+        {
+            string query = "CommentsOnValues".ReadGraphQLFile();
+
+            using var document = query.Parse(new ParserOptions { Ignore = options });
+            document.Definitions.Count.ShouldBe(1);
+            var def = document.Definitions.First() as GraphQLOperationDefinition;
+            def.SelectionSet.Selections.Count.ShouldBe(1);
+            var field = def.SelectionSet.Selections.First() as GraphQLFieldSelection;
+            field.SelectionSet.Selections.Count.ShouldBe(1);
+            field.Arguments.Count.ShouldBe(9);
+
+            var boolValue = field.Arguments[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            boolValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for bool");
+
+            var nullValue = field.Arguments[1].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            nullValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for null");
+
+            var enumValue = field.Arguments[2].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            enumValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for enum");
+
+            var listValue = field.Arguments[3].Value.ShouldBeAssignableTo<GraphQLListValue>();
+            listValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for list");
+
+            var objValue = field.Arguments[4].Value.ShouldBeAssignableTo<GraphQLObjectValue>();
+            objValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for object");
+
+            var intValue = field.Arguments[5].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            intValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for int");
+
+            var floatValue = field.Arguments[6].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            floatValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for float");
+
+            var stringValue = field.Arguments[7].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            stringValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for string");
+
+            var varValue = field.Arguments[8].Value.ShouldBeAssignableTo<GraphQLVariable>();
+            varValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for variable");
+        }
+
+        [Theory]
+        [InlineData(IgnoreOptions.None)]
+        //[InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        //[InlineData(IgnoreOptions.All)]
+        public void Comments_on_FragmentInline_Should_Read_Correctly(IgnoreOptions options)
         {
             string query = "CommentsOnInlineFragment".ReadGraphQLFile();
 
@@ -107,9 +155,10 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        //[InlineData(IgnoreOptions.IgnoreComments)]
-        //[InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
-        public void Comments_on_Variable_Should_Read_Correclty(IgnoreOptions options)
+        //[InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        //[InlineData(IgnoreOptions.All)]
+        public void Comments_on_Variable_Should_Read_Correctly(IgnoreOptions options)
         {
             string query = "CommentsOnVariables".ReadGraphQLFile();
 
@@ -124,8 +173,9 @@ namespace GraphQLParser.Tests
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        //[InlineData(IgnoreOptions.IgnoreComments)]
-        //[InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        //[InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        //[InlineData(IgnoreOptions.All)]
         public void Comments_On_SelectionSet_Should_Read_Correctly(IgnoreOptions options)
         {
             using var document = @"
@@ -147,9 +197,10 @@ query {
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        //[InlineData(IgnoreOptions.IgnoreComments)]
-        //[InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
-        public void Comments_On_Enums_Should_Read_Correctly(IgnoreOptions options)
+        //[InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        //[InlineData(IgnoreOptions.All)]
+        public void Comments_On_Enum_Definitions_Should_Read_Correctly(IgnoreOptions options)
         {
             using var document = @"
 # different animals
@@ -352,20 +403,31 @@ scalar JSON
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        //[InlineData(IgnoreOptions.IgnoreComments)]
-        //[InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_KitchenSink_DoesNotThrowError(IgnoreOptions options)
         {
             using var document = "KitchenSink".ReadGraphQLFile().Parse(new ParserOptions { Ignore = options });
             var typeDef = document.Definitions.OfType<GraphQLObjectTypeDefinition>().First(d => d.Name.Value == "Foo");
             var fieldDef = typeDef.Fields.First(d => d.Name.Value == "three");
-            fieldDef.Comment.ShouldNotBeNull().Text.ShouldBe($" multiline comments{_nl} with very importand description #{_nl} # and symbol # and ##");
+            if (options.HasFlag(IgnoreOptions.Comments))
+                fieldDef.Comment.ShouldBeNull();
+            else
+                fieldDef.Comment.ShouldNotBeNull().Text.ShouldBe($" multiline comments{_nl} with very importand description #{_nl} # and symbol # and ##");
 
             // Schema description
             // https://github.com/graphql/graphql-spec/pull/466
             var comment = document.Definitions.OfType<GraphQLSchemaDefinition>().First().Comment;
-            comment.ShouldNotBeNull();
-            ((string)comment.Text).StartsWith("﻿ Copyright (c) 2015, Facebook, Inc.").ShouldBeTrue();
+            if (options.HasFlag(IgnoreOptions.Comments))
+            {
+                comment.ShouldBeNull();
+            }
+            else
+            {
+                comment.ShouldNotBeNull();
+                ((string)comment.Text).StartsWith("﻿ Copyright (c) 2015, Facebook, Inc.").ShouldBeTrue();
+            }
         }
 
         [Theory]
@@ -777,7 +839,7 @@ directive @TestDirective (
 ".Parse(new ParserOptions { Ignore = options });
             var defs = document.Definitions;
             defs.Count.ShouldBe(8);
-            var parseComments = options == IgnoreOptions.None;
+            var parseComments = !options.HasFlag(IgnoreOptions.Comments);
 
             var schemaDef = defs.Single(x => x is GraphQLSchemaDefinition) as GraphQLSchemaDefinition;
             schemaDef.Description.Value.ShouldBe("Super schema");
@@ -961,7 +1023,7 @@ directive @TestDirective (
 ".Parse(new ParserOptions { Ignore = options });
             var defs = document.Definitions;
             defs.Count.ShouldBe(8);
-            var parseComments = options == IgnoreOptions.None;
+            var parseComments = !options.HasFlag(IgnoreOptions.Comments);
 
             var schemaDef = defs.Single(x => x is GraphQLSchemaDefinition) as GraphQLSchemaDefinition;
             schemaDef.Description.Value.ShouldBe("Super schema");
@@ -1145,7 +1207,7 @@ directive @TestDirective (
 ".Parse(new ParserOptions { Ignore = options });
             var defs = document.Definitions;
             defs.Count.ShouldBe(8);
-            var parseComments = options == IgnoreOptions.None;
+            var parseComments = !options.HasFlag(IgnoreOptions.Comments);
 
             var schemaDef = defs.Single(x => x is GraphQLSchemaDefinition) as GraphQLSchemaDefinition;
             schemaDef.Description.Value.ShouldBe("Super schema");

--- a/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
+++ b/src/GraphQLParser.Tests/Validation/ParserValidationTests.cs
@@ -8,8 +8,9 @@ namespace GraphQLParser.Tests.Validation
     {
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_FragmentInvalidOnName_ThrowsExceptionWithCorrectMessage(IgnoreOptions options)
         {
             var exception = Should.Throw<GraphQLSyntaxErrorException>(() => "fragment on on on { on }".Parse(new ParserOptions { Ignore = options }));
@@ -25,8 +26,9 @@ namespace GraphQLParser.Tests.Validation
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_InvalidDefaultValue_ThrowsExceptionWithCorrectMessage(IgnoreOptions options)
         {
             var exception = Should.Throw<GraphQLSyntaxErrorException>(() => "query Foo($x: Complex = { a: { b: [ $var ] } }) { field }".Parse(new ParserOptions { Ignore = options }));
@@ -42,8 +44,9 @@ namespace GraphQLParser.Tests.Validation
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_InvalidFragmentNameInSpread_ThrowsExceptionWithCorrectMessage(IgnoreOptions options)
         {
             var exception = Should.Throw<GraphQLSyntaxErrorException>(() => "{ ...on }".Parse(new ParserOptions { Ignore = options }));
@@ -59,8 +62,9 @@ namespace GraphQLParser.Tests.Validation
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_LonelySpread_ThrowsExceptionWithCorrectMessage(IgnoreOptions options)
         {
             var exception = Should.Throw<GraphQLSyntaxErrorException>(() => "...".Parse(new ParserOptions { Ignore = options }));
@@ -76,8 +80,9 @@ namespace GraphQLParser.Tests.Validation
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_MissingEndingBrace_ThrowsExceptionWithCorrectMessage(IgnoreOptions options)
         {
             var exception = Should.Throw<GraphQLSyntaxErrorException>(() => "{".Parse(new ParserOptions { Ignore = options }));
@@ -93,8 +98,9 @@ namespace GraphQLParser.Tests.Validation
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_MissingFieldNameWhenAliasing_ThrowsExceptionWithCorrectMessage(IgnoreOptions options)
         {
             var exception = Should.Throw<GraphQLSyntaxErrorException>(() => "{ field: {} }".Parse(new ParserOptions { Ignore = options }));
@@ -110,8 +116,9 @@ namespace GraphQLParser.Tests.Validation
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_MissingFragmentType_ThrowsExceptionWithCorrectMessage(IgnoreOptions options)
         {
             var exception = Should.Throw<GraphQLSyntaxErrorException>(() => "{ ...MissingOn }\nfragment MissingOn Type".Parse(new ParserOptions { Ignore = options }));
@@ -128,8 +135,9 @@ namespace GraphQLParser.Tests.Validation
 
         [Theory]
         [InlineData(IgnoreOptions.None)]
-        [InlineData(IgnoreOptions.IgnoreComments)]
-        [InlineData(IgnoreOptions.IgnoreCommentsAndLocations)]
+        [InlineData(IgnoreOptions.Comments)]
+        [InlineData(IgnoreOptions.Locations)]
+        [InlineData(IgnoreOptions.All)]
         public void Parse_UnknownOperation_ThrowsExceptionWithCorrectMessage(IgnoreOptions options)
         {
             var exception = Should.Throw<GraphQLSyntaxErrorException>(() => "notanoperation Foo { field }".Parse(new ParserOptions { Ignore = options }));

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -91,7 +91,7 @@ namespace GraphQLParser.AST
         Comment,
 
         /// <summary>
-        /// Description of a type definition.
+        /// Description of a GraphQL definition.
         /// </summary>
         Description,
     }

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -15,8 +15,24 @@ namespace GraphQLParser.AST
         OperationDefinition,
         VariableDefinition,
         Variable,
+
+        /// <summary>
+        /// An operation selects the set of information it needs, and will
+        /// receive exactly that information and nothing more, avoiding
+        /// over-fetching and under-fetching data.
+        /// </summary>
         SelectionSet,
+
+        /// <summary>
+        /// A selection set is primarily composed of fields. A field describes
+        /// one discrete piece of information available to request within a selection set.
+        /// </summary>
         Field,
+
+        /// <summary>
+        /// Fields are conceptually functions which return values, and occasionally
+        /// accept arguments which alter their behavior.
+        /// </summary>
         Argument,
         FragmentSpread,
         InlineFragment,
@@ -42,9 +58,33 @@ namespace GraphQLParser.AST
         /// Boolean value. The two keywords true and false represent the two boolean values.
         /// </summary>
         BooleanValue,
+
+        /// <summary>
+        /// Enum values are represented as unquoted names (ex. MOBILE_WEB). It is recommended
+        /// that Enum values be "all caps". Enum values are only used in contexts where the
+        /// precise enumeration type is known. Therefore it’s not necessary to supply an
+        /// enumeration type name in the literal.
+        /// </summary>
         EnumValue,
+
+        /// <summary>
+        /// Lists are ordered sequences of values wrapped in square-brackets [ ].
+        /// The values of a List literal may be any value literal or variable (ex. [1, 2, 3]).
+        /// Commas are optional throughout GraphQL so trailing commas are allowed and repeated
+        /// commas do not represent missing values.
+        /// </summary>
         ListValue,
+
+        /// <summary>
+        /// Input object literal values are unordered lists of keyed input values wrapped
+        /// in curly-braces { }. The values of an object literal may be any input value
+        /// literal or variable (ex. { name: "Hello world", score: 1.0 }).
+        /// </summary>
         ObjectValue,
+
+        /// <summary>
+        /// A keyed input value within <see cref="ObjectValue"/>.
+        /// </summary>
         ObjectField,
 
         /// <summary>
@@ -53,8 +93,28 @@ namespace GraphQLParser.AST
         /// additional information for types, fields, fragments, operations, etc.
         /// </summary>
         Directive,
+
+        /// <summary>
+        /// The fundamental unit of any GraphQL Schema is the type. There are six kinds of named
+        /// type definitions in GraphQL, and two wrapping types. In other words all non-wrapping
+        /// types are referred to as "named types".
+        /// </summary>
         NamedType,
+
+        /// <summary>
+        /// Wrapping type. A GraphQL schema may describe that a field represents a list of
+        /// another type; the List type is provided for this reason, and wraps another type.
+        /// A wrapping type has an underlying named type, found by continually unwrapping
+        /// the type until a named type is found.
+        /// </summary>
         ListType,
+
+        /// <summary>
+        /// Wrapping type. The Non-Null type wraps another type, and denotes that the resulting
+        /// value will never be null (and that a field error cannot result in a null value).
+        /// A wrapping type has an underlying named type, found by continually unwrapping
+        /// the type until a named type is found.
+        /// </summary>
         NonNullType,
 
         /// <summary>

--- a/src/GraphQLParser/AST/GraphQLArgument.cs
+++ b/src/GraphQLParser/AST/GraphQLArgument.cs
@@ -11,6 +11,28 @@ namespace GraphQLParser.AST
         public GraphQLValue? Value { get; set; }
     }
 
+    internal sealed class GraphQLArgumentWithLocation : GraphQLArgument
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLArgumentWithComment : GraphQLArgument
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLArgumentFull : GraphQLArgument
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLComment.cs
+++ b/src/GraphQLParser/AST/GraphQLComment.cs
@@ -24,7 +24,7 @@ namespace GraphQLParser.AST
         //}
     }
 
-    internal class GraphQLCommentFull : GraphQLComment
+    internal class GraphQLCommentWithLocation : GraphQLComment
     {
         private GraphQLLocation _location;
 

--- a/src/GraphQLParser/AST/GraphQLComment.cs
+++ b/src/GraphQLParser/AST/GraphQLComment.cs
@@ -6,7 +6,6 @@ namespace GraphQLParser.AST
     [DebuggerDisplay("{Text}")]
     public class GraphQLComment : ASTNode
     {
-        private GraphQLLocation _location;
         //private GraphQLComment? _comment;
 
         /// <inheritdoc/>
@@ -17,17 +16,22 @@ namespace GraphQLParser.AST
         /// </summary>
         public ROM Text { get; set; }
 
-        public override GraphQLLocation Location
-        {
-            get => _location;
-            set => _location = value;
-        }
-
         // Comment itself can't have a comment
         //public override GraphQLComment? Comment
         //{
         //    get => _comment;
         //    set => _comment = value;
         //}
+    }
+
+    internal class GraphQLCommentFull : GraphQLComment
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLDescription.cs
+++ b/src/GraphQLParser/AST/GraphQLDescription.cs
@@ -1,5 +1,9 @@
+using System.Diagnostics;
+
 namespace GraphQLParser.AST
 {
+    /// <inheritdoc cref="ASTNodeKind.Description"/>
+    [DebuggerDisplay("{Value}")]
     public class GraphQLDescription : ASTNode
     {
         public override ASTNodeKind Kind => ASTNodeKind.Description;

--- a/src/GraphQLParser/AST/GraphQLDescription.cs
+++ b/src/GraphQLParser/AST/GraphQLDescription.cs
@@ -10,4 +10,15 @@ namespace GraphQLParser.AST
 
         public ROM Value { get; set; }
     }
+
+    internal sealed class GraphQLDescriptionWithLocation : GraphQLDescription
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
 }

--- a/src/GraphQLParser/AST/GraphQLDirective.cs
+++ b/src/GraphQLParser/AST/GraphQLDirective.cs
@@ -16,10 +16,32 @@ namespace GraphQLParser.AST
         public GraphQLName? Name { get; set; }
     }
 
+    internal sealed class GraphQLDirectiveWithLocation : GraphQLDirective
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLDirectiveWithComment : GraphQLDirective
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLDirectiveFull : GraphQLDirective
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
+        private GraphQLComment? _comment;
 
         public override GraphQLLocation Location
         {
@@ -27,11 +49,10 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
 
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
@@ -28,6 +28,28 @@ namespace GraphQLParser.AST
         public bool Repeatable { get; set; }
     }
 
+    internal sealed class GraphQLDirectiveDefinitionWithLocation : GraphQLDirectiveDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLDirectiveDefinitionWithComment : GraphQLDirectiveDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLDirectiveDefinitionFull : GraphQLDirectiveDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
@@ -5,7 +5,7 @@ namespace GraphQLParser.AST
     /// <summary>
     /// Represents a directive definition.
     /// </summary>
-    public class GraphQLDirectiveDefinition : GraphQLTypeDefinitionWithDescription
+    public class GraphQLDirectiveDefinition : GraphQLTypeDefinition
     {
         public List<GraphQLInputValueDefinition>? Arguments { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLDocument.cs
+++ b/src/GraphQLParser/AST/GraphQLDocument.cs
@@ -48,22 +48,45 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLDocumentFull : GraphQLDocument
+    internal sealed class GraphQLDocumentWithLocation : GraphQLDocument
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
 
         public override GraphQLLocation Location
         {
             get => _location;
             set => _location = value;
         }
-
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
     }
+
+    //TODO: GraphQLDocument has no comments
+
+    //internal sealed class GraphQLDocumentWithComment : GraphQLDocument
+    //{
+    //    private GraphQLComment? _comment;
+
+    //    public override GraphQLComment? Comment
+    //    {
+    //        get => _comment;
+    //        set => _comment = value;
+    //    }
+    //}
+
+    //internal sealed class GraphQLDocumentFull : GraphQLDocument
+    //{
+    //    private GraphQLLocation _location;
+    //    private GraphQLComment? _comment;
+
+    //    public override GraphQLLocation Location
+    //    {
+    //        get => _location;
+    //        set => _location = value;
+    //    }
+
+    //    public override GraphQLComment? Comment
+    //    {
+    //        get => _comment;
+    //        set => _comment = value;
+    //    }
+    //}
 }

--- a/src/GraphQLParser/AST/GraphQLDocument.cs
+++ b/src/GraphQLParser/AST/GraphQLDocument.cs
@@ -45,6 +45,7 @@ namespace GraphQLParser.AST
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 
@@ -58,35 +59,4 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
     }
-
-    //TODO: GraphQLDocument has no comments
-
-    //internal sealed class GraphQLDocumentWithComment : GraphQLDocument
-    //{
-    //    private GraphQLComment? _comment;
-
-    //    public override GraphQLComment? Comment
-    //    {
-    //        get => _comment;
-    //        set => _comment = value;
-    //    }
-    //}
-
-    //internal sealed class GraphQLDocumentFull : GraphQLDocument
-    //{
-    //    private GraphQLLocation _location;
-    //    private GraphQLComment? _comment;
-
-    //    public override GraphQLLocation Location
-    //    {
-    //        get => _location;
-    //        set => _location = value;
-    //    }
-
-    //    public override GraphQLComment? Comment
-    //    {
-    //        get => _comment;
-    //        set => _comment = value;
-    //    }
-    //}
 }

--- a/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLEnumTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
+    public class GraphQLEnumTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
@@ -13,6 +13,28 @@ namespace GraphQLParser.AST
         public List<GraphQLEnumValueDefinition>? Values { get; set; }
     }
 
+    internal sealed class GraphQLEnumTypeDefinitionWithLocation : GraphQLEnumTypeDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLEnumTypeDefinitionWithComment : GraphQLEnumTypeDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLEnumTypeDefinitionFull : GraphQLEnumTypeDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
@@ -11,6 +11,28 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.EnumValueDefinition;
     }
 
+    internal sealed class GraphQLEnumValueDefinitionWithLocation : GraphQLEnumValueDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLEnumValueDefinitionWithComment : GraphQLEnumValueDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLEnumValueDefinitionFull : GraphQLEnumValueDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLEnumValueDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
+    public class GraphQLEnumValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLField.cs
+++ b/src/GraphQLParser/AST/GraphQLField.cs
@@ -1,16 +1,26 @@
+using System.Collections.Generic;
+
 namespace GraphQLParser.AST
 {
-    public class GraphQLOperationTypeDefinition : ASTNode
+    public class GraphQLField : ASTNode, IHasDirectivesNode, INamedNode
     {
+        public GraphQLName? Alias { get; set; }
+
+        public List<GraphQLArgument>? Arguments { get; set; }
+
         /// <inheritdoc/>
-        public override ASTNodeKind Kind => ASTNodeKind.OperationTypeDefinition;
+        public List<GraphQLDirective>? Directives { get; set; }
 
-        public OperationType Operation { get; set; }
+        /// <inheritdoc/>
+        public override ASTNodeKind Kind => ASTNodeKind.Field;
 
-        public GraphQLNamedType? Type { get; set; }
+        /// <inheritdoc/>
+        public GraphQLName? Name { get; set; }
+
+        public GraphQLSelectionSet? SelectionSet { get; set; }
     }
 
-    internal sealed class GraphQLOperationTypeDefinitionWithLocation : GraphQLOperationTypeDefinition
+    internal sealed class GraphQLFieldWithLocation : GraphQLField
     {
         private GraphQLLocation _location;
 
@@ -21,7 +31,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLOperationTypeDefinitionWithComment : GraphQLOperationTypeDefinition
+    internal sealed class GraphQLFieldWithComment : GraphQLField
     {
         private GraphQLComment? _comment;
 
@@ -32,7 +42,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLOperationTypeDefinitionFull : GraphQLOperationTypeDefinition
+    internal sealed class GraphQLFieldFull : GraphQLField
     {
         private GraphQLLocation _location;
         private GraphQLComment? _comment;

--- a/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
@@ -15,6 +15,28 @@ namespace GraphQLParser.AST
         public GraphQLType? Type { get; set; }
     }
 
+    internal sealed class GraphQLFieldDefinitionWithLocation : GraphQLFieldDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLFieldDefinitionWithComment : GraphQLFieldDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLFieldDefinitionFull : GraphQLFieldDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLFieldDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
+    public class GraphQLFieldDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public List<GraphQLInputValueDefinition>? Arguments { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLFieldSelection.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldSelection.cs
@@ -20,6 +20,28 @@ namespace GraphQLParser.AST
         public GraphQLSelectionSet? SelectionSet { get; set; }
     }
 
+    internal sealed class GraphQLFieldSelectionWithLocation : GraphQLFieldSelection
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLFieldSelectionWithComment : GraphQLFieldSelection
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLFieldSelectionFull : GraphQLFieldSelection
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLFragmentDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFragmentDefinition.cs
@@ -9,6 +9,27 @@ namespace GraphQLParser.AST
         public GraphQLName? Name { get; set; }
     }
 
+    internal sealed class GraphQLFragmentDefinitionWithLocation : GraphQLFragmentDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLFragmentDefinitionWithComment : GraphQLFragmentDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
     internal sealed class GraphQLFragmentDefinitionFull : GraphQLFragmentDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLFragmentSpread.cs
+++ b/src/GraphQLParser/AST/GraphQLFragmentSpread.cs
@@ -14,6 +14,28 @@ namespace GraphQLParser.AST
         public GraphQLName? Name { get; set; }
     }
 
+    internal sealed class GraphQLFragmentSpreadWithLocation : GraphQLFragmentSpread
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLFragmentSpreadWithComment : GraphQLFragmentSpread
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLFragmentSpreadFull : GraphQLFragmentSpread
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLInlineFragment.cs
+++ b/src/GraphQLParser/AST/GraphQLInlineFragment.cs
@@ -15,6 +15,28 @@ namespace GraphQLParser.AST
         public GraphQLNamedType? TypeCondition { get; set; }
     }
 
+    internal sealed class GraphQLInlineFragmentWithLocation : GraphQLInlineFragment
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLInlineFragmentWithComment : GraphQLInlineFragment
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLInlineFragmentFull : GraphQLInlineFragment
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
@@ -13,6 +13,28 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.InputObjectTypeDefinition;
     }
 
+    internal sealed class GraphQLInputObjectTypeDefinitionWithLocation : GraphQLInputObjectTypeDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLInputObjectTypeDefinitionWithComment : GraphQLInputObjectTypeDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLInputObjectTypeDefinitionFull : GraphQLInputObjectTypeDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInputObjectTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
+    public class GraphQLInputObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
@@ -15,6 +15,28 @@ namespace GraphQLParser.AST
         public GraphQLType? Type { get; set; }
     }
 
+    internal sealed class GraphQLInputValueDefinitionWithLocation : GraphQLInputValueDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLInputValueDefinitionWithComment : GraphQLInputValueDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLInputValueDefinitionFull : GraphQLInputValueDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInputValueDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
+    public class GraphQLInputValueDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         public GraphQLValue? DefaultValue { get; set; }
 

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
+    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
@@ -13,6 +13,28 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.InterfaceTypeDefinition;
     }
 
+    internal sealed class GraphQLInterfaceTypeDefinitionWithLocation : GraphQLInterfaceTypeDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLInterfaceTypeDefinitionWithComment : GraphQLInterfaceTypeDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLInterfaceTypeDefinitionFull : GraphQLInterfaceTypeDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLListType.cs
+++ b/src/GraphQLParser/AST/GraphQLListType.cs
@@ -11,10 +11,32 @@ namespace GraphQLParser.AST
         public override string ToString() => $"[{Type}]";
     }
 
+    internal sealed class GraphQLListTypeWithLocation : GraphQLListType
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLListTypeWithComment : GraphQLListType
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLListTypeFull : GraphQLListType
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
+        private GraphQLComment? _comment;
 
         public override GraphQLLocation Location
         {
@@ -22,11 +44,10 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
 
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLListValue.cs
+++ b/src/GraphQLParser/AST/GraphQLListValue.cs
@@ -22,10 +22,42 @@ namespace GraphQLParser.AST
         public override string ToString() => AstValue.ToString();
     }
 
+    internal sealed class GraphQLListValueWithLocation : GraphQLListValue
+    {
+        private GraphQLLocation _location;
+
+        public GraphQLListValueWithLocation(ASTNodeKind kind)
+            : base(kind)
+        {
+        }
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLListValueWithComment : GraphQLListValue
+    {
+        private GraphQLComment? _comment;
+
+        public GraphQLListValueWithComment(ASTNodeKind kind)
+            : base(kind)
+        {
+        }
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLListValueFull : GraphQLListValue
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
+        private GraphQLComment? _comment;
 
         public GraphQLListValueFull(ASTNodeKind kind)
             : base(kind)
@@ -38,11 +70,10 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
 
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLName.cs
+++ b/src/GraphQLParser/AST/GraphQLName.cs
@@ -15,10 +15,32 @@ namespace GraphQLParser.AST
         public ROM Value { get; set; }
     }
 
+    internal sealed class GraphQLNameWithLocation : GraphQLName
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLNameWithComment : GraphQLName
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLNameFull : GraphQLName
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
+        private GraphQLComment? _comment;
 
         public override GraphQLLocation Location
         {
@@ -26,11 +48,10 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
 
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLNamedType.cs
+++ b/src/GraphQLParser/AST/GraphQLNamedType.cs
@@ -12,10 +12,32 @@ namespace GraphQLParser.AST
         public override string ToString() => Name?.Value.ToString()!;
     }
 
+    internal sealed class GraphQLNamedTypeWithLocation : GraphQLNamedType
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLNamedTypeWithComment : GraphQLNamedType
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLNamedTypeFull : GraphQLNamedType
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
+        private GraphQLComment? _comment;
 
         public override GraphQLLocation Location
         {
@@ -23,11 +45,10 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
 
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLNonNullType.cs
+++ b/src/GraphQLParser/AST/GraphQLNonNullType.cs
@@ -11,10 +11,32 @@ namespace GraphQLParser.AST
         public override string ToString() => Type + "!";
     }
 
+    internal sealed class GraphQLNonNullTypeWithLocation : GraphQLNonNullType
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLNonNullTypeWithComment : GraphQLNonNullType
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLNonNullTypeFull : GraphQLNonNullType
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
+        private GraphQLComment? _comment;
 
         public override GraphQLLocation Location
         {
@@ -22,11 +44,10 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
 
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLObjectField.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectField.cs
@@ -11,6 +11,28 @@ namespace GraphQLParser.AST
         public GraphQLValue? Value { get; set; }
     }
 
+    internal sealed class GraphQLObjectFieldWithLocation : GraphQLObjectField
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLObjectFieldWithComment : GraphQLObjectField
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLObjectFieldFull : GraphQLObjectField
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLObjectTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
+    public class GraphQLObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
@@ -15,6 +15,28 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.ObjectTypeDefinition;
     }
 
+    internal sealed class GraphQLObjectTypeDefinitionWithLocation : GraphQLObjectTypeDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLObjectTypeDefinitionWithComment : GraphQLObjectTypeDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLObjectTypeDefinitionFull : GraphQLObjectTypeDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLObjectValue.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectValue.cs
@@ -10,6 +10,28 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.ObjectValue;
     }
 
+    internal sealed class GraphQLObjectValueWithLocation : GraphQLObjectValue
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLObjectValueWithComment : GraphQLObjectValue
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLObjectValueFull : GraphQLObjectValue
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLOperationDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLOperationDefinition.cs
@@ -20,6 +20,28 @@ namespace GraphQLParser.AST
         public List<GraphQLVariableDefinition>? VariableDefinitions { get; set; }
     }
 
+    internal sealed class GraphQLOperationDefinitionWithLocation : GraphQLOperationDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLOperationDefinitionWithComment : GraphQLOperationDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLOperationDefinitionFull : GraphQLOperationDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLOperationTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLOperationTypeDefinition.cs
@@ -10,10 +10,32 @@ namespace GraphQLParser.AST
         public GraphQLNamedType? Type { get; set; }
     }
 
+    internal sealed class GraphQLOperationTypeDefinitionWithLocation : GraphQLOperationTypeDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLOperationTypeDefinitionWithComment : GraphQLOperationTypeDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLOperationTypeDefinitionFull : GraphQLOperationTypeDefinition
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
+        private GraphQLComment? _comment;
 
         public override GraphQLLocation Location
         {
@@ -21,11 +43,10 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
 
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLRootOperationTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLRootOperationTypeDefinition.cs
@@ -1,26 +1,16 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
-    public class GraphQLFieldSelection : ASTNode, IHasDirectivesNode, INamedNode
+    public class GraphQLRootOperationTypeDefinition : ASTNode
     {
-        public GraphQLName? Alias { get; set; }
-
-        public List<GraphQLArgument>? Arguments { get; set; }
-
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public override ASTNodeKind Kind => ASTNodeKind.OperationTypeDefinition;
 
-        /// <inheritdoc/>
-        public override ASTNodeKind Kind => ASTNodeKind.Field;
+        public OperationType Operation { get; set; }
 
-        /// <inheritdoc/>
-        public GraphQLName? Name { get; set; }
-
-        public GraphQLSelectionSet? SelectionSet { get; set; }
+        public GraphQLNamedType? Type { get; set; }
     }
 
-    internal sealed class GraphQLFieldSelectionWithLocation : GraphQLFieldSelection
+    internal sealed class GraphQLRootOperationTypeDefinitionWithLocation : GraphQLRootOperationTypeDefinition
     {
         private GraphQLLocation _location;
 
@@ -31,7 +21,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLFieldSelectionWithComment : GraphQLFieldSelection
+    internal sealed class GraphQLRootOperationTypeDefinitionWithComment : GraphQLRootOperationTypeDefinition
     {
         private GraphQLComment? _comment;
 
@@ -42,7 +32,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLFieldSelectionFull : GraphQLFieldSelection
+    internal sealed class GraphQLRootOperationTypeDefinitionFull : GraphQLRootOperationTypeDefinition
     {
         private GraphQLLocation _location;
         private GraphQLComment? _comment;

--- a/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
@@ -11,6 +11,28 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.ScalarTypeDefinition;
     }
 
+    internal sealed class GraphQLScalarTypeDefinitionWithLocation : GraphQLScalarTypeDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLScalarTypeDefinitionWithComment : GraphQLScalarTypeDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLScalarTypeDefinitionFull : GraphQLScalarTypeDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLScalarTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
+    public class GraphQLScalarTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLScalarValue.cs
+++ b/src/GraphQLParser/AST/GraphQLScalarValue.cs
@@ -45,10 +45,42 @@ namespace GraphQLParser.AST
         public override string? ToString() => Kind == ASTNodeKind.StringValue ? $"\"{Value}\"" : Value.ToString();
     }
 
+    internal sealed class GraphQLScalarValueWithLocation : GraphQLScalarValue
+    {
+        private GraphQLLocation _location;
+
+        public GraphQLScalarValueWithLocation(ASTNodeKind kind)
+            : base(kind)
+        {
+        }
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLScalarValueWithComment : GraphQLScalarValue
+    {
+        private GraphQLComment? _comment;
+
+        public GraphQLScalarValueWithComment(ASTNodeKind kind)
+            : base(kind)
+        {
+        }
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLScalarValueFull : GraphQLScalarValue
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
+        private GraphQLComment? _comment;
 
         public GraphQLScalarValueFull(ASTNodeKind kind)
             : base(kind)
@@ -61,11 +93,10 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
 
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
@@ -13,7 +13,7 @@ namespace GraphQLParser.AST
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.SchemaDefinition;
 
-        public List<GraphQLOperationTypeDefinition>? OperationTypes { get; set; }
+        public List<GraphQLRootOperationTypeDefinition>? OperationTypes { get; set; }
     }
 
     internal sealed class GraphQLSchemaDefinitionWithLocation : GraphQLSchemaDefinition

--- a/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
@@ -2,10 +2,13 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLSchemaDefinition : ASTNode, IHasDirectivesNode
+    public class GraphQLSchemaDefinition : ASTNode, IHasDirectivesNode, IHasDescriptionNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }
+
+        /// <inheritdoc/>
+        public GraphQLDescription? Description { get; set; }
 
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.SchemaDefinition;

--- a/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
@@ -16,6 +16,28 @@ namespace GraphQLParser.AST
         public List<GraphQLOperationTypeDefinition>? OperationTypes { get; set; }
     }
 
+    internal sealed class GraphQLSchemaDefinitionWithLocation : GraphQLSchemaDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLSchemaDefinitionWithComment : GraphQLSchemaDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLSchemaDefinitionFull : GraphQLSchemaDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLSelectionSet.cs
+++ b/src/GraphQLParser/AST/GraphQLSelectionSet.cs
@@ -10,10 +10,32 @@ namespace GraphQLParser.AST
         public List<ASTNode>? Selections { get; set; }
     }
 
+    internal sealed class GraphQLSelectionSetWithLocation : GraphQLSelectionSet
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLSelectionSetWithComment : GraphQLSelectionSet
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLSelectionSetFull : GraphQLSelectionSet
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
+        private GraphQLComment? _comment;
 
         public override GraphQLLocation Location
         {
@@ -21,11 +43,10 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
 
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLTypeDefinition.cs
@@ -1,16 +1,11 @@
 namespace GraphQLParser.AST
 {
-    public abstract class GraphQLTypeDefinition : ASTNode, INamedNode
+    public abstract class GraphQLTypeDefinition : ASTNode, INamedNode, IHasDescriptionNode
     {
         /// <inheritdoc/>
         public GraphQLName? Name { get; set; }
-    }
 
-    public abstract class GraphQLTypeDefinitionWithDescription : GraphQLTypeDefinition, IHasDescription
-    {
-        /// <summary>
-        /// Description of the node
-        /// </summary>
+        /// <inheritdoc/>
         public GraphQLDescription? Description { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLTypeExtensionDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLTypeExtensionDefinition.cs
@@ -8,6 +8,28 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.TypeExtensionDefinition;
     }
 
+    internal sealed class GraphQLTypeExtensionDefinitionWithLocation : GraphQLTypeExtensionDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLTypeExtensionDefinitionWithComment : GraphQLTypeExtensionDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLTypeExtensionDefinitionFull : GraphQLTypeExtensionDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace GraphQLParser.AST
 {
-    public class GraphQLUnionTypeDefinition : GraphQLTypeDefinitionWithDescription, IHasDirectivesNode
+    public class GraphQLUnionTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode
     {
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
@@ -13,6 +13,28 @@ namespace GraphQLParser.AST
         public List<GraphQLNamedType>? Types { get; set; }
     }
 
+    internal sealed class GraphQLUnionTypeDefinitionWithLocation : GraphQLUnionTypeDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLUnionTypeDefinitionWithComment : GraphQLUnionTypeDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLUnionTypeDefinitionFull : GraphQLUnionTypeDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/GraphQLVariable.cs
+++ b/src/GraphQLParser/AST/GraphQLVariable.cs
@@ -9,10 +9,32 @@ namespace GraphQLParser.AST
         public GraphQLName? Name { get; set; }
     }
 
+    internal sealed class GraphQLVariableWithLocation : GraphQLVariable
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLVariableWithComment : GraphQLVariable
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
+
     internal sealed class GraphQLVariableFull : GraphQLVariable
     {
         private GraphQLLocation _location;
-        //private GraphQLComment? _comment;
+        private GraphQLComment? _comment;
 
         public override GraphQLLocation Location
         {
@@ -20,11 +42,10 @@ namespace GraphQLParser.AST
             set => _location = value;
         }
 
-        // TODO: this property is not set anywhere (yet), so it makes no sense to create a field for it
-        //public override GraphQLComment? Comment
-        //{
-        //    get => _comment;
-        //    set => _comment = value;
-        //}
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
     }
 }

--- a/src/GraphQLParser/AST/GraphQLVariableDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLVariableDefinition.cs
@@ -12,6 +12,27 @@ namespace GraphQLParser.AST
         public GraphQLVariable? Variable { get; set; }
     }
 
+    internal sealed class GraphQLVariableDefinitionWithLocation : GraphQLVariableDefinition
+    {
+        private GraphQLLocation _location;
+
+        public override GraphQLLocation Location
+        {
+            get => _location;
+            set => _location = value;
+        }
+    }
+
+    internal sealed class GraphQLVariableDefinitionWithComment : GraphQLVariableDefinition
+    {
+        private GraphQLComment? _comment;
+
+        public override GraphQLComment? Comment
+        {
+            get => _comment;
+            set => _comment = value;
+        }
+    }
     internal sealed class GraphQLVariableDefinitionFull : GraphQLVariableDefinition
     {
         private GraphQLLocation _location;

--- a/src/GraphQLParser/AST/IHasDescription.cs
+++ b/src/GraphQLParser/AST/IHasDescription.cs
@@ -1,7 +1,0 @@
-namespace GraphQLParser.AST
-{
-    public interface IHasDescription
-    {
-        GraphQLDescription? Description { get; set; }
-    }
-}

--- a/src/GraphQLParser/AST/IHasDescriptionNode.cs
+++ b/src/GraphQLParser/AST/IHasDescriptionNode.cs
@@ -1,0 +1,14 @@
+namespace GraphQLParser.AST
+{
+    /// <summary>
+    /// Represents an AST node that may have description applied to it.
+    /// As a rule, these are definition nodes: type, arguments, enum values etc.
+    /// </summary>
+    public interface IHasDescriptionNode
+    {
+        /// <summary>
+        /// Description of a GraphQL definition.
+        /// </summary>
+        GraphQLDescription? Description { get; set; }
+    }
+}

--- a/src/GraphQLParser/GraphQLAstVisitor.cs
+++ b/src/GraphQLParser/GraphQLAstVisitor.cs
@@ -4,7 +4,7 @@ using GraphQLParser.AST;
 
 namespace GraphQLParser
 {
-    public class GraphQLAstVisitor //TODO: not used
+    public class GraphQLAstVisitor // TODO: not used
     {
         protected IDictionary<string, GraphQLFragmentDefinition> Fragments { get; private set; }
 
@@ -57,7 +57,7 @@ namespace GraphQLParser
 
         public virtual GraphQLScalarValue BeginVisitEnumValue(GraphQLScalarValue value) => value;
 
-        public virtual GraphQLFieldSelection BeginVisitFieldSelection(GraphQLFieldSelection selection)
+        public virtual GraphQLField BeginVisitField(GraphQLField selection)
         {
             BeginVisitNode(selection.Name);
 
@@ -73,7 +73,7 @@ namespace GraphQLParser
             if (selection.Directives != null)
                 BeginVisitDirectives(selection.Directives);
 
-            return EndVisitFieldSelection(selection);
+            return EndVisitField(selection);
         }
 
         public virtual GraphQLScalarValue BeginVisitFloatValue(GraphQLScalarValue value) => value;
@@ -119,7 +119,7 @@ namespace GraphQLParser
         {
             ASTNodeKind.OperationDefinition => BeginVisitOperationDefinition((GraphQLOperationDefinition)node),
             ASTNodeKind.SelectionSet => BeginVisitSelectionSet((GraphQLSelectionSet)node),
-            ASTNodeKind.Field => BeginVisitNonIntrospectionFieldSelection((GraphQLFieldSelection)node),
+            ASTNodeKind.Field => BeginVisitNonIntrospectionField((GraphQLField)node),
             ASTNodeKind.Name => BeginVisitName((GraphQLName)node),
             ASTNodeKind.Argument => BeginVisitArgument((GraphQLArgument)node),
             ASTNodeKind.FragmentSpread => BeginVisitFragmentSpread((GraphQLFragmentSpread)node),
@@ -193,7 +193,7 @@ namespace GraphQLParser
 
         public virtual GraphQLArgument EndVisitArgument(GraphQLArgument argument) => argument;
 
-        public virtual GraphQLFieldSelection EndVisitFieldSelection(GraphQLFieldSelection selection) => selection;
+        public virtual GraphQLField EndVisitField(GraphQLField selection) => selection;
 
         public virtual GraphQLVariable EndVisitVariable(GraphQLVariable variable) => variable;
 
@@ -206,7 +206,7 @@ namespace GraphQLParser
                     if (definition.Kind == ASTNodeKind.FragmentDefinition)
                     {
                         var fragment = (GraphQLFragmentDefinition)definition;
-                        string? name = fragment.Name?.Value.ToString(); //TODO: heap allocation
+                        string? name = fragment.Name?.Value.ToString(); // TODO: heap allocation
                         if (name == null)
                             throw new InvalidOperationException("Fragment name cannot be null");
 
@@ -256,9 +256,9 @@ namespace GraphQLParser
             return EndVisitListValue(node);
         }
 
-        private ASTNode BeginVisitNonIntrospectionFieldSelection(GraphQLFieldSelection selection)
+        private ASTNode BeginVisitNonIntrospectionField(GraphQLField selection)
         {
-            return BeginVisitFieldSelection(selection);
+            return BeginVisitField(selection);
         }
     }
 }

--- a/src/GraphQLParser/IgnoreOptions.cs
+++ b/src/GraphQLParser/IgnoreOptions.cs
@@ -19,7 +19,7 @@ namespace GraphQLParser
         Comments = 1,
 
         /// <summary>
-        /// Specifies whether to ignore  token locations when parsing GraphQL document.
+        /// Specifies whether to ignore token locations when parsing GraphQL document.
         /// </summary>
         Locations = 2,
 

--- a/src/GraphQLParser/IgnoreOptions.cs
+++ b/src/GraphQLParser/IgnoreOptions.cs
@@ -1,23 +1,31 @@
+using System;
+
 namespace GraphQLParser
 {
     /// <summary>
     /// Options to selectively ignore some information when parsing GraphQL document.
     /// </summary>
+    [Flags]
     public enum IgnoreOptions
     {
         /// <summary>
+        /// No information is ignored.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
         /// Specifies whether to ignore comments when parsing GraphQL document.
         /// </summary>
-        IgnoreComments = 0,
+        Comments = 1,
+
+        /// <summary>
+        /// Specifies whether to ignore  token locations when parsing GraphQL document.
+        /// </summary>
+        Locations = 2,
 
         /// <summary>
         /// Specifies whether to ignore comments and token locations when parsing GraphQL document.
         /// </summary>
-        IgnoreCommentsAndLocations = 1,
-
-        /// <summary>
-        /// No information is ignored.
-        /// </summary>
-        None = 2
+        All = Comments | Locations,
     }
 }

--- a/src/GraphQLParser/Location.cs
+++ b/src/GraphQLParser/Location.cs
@@ -7,7 +7,7 @@ namespace GraphQLParser
     /// </summary>
     public readonly struct Location
     {
-        private static readonly Regex _lineRegex = new Regex("\r\n|[\n\r]", RegexOptions.ECMAScript);
+        private static readonly Regex _lineRegex = new("\r\n|[\n\r]", RegexOptions.ECMAScript);
 
         /// <summary>
         /// Creates location from a given sequence of characters and a linear character position.

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -1,0 +1,416 @@
+using System.Runtime.CompilerServices;
+using GraphQLParser.AST;
+
+namespace GraphQLParser
+{
+    internal static class NodeHelper
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLComment CreateGraphQLComment(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLComment(),
+                IgnoreOptions.Comments => new GraphQLCommentWithLocation(),
+                IgnoreOptions.Locations => new GraphQLComment(),
+                _ => new GraphQLCommentWithLocation(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLDocument CreateGraphQLDocument(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLDocument(),
+                IgnoreOptions.Comments => new GraphQLDocumentWithLocation(),
+                IgnoreOptions.Locations => new GraphQLDocument(),
+                _ => new GraphQLDocumentWithLocation(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLDescription CreateGraphQLDescription(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLDescription(),
+                IgnoreOptions.Comments => new GraphQLDescriptionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLDescription(),
+                _ => new GraphQLDescriptionWithLocation(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLArgument CreateGraphQLArgument(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLArgument(),
+                IgnoreOptions.Comments => new GraphQLArgumentWithLocation(),
+                IgnoreOptions.Locations => new GraphQLArgumentWithComment(),
+                _ => new GraphQLArgumentFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLDirective CreateGraphQLDirective(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLDirective(),
+                IgnoreOptions.Comments => new GraphQLDirectiveWithLocation(),
+                IgnoreOptions.Locations => new GraphQLDirectiveWithComment(),
+                _ => new GraphQLDirectiveFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLVariableDefinition CreateGraphQLVariableDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLVariableDefinition(),
+                IgnoreOptions.Comments => new GraphQLVariableDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLVariableDefinitionWithComment(),
+                _ => new GraphQLVariableDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLEnumTypeDefinition CreateGraphQLEnumTypeDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLEnumTypeDefinition(),
+                IgnoreOptions.Comments => new GraphQLEnumTypeDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLEnumTypeDefinitionWithComment(),
+                _ => new GraphQLEnumTypeDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLScalarValue CreateGraphQLScalarValue(IgnoreOptions options, ASTNodeKind kind)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLScalarValue(kind),
+                IgnoreOptions.Comments => new GraphQLScalarValueWithLocation(kind),
+                IgnoreOptions.Locations => new GraphQLScalarValueWithComment(kind),
+                _ => new GraphQLScalarValueFull(kind),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLEnumValueDefinition CreateGraphQLEnumValueDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLEnumValueDefinition(),
+                IgnoreOptions.Comments => new GraphQLEnumValueDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLEnumValueDefinitionWithComment(),
+                _ => new GraphQLEnumValueDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLFieldDefinition CreateGraphQLFieldDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLFieldDefinition(),
+                IgnoreOptions.Comments => new GraphQLFieldDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLFieldDefinitionWithComment(),
+                _ => new GraphQLFieldDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLSelectionSet CreateGraphQLSelectionSet(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLSelectionSet(),
+                IgnoreOptions.Comments => new GraphQLSelectionSetWithLocation(),
+                IgnoreOptions.Locations => new GraphQLSelectionSetWithComment(),
+                _ => new GraphQLSelectionSetFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLVariable CreateGraphQLVariable(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLVariable(),
+                IgnoreOptions.Comments => new GraphQLVariableWithLocation(),
+                IgnoreOptions.Locations => new GraphQLVariableWithComment(),
+                _ => new GraphQLVariableFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLOperationTypeDefinition CreateGraphQLOperationTypeDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLOperationTypeDefinition(),
+                IgnoreOptions.Comments => new GraphQLOperationTypeDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLOperationTypeDefinitionWithComment(),
+                _ => new GraphQLOperationTypeDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLNamedType CreateGraphQLNamedType(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLNamedType(),
+                IgnoreOptions.Comments => new GraphQLNamedTypeWithLocation(),
+                IgnoreOptions.Locations => new GraphQLNamedTypeWithComment(),
+                _ => new GraphQLNamedTypeFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLName CreateGraphQLName(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLName(),
+                IgnoreOptions.Comments => new GraphQLNameWithLocation(),
+                IgnoreOptions.Locations => new GraphQLNameWithComment(),
+                _ => new GraphQLNameFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLListValue CreateGraphQLListValue(IgnoreOptions options, ASTNodeKind kind)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLListValue(kind),
+                IgnoreOptions.Comments => new GraphQLListValueWithLocation(kind),
+                IgnoreOptions.Locations => new GraphQLListValueWithComment(kind),
+                _ => new GraphQLListValueFull(kind),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLListType CreateGraphQLListType(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLListType(),
+                IgnoreOptions.Comments => new GraphQLListTypeWithLocation(),
+                IgnoreOptions.Locations => new GraphQLListTypeWithComment(),
+                _ => new GraphQLListTypeFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLDirectiveDefinition CreateGraphQLDirectiveDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLDirectiveDefinition(),
+                IgnoreOptions.Comments => new GraphQLDirectiveDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLDirectiveDefinitionWithComment(),
+                _ => new GraphQLDirectiveDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLFieldSelection CreateGraphQLFieldSelection(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLFieldSelection(),
+                IgnoreOptions.Comments => new GraphQLFieldSelectionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLFieldSelectionWithComment(),
+                _ => new GraphQLFieldSelectionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLFragmentDefinition CreateGraphQLFragmentDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLFragmentDefinition(),
+                IgnoreOptions.Comments => new GraphQLFragmentDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLFragmentDefinitionWithComment(),
+                _ => new GraphQLFragmentDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLUnionTypeDefinition CreateGraphQLUnionTypeDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLUnionTypeDefinition(),
+                IgnoreOptions.Comments => new GraphQLUnionTypeDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLUnionTypeDefinitionWithComment(),
+                _ => new GraphQLUnionTypeDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLTypeExtensionDefinition CreateGraphQLTypeExtensionDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLTypeExtensionDefinition(),
+                IgnoreOptions.Comments => new GraphQLTypeExtensionDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLTypeExtensionDefinitionWithComment(),
+                _ => new GraphQLTypeExtensionDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLFragmentSpread CreateGraphQLFragmentSpread(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLFragmentSpread(),
+                IgnoreOptions.Comments => new GraphQLFragmentSpreadWithLocation(),
+                IgnoreOptions.Locations => new GraphQLFragmentSpreadWithComment(),
+                _ => new GraphQLFragmentSpreadFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLInlineFragment CreateGraphQLInlineFragment(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLInlineFragment(),
+                IgnoreOptions.Comments => new GraphQLInlineFragmentWithLocation(),
+                IgnoreOptions.Locations => new GraphQLInlineFragmentWithComment(),
+                _ => new GraphQLInlineFragmentFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLInputObjectTypeDefinition CreateGraphQLInputObjectTypeDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLInputObjectTypeDefinition(),
+                IgnoreOptions.Comments => new GraphQLInputObjectTypeDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLInputObjectTypeDefinitionWithComment(),
+                _ => new GraphQLInputObjectTypeDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLInterfaceTypeDefinition CreateGraphQLInterfaceTypeDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLInterfaceTypeDefinition(),
+                IgnoreOptions.Comments => new GraphQLInterfaceTypeDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLInterfaceTypeDefinitionWithComment(),
+                _ => new GraphQLInterfaceTypeDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLNonNullType CreateGraphQLNonNullType(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLNonNullType(),
+                IgnoreOptions.Comments => new GraphQLNonNullTypeWithLocation(),
+                IgnoreOptions.Locations => new GraphQLNonNullTypeWithComment(),
+                _ => new GraphQLNonNullTypeFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLSchemaDefinition CreateGraphQLSchemaDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLSchemaDefinition(),
+                IgnoreOptions.Comments => new GraphQLSchemaDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLSchemaDefinitionWithComment(),
+                _ => new GraphQLSchemaDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLScalarTypeDefinition CreateGraphQLScalarTypeDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLScalarTypeDefinition(),
+                IgnoreOptions.Comments => new GraphQLScalarTypeDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLScalarTypeDefinitionWithComment(),
+                _ => new GraphQLScalarTypeDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLOperationDefinition CreateGraphQLOperationDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLOperationDefinition(),
+                IgnoreOptions.Comments => new GraphQLOperationDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLOperationDefinitionWithComment(),
+                _ => new GraphQLOperationDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLObjectTypeDefinition CreateGraphQLObjectTypeDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLObjectTypeDefinition(),
+                IgnoreOptions.Comments => new GraphQLObjectTypeDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLObjectTypeDefinitionWithComment(),
+                _ => new GraphQLObjectTypeDefinitionFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLObjectField CreateGraphQLObjectField(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLObjectField(),
+                IgnoreOptions.Comments => new GraphQLObjectFieldWithLocation(),
+                IgnoreOptions.Locations => new GraphQLObjectFieldWithComment(),
+                _ => new GraphQLObjectFieldFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLObjectValue CreateGraphQLObjectValue(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLObjectValue(),
+                IgnoreOptions.Comments => new GraphQLObjectValueWithLocation(),
+                IgnoreOptions.Locations => new GraphQLObjectValueWithComment(),
+                _ => new GraphQLObjectValueFull(),
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLInputValueDefinition CreateGraphQLInputValueDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLInputValueDefinition(),
+                IgnoreOptions.Comments => new GraphQLInputValueDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLInputValueDefinitionWithComment(),
+                _ => new GraphQLInputValueDefinitionFull(),
+            };
+        }
+    }
+}

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -5,6 +5,8 @@ namespace GraphQLParser
 {
     internal static class NodeHelper
     {
+        #region ASTNodes that can not have comments, only locations
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static GraphQLComment CreateGraphQLComment(IgnoreOptions options)
         {
@@ -40,6 +42,10 @@ namespace GraphQLParser
                 _ => new GraphQLDescriptionWithLocation(),
             };
         }
+
+        #endregion
+
+        #region ASTNodes that can have comments and locations
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static GraphQLArgument CreateGraphQLArgument(IgnoreOptions options)
@@ -150,14 +156,14 @@ namespace GraphQLParser
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static GraphQLOperationTypeDefinition CreateGraphQLOperationTypeDefinition(IgnoreOptions options)
+        public static GraphQLRootOperationTypeDefinition CreateGraphQLOperationTypeDefinition(IgnoreOptions options)
         {
             return options switch
             {
-                IgnoreOptions.All => new GraphQLOperationTypeDefinition(),
-                IgnoreOptions.Comments => new GraphQLOperationTypeDefinitionWithLocation(),
-                IgnoreOptions.Locations => new GraphQLOperationTypeDefinitionWithComment(),
-                _ => new GraphQLOperationTypeDefinitionFull(),
+                IgnoreOptions.All => new GraphQLRootOperationTypeDefinition(),
+                IgnoreOptions.Comments => new GraphQLRootOperationTypeDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLRootOperationTypeDefinitionWithComment(),
+                _ => new GraphQLRootOperationTypeDefinitionFull(),
             };
         }
 
@@ -222,14 +228,14 @@ namespace GraphQLParser
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static GraphQLFieldSelection CreateGraphQLFieldSelection(IgnoreOptions options)
+        public static GraphQLField CreateGraphQLField(IgnoreOptions options)
         {
             return options switch
             {
-                IgnoreOptions.All => new GraphQLFieldSelection(),
-                IgnoreOptions.Comments => new GraphQLFieldSelectionWithLocation(),
-                IgnoreOptions.Locations => new GraphQLFieldSelectionWithComment(),
-                _ => new GraphQLFieldSelectionFull(),
+                IgnoreOptions.All => new GraphQLField(),
+                IgnoreOptions.Comments => new GraphQLFieldWithLocation(),
+                IgnoreOptions.Locations => new GraphQLFieldWithComment(),
+                _ => new GraphQLFieldFull(),
             };
         }
 
@@ -412,5 +418,7 @@ namespace GraphQLParser
                 _ => new GraphQLInputValueDefinitionFull(),
             };
         }
+
+        #endregion
     }
 }

--- a/src/GraphQLParser/Parser.cs
+++ b/src/GraphQLParser/Parser.cs
@@ -13,6 +13,7 @@ namespace GraphQLParser
         /// <param name="source">Input data as a sequence of characters.</param>
         /// <param name="options">Parser options.</param>
         /// <returns>AST (Abstract Syntax Tree) for GraphQL document.</returns>
-        public static GraphQLDocument Parse(ROM source, ParserOptions options = default) => new ParserContext(source, options).Parse();
+        public static GraphQLDocument Parse(ROM source, ParserOptions options = default)
+            => new ParserContext(source, options).ParseDocument();
     }
 }

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -33,7 +33,7 @@ namespace GraphQLParser
             var comment = GetComment();
             int start = _currentToken.Start;
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLArgument
                 {
                     Name = ParseName(),
@@ -86,7 +86,7 @@ namespace GraphQLParser
         private GraphQLValue ParseBooleanValue(Token token)
         {
             Advance();
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLScalarValue(ASTNodeKind.BooleanValue)
                 {
                     Value = token.Value,
@@ -147,7 +147,8 @@ namespace GraphQLParser
 
         private GraphQLComment? ParseComment()
         {
-            if (_ignoreOptions != IgnoreOptions.None)
+            // skip comments
+            if (_ignoreOptions.HasFlag(IgnoreOptions.Comments))
             {
                 while (Peek(TokenKind.COMMENT))
                 {
@@ -173,14 +174,12 @@ namespace GraphQLParser
             }
             while (_currentToken.Kind == TokenKind.COMMENT);
 
-            var comment = new GraphQLComment
-            {
-                Location = new GraphQLLocation
-                (
-                    start,
-                    end
-                )
-            };
+            var comment = _ignoreOptions.HasFlag(IgnoreOptions.Locations)
+                ? new GraphQLComment()
+                : new GraphQLCommentFull
+                {
+                    Location = new GraphQLLocation(start, end),
+                };
 
             if (text.Count == 1)
             {
@@ -210,7 +209,7 @@ namespace GraphQLParser
         {
             int start = _currentToken.Start;
             Expect(TokenKind.AT);
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLDirective
                 {
                     Name = ParseName(),
@@ -250,7 +249,7 @@ namespace GraphQLParser
             ExpectKeyword("on");
             var locations = ParseDirectiveLocations();
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLDirectiveDefinition
                 {
                     Name = name,
@@ -323,14 +322,14 @@ namespace GraphQLParser
 
         private GraphQLDocument ParseDocument()
         {
-            _document = _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations ? new GraphQLDocument() : new GraphQLDocumentFull();
+            _document = _ignoreOptions.HasFlag(IgnoreOptions.Locations) ? new GraphQLDocument() : new GraphQLDocumentFull();
 
             int start = _currentToken.Start;
             var definitions = ParseDefinitionsIfNotEOF();
 
             SetCurrentComment(null);
 
-            if (_ignoreOptions != IgnoreOptions.IgnoreCommentsAndLocations)
+            if (!_ignoreOptions.HasFlag(IgnoreOptions.Locations))
             {
                 _document.Location = new GraphQLLocation
                 (
@@ -358,7 +357,7 @@ namespace GraphQLParser
             var comment = GetComment();
             ExpectKeyword("enum");
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLEnumTypeDefinition
                 {
                     Name = ParseName(),
@@ -380,7 +379,7 @@ namespace GraphQLParser
         private GraphQLValue ParseEnumValue(Token token)
         {
             Advance();
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLScalarValue(ASTNodeKind.EnumValue)
                 {
                     Value = token.Value,
@@ -403,7 +402,7 @@ namespace GraphQLParser
             }
             var comment = GetComment();
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLEnumValueDefinition
                 {
                     Name = ParseName(),
@@ -435,7 +434,7 @@ namespace GraphQLParser
             var args = ParseArgumentDefs();
             Expect(TokenKind.COLON);
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLFieldDefinition
                 {
                     Name = name,
@@ -475,7 +474,7 @@ namespace GraphQLParser
                 name = nameOrAlias;
             }
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
               ? new GraphQLFieldSelection
               {
                   Alias = alias,
@@ -500,7 +499,7 @@ namespace GraphQLParser
         {
             var token = _currentToken;
             Advance();
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLScalarValue(ASTNodeKind.FloatValue)
                 {
                     Value = token.Value,
@@ -525,7 +524,7 @@ namespace GraphQLParser
 
         private ASTNode CreateGraphQLFragmentSpread(int start, GraphQLComment? comment)
         {
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLFragmentSpread
                 {
                     Name = ParseFragmentName(),
@@ -542,7 +541,7 @@ namespace GraphQLParser
 
         private ASTNode CreateInlineFragment(int start, GraphQLComment? comment)
         {
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLInlineFragment
                 {
                     TypeCondition = ParseTypeCondition(),
@@ -565,7 +564,7 @@ namespace GraphQLParser
             int start = _currentToken.Start;
             ExpectKeyword("fragment");
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLFragmentDefinition
                 {
                     Name = ParseFragmentName(),
@@ -633,7 +632,7 @@ namespace GraphQLParser
             var comment = GetComment();
             ExpectKeyword("input");
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLInputObjectTypeDefinition
                 {
                     Name = ParseName(),
@@ -665,7 +664,7 @@ namespace GraphQLParser
             var name = ParseName();
             Expect(TokenKind.COLON);
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLInputValueDefinition
                 {
                     Name = name,
@@ -691,7 +690,7 @@ namespace GraphQLParser
             var token = _currentToken;
             Advance();
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLScalarValue(ASTNodeKind.IntValue)
                 {
                     Value = token.Value,
@@ -715,7 +714,7 @@ namespace GraphQLParser
             var comment = GetComment();
             ExpectKeyword("interface");
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLInterfaceTypeDefinition
                 {
                     Name = ParseName(),
@@ -741,7 +740,7 @@ namespace GraphQLParser
             ParseCallback<GraphQLValue> constant = (ref ParserContext context) => context.ParseValueLiteral(true);
             ParseCallback<GraphQLValue> value = (ref ParserContext context) => context.ParseValueLiteral(false);
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLListValue(ASTNodeKind.ListValue)
                 {
                     Values = ZeroOrMore(TokenKind.BRACKET_L, isConstant ? constant : value, TokenKind.BRACKET_R),
@@ -762,7 +761,7 @@ namespace GraphQLParser
 
             Expect(TokenKind.NAME);
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLName
                 {
                     Value = value
@@ -822,19 +821,22 @@ namespace GraphQLParser
 
         private ASTNode? ParseNamedDefinitionWithDescription()
         {
-            //look-ahead to next token
+            // look-ahead to next token (_currentToken remains unchanged)
             var token = Lexer.Lex(_source, _currentToken.End);
-            //skip comments
+            // skip comments
             while (token.Kind != TokenKind.EOF && token.Kind == TokenKind.COMMENT)
             {
                 token = Lexer.Lex(_source, token.End);
             }
-            //verify this is a NAME
+            // verify this is a NAME
             if (token.Kind != TokenKind.NAME)
                 return null;
 
-            //retrieve the value
+            // retrieve the value
             var value = token.Value;
+
+            if (value == "schema")
+                return ParseSchemaDefinition();
 
             if (value == "scalar")
                 return ParseScalarTypeDefinition();
@@ -863,7 +865,7 @@ namespace GraphQLParser
         private GraphQLNamedType ParseNamedType()
         {
             int start = _currentToken.Start;
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLNamedType
                 {
                     Name = ParseName(),
@@ -903,7 +905,7 @@ namespace GraphQLParser
             var comment = GetComment();
             int start = _currentToken.Start;
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLObjectValue
                 {
                     Fields = ParseObjectFields(isConstant),
@@ -919,7 +921,7 @@ namespace GraphQLParser
         private GraphQLValue ParseNullValue(Token token)
         {
             Advance();
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLScalarValue(ASTNodeKind.NullValue)
                 {
                     Value = token.Value,
@@ -935,7 +937,7 @@ namespace GraphQLParser
         {
             var comment = GetComment();
             int start = _currentToken.Start;
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLObjectField
                 {
                     Name = ParseName(),
@@ -974,7 +976,7 @@ namespace GraphQLParser
 
             ExpectKeyword("type");
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLObjectTypeDefinition
                 {
                     Name = ParseName(),
@@ -1007,7 +1009,7 @@ namespace GraphQLParser
         private ASTNode CreateOperationDefinition(int start)
         {
             var comment = GetComment();
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLOperationDefinition
                 {
                     Operation = OperationType.Query,
@@ -1025,7 +1027,7 @@ namespace GraphQLParser
         private ASTNode CreateOperationDefinition(int start, OperationType operation, GraphQLName? name)
         {
             var comment = GetComment();
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLOperationDefinition
                 {
                     Operation = operation,
@@ -1067,7 +1069,7 @@ namespace GraphQLParser
             Expect(TokenKind.COLON);
             var type = ParseNamedType();
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLOperationTypeDefinition
                 {
                     Operation = operation,
@@ -1095,7 +1097,7 @@ namespace GraphQLParser
             var name = ParseName();
             var directives = ParseDirectives();
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLScalarTypeDefinition
                 {
                     Name = name,
@@ -1114,23 +1116,31 @@ namespace GraphQLParser
 
         private GraphQLSchemaDefinition ParseSchemaDefinition()
         {
-            var comment = GetComment();
             int start = _currentToken.Start;
+            GraphQLDescription? description = null;
+            if (Peek(TokenKind.STRING))
+            {
+                description = ParseDescription();
+                ParseComment();
+            }
+            var comment = GetComment();
             ExpectKeyword("schema");
             var directives = ParseDirectives();
             var operationTypes = OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseOperationTypeDefinition(), TokenKind.BRACE_R);
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLSchemaDefinition
                 {
                     Directives = directives,
                     OperationTypes = operationTypes,
+                    Description = description,
                 }
                 : new GraphQLSchemaDefinitionFull
                 {
                     Comment = comment,
                     Directives = directives,
                     OperationTypes = operationTypes,
+                    Description = description,
                     Location = GetLocation(start)
                 };
         }
@@ -1145,7 +1155,7 @@ namespace GraphQLParser
         private GraphQLSelectionSet ParseSelectionSet()
         {
             int start = _currentToken.Start;
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLSelectionSet
                 {
                     Selections = OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseSelection(), TokenKind.BRACE_R),
@@ -1161,7 +1171,7 @@ namespace GraphQLParser
         {
             var token = _currentToken;
             Advance();
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLScalarValue(ASTNodeKind.StringValue)
                 {
                     Value = token.Value,
@@ -1177,7 +1187,7 @@ namespace GraphQLParser
         {
             var token = _currentToken;
             Advance();
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLDescription()
                 {
                     Value = token.Value,
@@ -1197,7 +1207,7 @@ namespace GraphQLParser
             {
                 type = ParseType();
                 Expect(TokenKind.BRACKET_R);
-                type = _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+                type = _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                     ? new GraphQLListType
                     {
                         Type = type,
@@ -1214,7 +1224,7 @@ namespace GraphQLParser
             }
 
             return Skip(TokenKind.BANG)
-                ? (_ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+                ? (_ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLNonNullType
                 {
                     Type = type,
@@ -1234,7 +1244,8 @@ namespace GraphQLParser
             ExpectKeyword("extend");
             var definition = ParseObjectTypeDefinition();
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            // Note that due to the spec extension definitions have no descriptions.
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLTypeExtensionDefinition
                 {
                     Name = definition.Name,
@@ -1282,7 +1293,7 @@ namespace GraphQLParser
             Expect(TokenKind.EQUALS);
             var types = ParseUnionMembers();
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLUnionTypeDefinition
                 {
                     Name = name,
@@ -1323,7 +1334,7 @@ namespace GraphQLParser
             int start = _currentToken.Start;
             Expect(TokenKind.DOLLAR);
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLVariable
                 {
                     Name = ParseName(),
@@ -1340,7 +1351,7 @@ namespace GraphQLParser
             var comment = GetComment();
             int start = _currentToken.Start;
 
-            return _ignoreOptions == IgnoreOptions.IgnoreCommentsAndLocations
+            return _ignoreOptions.HasFlag(IgnoreOptions.Locations)
                 ? new GraphQLVariableDefinition
                 {
                     Variable = ParseVariable(),

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -10,7 +10,6 @@ namespace GraphQLParser
         // http://spec.graphql.org/October2021/#Document
         public GraphQLDocument ParseDocument()
         {
-
             int start = _currentToken.Start;
             var definitions = ParseDefinitionsIfNotEOF();
 

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -24,7 +24,7 @@ namespace GraphQLParser
             _unattachedComments = null;
             _source = source;
             _ignoreOptions = options.Ignore;
-            // should create document beforehand to use RentedMemoryTracker while parsing coomments
+            // should create document beforehand to use RentedMemoryTracker while parsing comments
             _document = NodeHelper.CreateGraphQLDocument(options.Ignore);
             _currentToken = _prevToken = new Token
             (

--- a/src/GraphQLParser/ROM.cs
+++ b/src/GraphQLParser/ROM.cs
@@ -47,7 +47,7 @@ namespace GraphQLParser
         }
 
         /// <inheritdoc/>
-        public override int GetHashCode() //TODO: find a better implementation
+        public override int GetHashCode() // TODO: find a better implementation
         {
             if (_memory.Length == 0)
                 return 0;
@@ -80,7 +80,7 @@ namespace GraphQLParser
         /// <summary>
         /// Implicitly casts ReadOnlyMemory&lt;char&gt; to <see cref="ROM"/>.
         /// </summary>
-        public static implicit operator ROM(ReadOnlyMemory<char> memory) => new ROM(memory);
+        public static implicit operator ROM(ReadOnlyMemory<char> memory) => new(memory);
 
         /// <summary>
         /// Implicitly casts <see cref="ROM"/> to ReadOnlyMemory&lt;char&gt;.
@@ -95,7 +95,7 @@ namespace GraphQLParser
         /// <summary>
         /// Implicitly casts Memory&lt;char&gt; to <see cref="ROM"/>.
         /// </summary>
-        public static implicit operator ROM(Memory<char> memory) => new ROM(memory);
+        public static implicit operator ROM(Memory<char> memory) => new(memory);
 
         /// <summary>
         /// Implicitly casts string to <see cref="ROM"/>.


### PR DESCRIPTION
See #132 as a starting point. Fixes #141. Also now parser respects _ignore-locations_ option for comments. Also fixes exceptions caused by placing comments in "unexpected" positions in query/SDL.
