### PR TITLE
Add maximum depth limit to Parser

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -341,12 +341,20 @@ namespace GraphQLParser.AST
 }
 namespace GraphQLParser.Exceptions
 {
-    public class GraphQLSyntaxErrorException : System.Exception
+    public class GraphQLMaxDepthExceededException : GraphQLParser.Exceptions.GraphQLParserException
     {
-        public GraphQLSyntaxErrorException(string description, GraphQLParser.ROM source, int location) { }
+        public GraphQLMaxDepthExceededException(GraphQLParser.ROM source, int location) { }
+    }
+    public class GraphQLParserException : System.Exception
+    {
+        public GraphQLParserException(string description, GraphQLParser.ROM source, int location) { }
         public int Column { get; }
         public string Description { get; }
         public int Line { get; }
+    }
+    public class GraphQLSyntaxErrorException : GraphQLParser.Exceptions.GraphQLParserException
+    {
+        public GraphQLSyntaxErrorException(string description, GraphQLParser.ROM source, int location) { }
     }
 }
 namespace GraphQLParser

--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -412,6 +412,7 @@ namespace GraphQLParser
     public struct ParserOptions
     {
         public GraphQLParser.IgnoreOptions Ignore { get; set; }
+        public int? MaxDepth { get; set; }
     }
     public readonly struct ROM : System.IEquatable<GraphQLParser.ROM>
     {

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -15,7 +15,7 @@ namespace GraphQLParser.Tests
         [Fact]
         public void Should_Throw_With_Deep_Query()
         {
-            var count = 24000;
+            var count = 200;
             var sb = new System.Text.StringBuilder(count * 3);
             for (int i = 0; i < count; i++)
                 sb.Append("{a");
@@ -27,7 +27,7 @@ namespace GraphQLParser.Tests
         [Fact]
         public void Should_Throw_With_Deep_Literal()
         {
-            var count = 24000;
+            var count = 200;
             var sb = new System.Text.StringBuilder(count * 4 + 10);
             sb.Append("{a(b:");
             for (int i = 0; i < count; i++)

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -67,6 +67,19 @@ namespace GraphQLParser.Tests
         }
 
         [Fact]
+        public void Should_Parse_With_Shallow_Long_Query()
+        {
+            var count = 200;
+            var sb = new System.Text.StringBuilder(count * 5);
+            sb.Append('{');
+            for (int i = 0; i < count; i++)
+                sb.Append(" a" + i);
+            sb.Append('}');
+            var query = sb.ToString();
+            _ = query.Parse();
+        }
+
+        [Fact]
         public void Should_Throw_With_MaxDepth_0_On_SimpleQuery()
         {
             var query = "{a}";

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -12,6 +12,33 @@ namespace GraphQLParser.Tests
     {
         private static readonly string _nl = Environment.NewLine;
 
+        [Fact]
+        public void Should_Throw_With_Deep_Query()
+        {
+            var count = 24000;
+            var sb = new System.Text.StringBuilder(count * 3);
+            for (int i = 0; i < count; i++)
+                sb.Append("{a");
+            sb.Append(new string('}', count));
+            var query = sb.ToString();
+            Should.Throw<GraphQLSyntaxErrorException>(() => query.Parse()).Description.ShouldBe("Maximum depth exceeded.");
+        }
+
+        [Fact]
+        public void Should_Throw_With_Deep_Literal()
+        {
+            var count = 24000;
+            var sb = new System.Text.StringBuilder(count * 4 + 10);
+            sb.Append("{a(b:");
+            for (int i = 0; i < count; i++)
+                sb.Append("{c:");
+            sb.Append("{}");
+            sb.Append(new string('}', count));
+            sb.Append(")}");
+            var query = sb.ToString();
+            Should.Throw<GraphQLSyntaxErrorException>(() => query.Parse()).Description.ShouldBe("Maximum depth exceeded.");
+        }
+
         [Theory]
         [InlineData(IgnoreOptions.None)]
         //[InlineData(IgnoreOptions.Comments)]

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -21,7 +21,7 @@ namespace GraphQLParser.Tests
                 sb.Append("{a");
             sb.Append(new string('}', count));
             var query = sb.ToString();
-            Should.Throw<GraphQLSyntaxErrorException>(() => query.Parse()).Description.ShouldBe("Maximum depth exceeded.");
+            Should.Throw<GraphQLMaxDepthExceededException>(() => query.Parse());
         }
 
         [Fact]
@@ -36,28 +36,28 @@ namespace GraphQLParser.Tests
             sb.Append(new string('}', count));
             sb.Append(")}");
             var query = sb.ToString();
-            Should.Throw<GraphQLSyntaxErrorException>(() => query.Parse()).Description.ShouldBe("Maximum depth exceeded.");
+            Should.Throw<GraphQLMaxDepthExceededException>(() => query.Parse());
         }
 
         [Fact]
         public void Should_Throw_With_MaxDepth_0_On_SimpleQuery()
         {
             var query = "{a}";
-            Should.Throw<GraphQLSyntaxErrorException>(() => Parser.Parse(query, new ParserOptions { MaxDepth = 0 })).Description.ShouldBe("Maximum depth exceeded.");
+            Should.Throw<GraphQLMaxDepthExceededException>(() => Parser.Parse(query, new ParserOptions { MaxDepth = 0 }));
         }
 
         [Fact]
         public void Should_Throw_With_MaxDepth_0_On_TypeDefinition()
         {
             var query = "scalar Test";
-            Should.Throw<GraphQLSyntaxErrorException>(() => Parser.Parse(query, new ParserOptions { MaxDepth = 0 })).Description.ShouldBe("Maximum depth exceeded.");
+            Should.Throw<GraphQLMaxDepthExceededException>(() => Parser.Parse(query, new ParserOptions { MaxDepth = 0 }));
         }
 
         [Fact]
         public void Should_Throw_With_MaxDepth_1_On_SimpleQuery()
         {
             var query = "{a}";
-            Should.Throw<GraphQLSyntaxErrorException>(() => Parser.Parse(query, new ParserOptions { MaxDepth = 1 })).Description.ShouldBe("Maximum depth exceeded.");
+            Should.Throw<GraphQLMaxDepthExceededException>(() => Parser.Parse(query, new ParserOptions { MaxDepth = 1 }));
         }
 
         [Fact]

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -15,7 +15,7 @@ namespace GraphQLParser.Tests
         [Fact]
         public void Should_Throw_With_Deep_Query()
         {
-            var count = 200;
+            var count = 65;
             var sb = new System.Text.StringBuilder(count * 3);
             for (int i = 0; i < count; i++)
                 sb.Append("{a");
@@ -27,7 +27,7 @@ namespace GraphQLParser.Tests
         [Fact]
         public void Should_Throw_With_Deep_Literal()
         {
-            var count = 200;
+            var count = 65;
             var sb = new System.Text.StringBuilder(count * 4 + 10);
             sb.Append("{a(b:");
             for (int i = 0; i < count; i++)
@@ -37,6 +37,33 @@ namespace GraphQLParser.Tests
             sb.Append(")}");
             var query = sb.ToString();
             Should.Throw<GraphQLMaxDepthExceededException>(() => query.Parse());
+        }
+
+        [Fact]
+        public void Should_Parse_With_Almost_Deep_Query()
+        {
+            var count = 63;
+            var sb = new System.Text.StringBuilder(count * 3);
+            for (int i = 0; i < count; i++)
+                sb.Append("{a");
+            sb.Append(new string('}', count));
+            var query = sb.ToString();
+            _ = query.Parse();
+        }
+
+        [Fact]
+        public void Should_Parse_With_Almost_Deep_Literal()
+        {
+            var count = 60;
+            var sb = new System.Text.StringBuilder(count * 4 + 10);
+            sb.Append("{a(b:");
+            for (int i = 0; i < count; i++)
+                sb.Append("{c:");
+            sb.Append("{}");
+            sb.Append(new string('}', count));
+            sb.Append(")}");
+            var query = sb.ToString();
+            _ = query.Parse();
         }
 
         [Fact]

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -39,6 +39,41 @@ namespace GraphQLParser.Tests
             Should.Throw<GraphQLSyntaxErrorException>(() => query.Parse()).Description.ShouldBe("Maximum depth exceeded.");
         }
 
+        [Fact]
+        public void Should_Throw_With_MaxDepth_0_On_SimpleQuery()
+        {
+            var query = "{a}";
+            Should.Throw<GraphQLSyntaxErrorException>(() => Parser.Parse(query, new ParserOptions { MaxDepth = 0 })).Description.ShouldBe("Maximum depth exceeded.");
+        }
+
+        [Fact]
+        public void Should_Throw_With_MaxDepth_0_On_TypeDefinition()
+        {
+            var query = "scalar Test";
+            Should.Throw<GraphQLSyntaxErrorException>(() => Parser.Parse(query, new ParserOptions { MaxDepth = 0 })).Description.ShouldBe("Maximum depth exceeded.");
+        }
+
+        [Fact]
+        public void Should_Throw_With_MaxDepth_1_On_SimpleQuery()
+        {
+            var query = "{a}";
+            Should.Throw<GraphQLSyntaxErrorException>(() => Parser.Parse(query, new ParserOptions { MaxDepth = 1 })).Description.ShouldBe("Maximum depth exceeded.");
+        }
+
+        [Fact]
+        public void Should_Parse_With_MaxDepth_1_On_TypeDefinition()
+        {
+            var query = "scalar Test";
+            _ = Parser.Parse(query, new ParserOptions { MaxDepth = 1 });
+        }
+
+        [Fact]
+        public void Should_Parse_With_MaxDepth_2_On_SimpleQuery()
+        {
+            var query = "{a}";
+            _ = Parser.Parse(query, new ParserOptions { MaxDepth = 2 });
+        }
+
         [Theory]
         [InlineData(IgnoreOptions.None)]
         //[InlineData(IgnoreOptions.Comments)]

--- a/src/GraphQLParser/Exceptions/GraphQLMaxDepthExceededException.cs
+++ b/src/GraphQLParser/Exceptions/GraphQLMaxDepthExceededException.cs
@@ -3,13 +3,13 @@ namespace GraphQLParser.Exceptions
     /// <summary>
     /// An exception representing a GraphQL document syntax error.
     /// </summary>
-    public class GraphQLSyntaxErrorException : GraphQLParserException
+    public class GraphQLMaxDepthExceededException : GraphQLParserException
     {
         /// <summary>
         /// Initializes a new instance with the specified parameters.
         /// </summary>
-        public GraphQLSyntaxErrorException(string description, ROM source, int location)
-            : base(description, source, location)
+        public GraphQLMaxDepthExceededException(ROM source, int location)
+            : base("Maximum depth exceeded.", source, location)
         {
         }
     }

--- a/src/GraphQLParser/Exceptions/GraphQLMaxDepthExceededException.cs
+++ b/src/GraphQLParser/Exceptions/GraphQLMaxDepthExceededException.cs
@@ -1,7 +1,7 @@
 namespace GraphQLParser.Exceptions
 {
     /// <summary>
-    /// An exception representing a GraphQL document syntax error.
+    /// An exception representing a 'maximum depth exceeded' parser error.
     /// </summary>
     public class GraphQLMaxDepthExceededException : GraphQLParserException
     {

--- a/src/GraphQLParser/Exceptions/GraphQLParserException.cs
+++ b/src/GraphQLParser/Exceptions/GraphQLParserException.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Linq;
+using System.Text;
+
+namespace GraphQLParser.Exceptions
+{
+    /// <summary>
+    /// An exception representing a GraphQL document syntax error.
+    /// </summary>
+    public class GraphQLParserException : Exception
+    {
+        /// <summary>
+        /// Error description.
+        /// </summary>
+        public string Description { get; private set; }
+
+        /// <summary>
+        /// The line number on which the symbol that caused the error is located.
+        /// </summary>
+        public int Line { get; private set; }
+
+        /// <summary>
+        /// The column number on which the symbol that caused the error is located.
+        /// </summary>
+        public int Column { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance with the specified parameters.
+        /// </summary>
+        public GraphQLParserException(string description, ROM source, int location)
+            : this(description, source, new Location(source, location))
+        {
+        }
+
+        private GraphQLParserException(string description, ReadOnlySpan<char> source, Location location)
+            : base(ComposeMessage(description, source, location))
+        {
+            Description = description;
+            Line = location.Line;
+            Column = location.Column;
+        }
+
+        private static string ComposeMessage(string description, ReadOnlySpan<char> source, Location location)
+        {
+            return $"Syntax Error GraphQL ({location.Line}:{location.Column}) {description}" +
+                "\n" + HighlightSourceAtLocation(source, location);
+        }
+
+        private static string HighlightSourceAtLocation(ReadOnlySpan<char> source, Location location)
+        {
+            int line = location.Line;
+            string prevLineNum = (line - 1).ToString();
+            string lineNum = line.ToString();
+            string nextLineNum = (line + 1).ToString();
+            int padLen = nextLineNum.Length;
+            string[] lines = source
+                .ToString() // TODO: heap allocation
+                .Split(new string[] { "\n" }, StringSplitOptions.None)
+                .Select(e => ReplaceWithUnicodeRepresentation(e))
+                .ToArray();
+
+            return
+                (line >= 2 ? LeftPad(padLen, prevLineNum) + ": " + lines[line - 2] + "\n" : string.Empty) +
+                LeftPad(padLen, lineNum) + ": " + lines[line - 1] + "\n" +
+                LeftPad(1 + padLen + location.Column, string.Empty) + "^" + "\n" +
+                (line < lines.Length ? LeftPad(padLen, nextLineNum) + ": " + lines[line] + "\n" : string.Empty);
+        }
+
+        private static string LeftPad(int length, string str)
+        {
+            string pad = string.Empty;
+
+            for (int i = 0; i < length - str.Length; ++i)
+                pad += " ";
+
+            return pad + str;
+        }
+
+        private static string ReplaceWithUnicodeRepresentation(string str)
+        {
+            if (!HasReplacementCharacter(str))
+                return str;
+
+            var buffer = new StringBuilder(str.Length);
+
+            foreach (char code in str)
+            {
+                if (IsReplacementCharacter(code))
+                {
+                    buffer.Append(GetUnicodeRepresentation(code));
+                }
+                else
+                {
+                    buffer.Append(code);
+                }
+            }
+
+            return buffer.ToString();
+        }
+
+        private static bool HasReplacementCharacter(string str)
+        {
+            foreach (char code in str)
+            {
+                if (IsReplacementCharacter(code))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsReplacementCharacter(char code) => code < 0x0020 && code != 0x0009 && code != 0x000A && code != 0x000D;
+
+        private static string GetUnicodeRepresentation(char code) => code switch
+        {
+            '\0' => "\\u0000",
+            _ => "\\u" + ((int)code).ToString("D4")
+        };
+    }
+}

--- a/src/GraphQLParser/Exceptions/GraphQLParserException.cs
+++ b/src/GraphQLParser/Exceptions/GraphQLParserException.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace GraphQLParser.Exceptions
 {
     /// <summary>
-    /// An exception representing a GraphQL document syntax error.
+    /// An exception representing a GraphQL document parsing error.
     /// </summary>
     public class GraphQLParserException : Exception
     {

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -145,6 +145,7 @@ namespace GraphQLParser
         private List<ASTNode> ParseDefinitionsIfNotEOF()
         {
             var result = new List<ASTNode>();
+            IncreaseDepth();
 
             if (_currentToken.Kind != TokenKind.EOF)
             {
@@ -155,6 +156,7 @@ namespace GraphQLParser
                 while (!Skip(TokenKind.EOF));
             }
 
+            DecreaseDepth();
             return result;
         }
 
@@ -826,11 +828,13 @@ namespace GraphQLParser
         private List<GraphQLObjectField> ParseObjectFields(bool isConstant)
         {
             var fields = new List<GraphQLObjectField>();
+            IncreaseDepth();
 
             Expect(TokenKind.BRACE_L);
             while (!Skip(TokenKind.BRACE_R))
                 fields.Add(ParseObjectField(isConstant));
 
+            DecreaseDepth();
             return fields;
         }
 

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -50,7 +50,7 @@ namespace GraphQLParser
 
         private void ThrowMaxDepthException()
         {
-            throw new GraphQLSyntaxErrorException("Maximum depth exceeded.", _source, _currentToken.Start);
+            throw new GraphQLMaxDepthExceededException(_source, _currentToken.Start);
         }
 
         private void DecreaseDepth()

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -17,7 +17,7 @@ namespace GraphQLParser
         private Token _currentToken;
         private Token _prevToken;
         private readonly GraphQLDocument _document;
-        private int _currentDepth = 0;
+        private int _currentDepth;
         private readonly int _maxDepth;
 
         public ParserContext(ROM source, ParserOptions options)
@@ -26,6 +26,7 @@ namespace GraphQLParser
             _unattachedComments = null;
             _source = source;
             _ignoreOptions = options.Ignore;
+            _currentDepth = 0;
             _maxDepth = options.MaxDepth ?? 64;
             // should create document beforehand to use RentedMemoryTracker while parsing comments
             _document = NodeHelper.CreateGraphQLDocument(options.Ignore);

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -42,8 +42,14 @@ namespace GraphQLParser
 
         private void IncreaseDepth()
         {
+            // Encourage compiler inlining of this method by moving exception to a separate method
             if (_currentDepth++ >= _maxDepth)
-                throw new GraphQLSyntaxErrorException("Maximum depth exceeded.", _source, _currentToken.Start);
+                ThrowMaxDepthException();
+        }
+
+        private void ThrowMaxDepthException()
+        {
+            throw new GraphQLSyntaxErrorException("Maximum depth exceeded.", _source, _currentToken.Start);
         }
 
         private void DecreaseDepth()

--- a/src/GraphQLParser/ParserOptions.cs
+++ b/src/GraphQLParser/ParserOptions.cs
@@ -10,5 +10,11 @@ namespace GraphQLParser
         /// By default, all comments are ignored.
         /// </summary>
         public IgnoreOptions Ignore { get; set; }
+
+        /// <summary>
+        /// Maximum recursion depth during parsing.
+        /// Defaults to 64 if not set.
+        /// </summary>
+        public int? MaxDepth { get; set; }
     }
 }

--- a/src/GraphQLParser/ParserOptions.cs
+++ b/src/GraphQLParser/ParserOptions.cs
@@ -14,6 +14,7 @@ namespace GraphQLParser
         /// <summary>
         /// Maximum allowed recursion depth during parsing.
         /// Defaults to 64 if not set.
+        /// Minimum value is 1.
         /// </summary>
         public int? MaxDepth { get; set; }
     }


### PR DESCRIPTION
An unlimited depth can result in a stack overflow exception when parsing long queries.