### PR TITLE
New AST nodes

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -58,6 +58,9 @@ namespace GraphQLParser.AST
         ArgumentsDefinition = 46,
         Arguments = 47,
         InputFieldsDefinition = 48,
+        VariablesDefinition = 49,
+        EnumValuesDefinition = 50,
+        FieldsDefinition = 51,
     }
     public class GraphQLAlias : GraphQLParser.AST.ASTNode
     {
@@ -125,19 +128,25 @@ namespace GraphQLParser.AST
         public GraphQLEnumTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLEnumValueDefinition>? Values { get; set; }
+        public GraphQLParser.AST.GraphQLEnumValuesDefinition? Values { get; set; }
     }
     public class GraphQLEnumTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLEnumTypeExtension() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLEnumValueDefinition>? Values { get; set; }
+        public GraphQLParser.AST.GraphQLEnumValuesDefinition? Values { get; set; }
     }
     public class GraphQLEnumValueDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLEnumValueDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+    }
+    public class GraphQLEnumValuesDefinition : GraphQLParser.AST.ASTNode
+    {
+        public GraphQLEnumValuesDefinition() { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLEnumValueDefinition> Items { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLField : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasArgumentsNode, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.INamedNode
@@ -157,6 +166,12 @@ namespace GraphQLParser.AST
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
+    }
+    public class GraphQLFieldsDefinition : GraphQLParser.AST.ASTNode
+    {
+        public GraphQLFieldsDefinition() { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFieldDefinition> Items { get; set; }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLFragmentDefinition : GraphQLParser.AST.GraphQLInlineFragment, GraphQLParser.AST.INamedNode
     {
@@ -207,19 +222,19 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
     }
-    public class GraphQLInterfaceTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasInterfacesNode
+    public class GraphQLInterfaceTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasFieldsDefinitionNode, GraphQLParser.AST.IHasInterfacesNode
     {
         public GraphQLInterfaceTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFieldDefinition>? Fields { get; set; }
+        public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
-    public class GraphQLInterfaceTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasInterfacesNode
+    public class GraphQLInterfaceTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasFieldsDefinitionNode, GraphQLParser.AST.IHasInterfacesNode
     {
         public GraphQLInterfaceTypeExtension() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFieldDefinition>? Fields { get; set; }
+        public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
@@ -277,19 +292,19 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.GraphQLValue? Value { get; set; }
     }
-    public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasInterfacesNode
+    public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasFieldsDefinitionNode, GraphQLParser.AST.IHasInterfacesNode
     {
         public GraphQLObjectTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFieldDefinition>? Fields { get; set; }
+        public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
-    public class GraphQLObjectTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasInterfacesNode
+    public class GraphQLObjectTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasFieldsDefinitionNode, GraphQLParser.AST.IHasInterfacesNode
     {
         public GraphQLObjectTypeExtension() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFieldDefinition>? Fields { get; set; }
+        public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
@@ -307,7 +322,7 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.OperationType Operation { get; set; }
         public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLVariableDefinition>? VariableDefinitions { get; set; }
+        public GraphQLParser.AST.GraphQLVariablesDefinition? Variables { get; set; }
     }
     public class GraphQLRootOperationTypeDefinition : GraphQLParser.AST.ASTNode
     {
@@ -403,6 +418,12 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
         public GraphQLParser.AST.GraphQLVariable? Variable { get; set; }
     }
+    public class GraphQLVariablesDefinition : GraphQLParser.AST.ASTNode
+    {
+        public GraphQLVariablesDefinition() { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLVariableDefinition> Items { get; set; }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+    }
     public interface IHasArgumentsDefinitionNode
     {
         GraphQLParser.AST.GraphQLArgumentsDefinition? Arguments { get; set; }
@@ -418,6 +439,10 @@ namespace GraphQLParser.AST
     public interface IHasDirectivesNode
     {
         System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+    }
+    public interface IHasFieldsDefinitionNode
+    {
+        GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
     }
     public interface IHasInterfacesNode
     {
@@ -555,8 +580,10 @@ namespace GraphQLParser.Visitors
         public virtual System.Threading.Tasks.ValueTask VisitEnumTypeExtension(GraphQLParser.AST.GraphQLEnumTypeExtension enumTypeExtension, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitEnumValue(GraphQLParser.AST.GraphQLScalarValue enumValue, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitEnumValueDefinition(GraphQLParser.AST.GraphQLEnumValueDefinition enumValueDefinition, TContext context) { }
+        public virtual System.Threading.Tasks.ValueTask VisitEnumValuesDefinition(GraphQLParser.AST.GraphQLEnumValuesDefinition enumValuesDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitField(GraphQLParser.AST.GraphQLField field, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitFieldDefinition(GraphQLParser.AST.GraphQLFieldDefinition fieldDefinition, TContext context) { }
+        public virtual System.Threading.Tasks.ValueTask VisitFieldsDefinition(GraphQLParser.AST.GraphQLFieldsDefinition fieldsDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitFloatValue(GraphQLParser.AST.GraphQLScalarValue floatValue, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitFragmentDefinition(GraphQLParser.AST.GraphQLFragmentDefinition fragmentDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitFragmentSpread(GraphQLParser.AST.GraphQLFragmentSpread fragmentSpread, TContext context) { }
@@ -590,6 +617,7 @@ namespace GraphQLParser.Visitors
         public virtual System.Threading.Tasks.ValueTask VisitUnionTypeExtension(GraphQLParser.AST.GraphQLUnionTypeExtension unionTypeExtension, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitVariable(GraphQLParser.AST.GraphQLVariable variable, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitVariableDefinition(GraphQLParser.AST.GraphQLVariableDefinition variableDefinition, TContext context) { }
+        public virtual System.Threading.Tasks.ValueTask VisitVariablesDefinition(GraphQLParser.AST.GraphQLVariablesDefinition variablesDefinition, TContext context) { }
     }
     public interface INodeVisitorContext
     {
@@ -612,8 +640,10 @@ namespace GraphQLParser.Visitors
         System.Threading.Tasks.ValueTask VisitEnumTypeExtension(GraphQLParser.AST.GraphQLEnumTypeExtension enumTypeExtension, TContext context);
         System.Threading.Tasks.ValueTask VisitEnumValue(GraphQLParser.AST.GraphQLScalarValue enumValue, TContext context);
         System.Threading.Tasks.ValueTask VisitEnumValueDefinition(GraphQLParser.AST.GraphQLEnumValueDefinition enumValueDefinition, TContext context);
+        System.Threading.Tasks.ValueTask VisitEnumValuesDefinition(GraphQLParser.AST.GraphQLEnumValuesDefinition enumValuesDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitField(GraphQLParser.AST.GraphQLField field, TContext context);
         System.Threading.Tasks.ValueTask VisitFieldDefinition(GraphQLParser.AST.GraphQLFieldDefinition fieldDefinition, TContext context);
+        System.Threading.Tasks.ValueTask VisitFieldsDefinition(GraphQLParser.AST.GraphQLFieldsDefinition fieldsDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitFloatValue(GraphQLParser.AST.GraphQLScalarValue floatValue, TContext context);
         System.Threading.Tasks.ValueTask VisitFragmentDefinition(GraphQLParser.AST.GraphQLFragmentDefinition fragmentDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitFragmentSpread(GraphQLParser.AST.GraphQLFragmentSpread fragmentSpread, TContext context);
@@ -647,6 +677,7 @@ namespace GraphQLParser.Visitors
         System.Threading.Tasks.ValueTask VisitUnionTypeExtension(GraphQLParser.AST.GraphQLUnionTypeExtension unionTypeExtension, TContext context);
         System.Threading.Tasks.ValueTask VisitVariable(GraphQLParser.AST.GraphQLVariable variable, TContext context);
         System.Threading.Tasks.ValueTask VisitVariableDefinition(GraphQLParser.AST.GraphQLVariableDefinition variableDefinition, TContext context);
+        System.Threading.Tasks.ValueTask VisitVariablesDefinition(GraphQLParser.AST.GraphQLVariablesDefinition variablesDefinition, TContext context);
     }
     public interface IWriteContext : GraphQLParser.Visitors.INodeVisitorContext
     {
@@ -672,8 +703,10 @@ namespace GraphQLParser.Visitors
         public override System.Threading.Tasks.ValueTask VisitEnumTypeExtension(GraphQLParser.AST.GraphQLEnumTypeExtension enumTypeExtension, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitEnumValue(GraphQLParser.AST.GraphQLScalarValue enumValue, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitEnumValueDefinition(GraphQLParser.AST.GraphQLEnumValueDefinition enumValueDefinition, TContext context) { }
+        public override System.Threading.Tasks.ValueTask VisitEnumValuesDefinition(GraphQLParser.AST.GraphQLEnumValuesDefinition enumValuesDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitField(GraphQLParser.AST.GraphQLField field, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitFieldDefinition(GraphQLParser.AST.GraphQLFieldDefinition fieldDefinition, TContext context) { }
+        public override System.Threading.Tasks.ValueTask VisitFieldsDefinition(GraphQLParser.AST.GraphQLFieldsDefinition fieldsDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitFloatValue(GraphQLParser.AST.GraphQLScalarValue floatValue, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitFragmentDefinition(GraphQLParser.AST.GraphQLFragmentDefinition fragmentDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitFragmentSpread(GraphQLParser.AST.GraphQLFragmentSpread fragmentSpread, TContext context) { }
@@ -707,6 +740,7 @@ namespace GraphQLParser.Visitors
         public override System.Threading.Tasks.ValueTask VisitUnionTypeExtension(GraphQLParser.AST.GraphQLUnionTypeExtension unionTypeExtension, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitVariable(GraphQLParser.AST.GraphQLVariable variable, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitVariableDefinition(GraphQLParser.AST.GraphQLVariableDefinition variableDefinition, TContext context) { }
+        public override System.Threading.Tasks.ValueTask VisitVariablesDefinition(GraphQLParser.AST.GraphQLVariablesDefinition variablesDefinition, TContext context) { }
     }
     public class StructureWriterOptions
     {

--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -56,6 +56,7 @@ namespace GraphQLParser.AST
         EnumTypeExtension = 44,
         InputObjectTypeExtension = 45,
         ArgumentsDefinition = 46,
+        Arguments = 47,
     }
     public class GraphQLAlias : GraphQLParser.AST.ASTNode
     {
@@ -70,10 +71,16 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.GraphQLValue? Value { get; set; }
     }
+    public class GraphQLArguments : GraphQLParser.AST.ASTNode
+    {
+        public GraphQLArguments() { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLArgument> Items { get; set; }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+    }
     public class GraphQLArgumentsDefinition : GraphQLParser.AST.ASTNode
     {
         public GraphQLArgumentsDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition> InputValueDefinitions { get; set; }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition> Items { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLComment : GraphQLParser.AST.ASTNode
@@ -91,7 +98,7 @@ namespace GraphQLParser.AST
     public class GraphQLDirective : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasArgumentsNode, GraphQLParser.AST.INamedNode
     {
         public GraphQLDirective() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLArgument>? Arguments { get; set; }
+        public GraphQLParser.AST.GraphQLArguments? Arguments { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
@@ -136,7 +143,7 @@ namespace GraphQLParser.AST
     {
         public GraphQLField() { }
         public GraphQLParser.AST.GraphQLAlias? Alias { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLArgument>? Arguments { get; set; }
+        public GraphQLParser.AST.GraphQLArguments? Arguments { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
@@ -395,7 +402,7 @@ namespace GraphQLParser.AST
     }
     public interface IHasArgumentsNode
     {
-        System.Collections.Generic.List<GraphQLParser.AST.GraphQLArgument>? Arguments { get; set; }
+        GraphQLParser.AST.GraphQLArguments? Arguments { get; set; }
     }
     public interface IHasDescriptionNode
     {
@@ -529,6 +536,7 @@ namespace GraphQLParser.Visitors
             where T : GraphQLParser.AST.ASTNode { }
         public virtual System.Threading.Tasks.ValueTask VisitAlias(GraphQLParser.AST.GraphQLAlias alias, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitArgument(GraphQLParser.AST.GraphQLArgument argument, TContext context) { }
+        public virtual System.Threading.Tasks.ValueTask VisitArguments(GraphQLParser.AST.GraphQLArguments arguments, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitArgumentsDefinition(GraphQLParser.AST.GraphQLArgumentsDefinition argumentsDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitBooleanValue(GraphQLParser.AST.GraphQLScalarValue booleanValue, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitComment(GraphQLParser.AST.GraphQLComment comment, TContext context) { }
@@ -584,6 +592,7 @@ namespace GraphQLParser.Visitors
     {
         System.Threading.Tasks.ValueTask VisitAlias(GraphQLParser.AST.GraphQLAlias alias, TContext context);
         System.Threading.Tasks.ValueTask VisitArgument(GraphQLParser.AST.GraphQLArgument argument, TContext context);
+        System.Threading.Tasks.ValueTask VisitArguments(GraphQLParser.AST.GraphQLArguments arguments, TContext context);
         System.Threading.Tasks.ValueTask VisitArgumentsDefinition(GraphQLParser.AST.GraphQLArgumentsDefinition argumentsDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitBooleanValue(GraphQLParser.AST.GraphQLScalarValue booleanValue, TContext context);
         System.Threading.Tasks.ValueTask VisitComment(GraphQLParser.AST.GraphQLComment comment, TContext context);
@@ -642,6 +651,7 @@ namespace GraphQLParser.Visitors
         public override System.Threading.Tasks.ValueTask Visit(GraphQLParser.AST.ASTNode? node, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitAlias(GraphQLParser.AST.GraphQLAlias alias, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitArgument(GraphQLParser.AST.GraphQLArgument argument, TContext context) { }
+        public override System.Threading.Tasks.ValueTask VisitArguments(GraphQLParser.AST.GraphQLArguments arguments, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitArgumentsDefinition(GraphQLParser.AST.GraphQLArgumentsDefinition argumentsDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitBooleanValue(GraphQLParser.AST.GraphQLScalarValue booleanValue, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitComment(GraphQLParser.AST.GraphQLComment comment, TContext context) { }

--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -57,6 +57,7 @@ namespace GraphQLParser.AST
         InputObjectTypeExtension = 45,
         ArgumentsDefinition = 46,
         Arguments = 47,
+        InputFieldsDefinition = 48,
     }
     public class GraphQLAlias : GraphQLParser.AST.ASTNode
     {
@@ -178,18 +179,24 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
         public GraphQLParser.AST.GraphQLTypeCondition? TypeCondition { get; set; }
     }
+    public class GraphQLInputFieldsDefinition : GraphQLParser.AST.ASTNode
+    {
+        public GraphQLInputFieldsDefinition() { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition> Items { get; set; }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+    }
     public class GraphQLInputObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInputObjectTypeDefinition() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition>? Fields { get; set; }
+        public GraphQLParser.AST.GraphQLInputFieldsDefinition? Fields { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLInputObjectTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInputObjectTypeExtension() { }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition>? Fields { get; set; }
+        public GraphQLParser.AST.GraphQLInputFieldsDefinition? Fields { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLInputValueDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
@@ -554,6 +561,7 @@ namespace GraphQLParser.Visitors
         public virtual System.Threading.Tasks.ValueTask VisitFragmentDefinition(GraphQLParser.AST.GraphQLFragmentDefinition fragmentDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitFragmentSpread(GraphQLParser.AST.GraphQLFragmentSpread fragmentSpread, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitInlineFragment(GraphQLParser.AST.GraphQLInlineFragment inlineFragment, TContext context) { }
+        public virtual System.Threading.Tasks.ValueTask VisitInputFieldsDefinition(GraphQLParser.AST.GraphQLInputFieldsDefinition inputFieldsDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitInputObjectTypeDefinition(GraphQLParser.AST.GraphQLInputObjectTypeDefinition inputObjectTypeDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitInputObjectTypeExtension(GraphQLParser.AST.GraphQLInputObjectTypeExtension inputObjectTypeExtension, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitInputValueDefinition(GraphQLParser.AST.GraphQLInputValueDefinition inputValueDefinition, TContext context) { }
@@ -610,6 +618,7 @@ namespace GraphQLParser.Visitors
         System.Threading.Tasks.ValueTask VisitFragmentDefinition(GraphQLParser.AST.GraphQLFragmentDefinition fragmentDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitFragmentSpread(GraphQLParser.AST.GraphQLFragmentSpread fragmentSpread, TContext context);
         System.Threading.Tasks.ValueTask VisitInlineFragment(GraphQLParser.AST.GraphQLInlineFragment inlineFragment, TContext context);
+        System.Threading.Tasks.ValueTask VisitInputFieldsDefinition(GraphQLParser.AST.GraphQLInputFieldsDefinition inputFieldsDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitInputObjectTypeDefinition(GraphQLParser.AST.GraphQLInputObjectTypeDefinition inputObjectTypeDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitInputObjectTypeExtension(GraphQLParser.AST.GraphQLInputObjectTypeExtension inputObjectTypeExtension, TContext context);
         System.Threading.Tasks.ValueTask VisitInputValueDefinition(GraphQLParser.AST.GraphQLInputValueDefinition inputValueDefinition, TContext context);
@@ -669,6 +678,7 @@ namespace GraphQLParser.Visitors
         public override System.Threading.Tasks.ValueTask VisitFragmentDefinition(GraphQLParser.AST.GraphQLFragmentDefinition fragmentDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitFragmentSpread(GraphQLParser.AST.GraphQLFragmentSpread fragmentSpread, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitInlineFragment(GraphQLParser.AST.GraphQLInlineFragment inlineFragment, TContext context) { }
+        public override System.Threading.Tasks.ValueTask VisitInputFieldsDefinition(GraphQLParser.AST.GraphQLInputFieldsDefinition inputFieldsDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitInputObjectTypeDefinition(GraphQLParser.AST.GraphQLInputObjectTypeDefinition inputObjectTypeDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitInputObjectTypeExtension(GraphQLParser.AST.GraphQLInputObjectTypeExtension inputObjectTypeExtension, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitInputValueDefinition(GraphQLParser.AST.GraphQLInputValueDefinition inputValueDefinition, TContext context) { }

--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -55,6 +55,7 @@ namespace GraphQLParser.AST
         UnionTypeExtension = 43,
         EnumTypeExtension = 44,
         InputObjectTypeExtension = 45,
+        ArgumentsDefinition = 46,
     }
     public class GraphQLAlias : GraphQLParser.AST.ASTNode
     {
@@ -68,6 +69,12 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.GraphQLValue? Value { get; set; }
+    }
+    public class GraphQLArgumentsDefinition : GraphQLParser.AST.ASTNode
+    {
+        public GraphQLArgumentsDefinition() { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition> InputValueDefinitions { get; set; }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLComment : GraphQLParser.AST.ASTNode
     {
@@ -88,10 +95,10 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
-    public class GraphQLDirectiveDefinition : GraphQLParser.AST.GraphQLTypeDefinition
+    public class GraphQLDirectiveDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasArgumentsDefinitionNode
     {
         public GraphQLDirectiveDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition>? Arguments { get; set; }
+        public GraphQLParser.AST.GraphQLArgumentsDefinition? Arguments { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLName>? Locations { get; set; }
         public bool Repeatable { get; set; }
@@ -135,10 +142,10 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
     }
-    public class GraphQLFieldDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
+    public class GraphQLFieldDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasArgumentsDefinitionNode, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLFieldDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition>? Arguments { get; set; }
+        public GraphQLParser.AST.GraphQLArgumentsDefinition? Arguments { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
@@ -382,6 +389,10 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
         public GraphQLParser.AST.GraphQLVariable? Variable { get; set; }
     }
+    public interface IHasArgumentsDefinitionNode
+    {
+        GraphQLParser.AST.GraphQLArgumentsDefinition? Arguments { get; set; }
+    }
     public interface IHasArgumentsNode
     {
         System.Collections.Generic.List<GraphQLParser.AST.GraphQLArgument>? Arguments { get; set; }
@@ -518,6 +529,7 @@ namespace GraphQLParser.Visitors
             where T : GraphQLParser.AST.ASTNode { }
         public virtual System.Threading.Tasks.ValueTask VisitAlias(GraphQLParser.AST.GraphQLAlias alias, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitArgument(GraphQLParser.AST.GraphQLArgument argument, TContext context) { }
+        public virtual System.Threading.Tasks.ValueTask VisitArgumentsDefinition(GraphQLParser.AST.GraphQLArgumentsDefinition argumentsDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitBooleanValue(GraphQLParser.AST.GraphQLScalarValue booleanValue, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitComment(GraphQLParser.AST.GraphQLComment comment, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitDescription(GraphQLParser.AST.GraphQLDescription description, TContext context) { }
@@ -572,6 +584,7 @@ namespace GraphQLParser.Visitors
     {
         System.Threading.Tasks.ValueTask VisitAlias(GraphQLParser.AST.GraphQLAlias alias, TContext context);
         System.Threading.Tasks.ValueTask VisitArgument(GraphQLParser.AST.GraphQLArgument argument, TContext context);
+        System.Threading.Tasks.ValueTask VisitArgumentsDefinition(GraphQLParser.AST.GraphQLArgumentsDefinition argumentsDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitBooleanValue(GraphQLParser.AST.GraphQLScalarValue booleanValue, TContext context);
         System.Threading.Tasks.ValueTask VisitComment(GraphQLParser.AST.GraphQLComment comment, TContext context);
         System.Threading.Tasks.ValueTask VisitDescription(GraphQLParser.AST.GraphQLDescription description, TContext context);
@@ -629,6 +642,7 @@ namespace GraphQLParser.Visitors
         public override System.Threading.Tasks.ValueTask Visit(GraphQLParser.AST.ASTNode? node, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitAlias(GraphQLParser.AST.GraphQLAlias alias, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitArgument(GraphQLParser.AST.GraphQLArgument argument, TContext context) { }
+        public override System.Threading.Tasks.ValueTask VisitArgumentsDefinition(GraphQLParser.AST.GraphQLArgumentsDefinition argumentsDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitBooleanValue(GraphQLParser.AST.GraphQLScalarValue booleanValue, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitComment(GraphQLParser.AST.GraphQLComment comment, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitDescription(GraphQLParser.AST.GraphQLDescription description, TContext context) { }

--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -62,6 +62,7 @@ namespace GraphQLParser.AST
         EnumValuesDefinition = 50,
         FieldsDefinition = 51,
         Directives = 52,
+        ImplementsInterfaces = 53,
     }
     public class GraphQLAlias : GraphQLParser.AST.ASTNode
     {
@@ -193,6 +194,12 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
+    public class GraphQLImplementsInterfaces : GraphQLParser.AST.ASTNode
+    {
+        public GraphQLImplementsInterfaces() { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType> Items { get; set; }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+    }
     public class GraphQLInlineFragment : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInlineFragment() { }
@@ -234,7 +241,7 @@ namespace GraphQLParser.AST
         public GraphQLInterfaceTypeDefinition() { }
         public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
+        public GraphQLParser.AST.GraphQLImplementsInterfaces? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLInterfaceTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasFieldsDefinitionNode, GraphQLParser.AST.IHasInterfacesNode
@@ -242,7 +249,7 @@ namespace GraphQLParser.AST
         public GraphQLInterfaceTypeExtension() { }
         public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
+        public GraphQLParser.AST.GraphQLImplementsInterfaces? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLListType : GraphQLParser.AST.GraphQLType
@@ -304,7 +311,7 @@ namespace GraphQLParser.AST
         public GraphQLObjectTypeDefinition() { }
         public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
+        public GraphQLParser.AST.GraphQLImplementsInterfaces? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLObjectTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasFieldsDefinitionNode, GraphQLParser.AST.IHasInterfacesNode
@@ -312,7 +319,7 @@ namespace GraphQLParser.AST
         public GraphQLObjectTypeExtension() { }
         public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
+        public GraphQLParser.AST.GraphQLImplementsInterfaces? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLObjectValue : GraphQLParser.AST.GraphQLValue
@@ -453,7 +460,7 @@ namespace GraphQLParser.AST
     }
     public interface IHasInterfacesNode
     {
-        System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
+        GraphQLParser.AST.GraphQLImplementsInterfaces? Interfaces { get; set; }
     }
     public interface INamedNode
     {
@@ -595,6 +602,7 @@ namespace GraphQLParser.Visitors
         public virtual System.Threading.Tasks.ValueTask VisitFloatValue(GraphQLParser.AST.GraphQLScalarValue floatValue, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitFragmentDefinition(GraphQLParser.AST.GraphQLFragmentDefinition fragmentDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitFragmentSpread(GraphQLParser.AST.GraphQLFragmentSpread fragmentSpread, TContext context) { }
+        public virtual System.Threading.Tasks.ValueTask VisitImplementsInterfaces(GraphQLParser.AST.GraphQLImplementsInterfaces implementsInterfaces, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitInlineFragment(GraphQLParser.AST.GraphQLInlineFragment inlineFragment, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitInputFieldsDefinition(GraphQLParser.AST.GraphQLInputFieldsDefinition inputFieldsDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitInputObjectTypeDefinition(GraphQLParser.AST.GraphQLInputObjectTypeDefinition inputObjectTypeDefinition, TContext context) { }
@@ -656,6 +664,7 @@ namespace GraphQLParser.Visitors
         System.Threading.Tasks.ValueTask VisitFloatValue(GraphQLParser.AST.GraphQLScalarValue floatValue, TContext context);
         System.Threading.Tasks.ValueTask VisitFragmentDefinition(GraphQLParser.AST.GraphQLFragmentDefinition fragmentDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitFragmentSpread(GraphQLParser.AST.GraphQLFragmentSpread fragmentSpread, TContext context);
+        System.Threading.Tasks.ValueTask VisitImplementsInterfaces(GraphQLParser.AST.GraphQLImplementsInterfaces implementsInterfaces, TContext context);
         System.Threading.Tasks.ValueTask VisitInlineFragment(GraphQLParser.AST.GraphQLInlineFragment inlineFragment, TContext context);
         System.Threading.Tasks.ValueTask VisitInputFieldsDefinition(GraphQLParser.AST.GraphQLInputFieldsDefinition inputFieldsDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitInputObjectTypeDefinition(GraphQLParser.AST.GraphQLInputObjectTypeDefinition inputObjectTypeDefinition, TContext context);
@@ -720,6 +729,7 @@ namespace GraphQLParser.Visitors
         public override System.Threading.Tasks.ValueTask VisitFloatValue(GraphQLParser.AST.GraphQLScalarValue floatValue, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitFragmentDefinition(GraphQLParser.AST.GraphQLFragmentDefinition fragmentDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitFragmentSpread(GraphQLParser.AST.GraphQLFragmentSpread fragmentSpread, TContext context) { }
+        public override System.Threading.Tasks.ValueTask VisitImplementsInterfaces(GraphQLParser.AST.GraphQLImplementsInterfaces implementsInterfaces, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitInlineFragment(GraphQLParser.AST.GraphQLInlineFragment inlineFragment, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitInputFieldsDefinition(GraphQLParser.AST.GraphQLInputFieldsDefinition inputFieldsDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitInputObjectTypeDefinition(GraphQLParser.AST.GraphQLInputObjectTypeDefinition inputObjectTypeDefinition, TContext context) { }

--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -1,5 +1,13 @@
 namespace GraphQLParser.AST
 {
+    public abstract class ASTListNode<TNode> : GraphQLParser.AST.ASTNode, System.Collections.Generic.IEnumerable<TNode>, System.Collections.IEnumerable
+    {
+        protected ASTListNode() { }
+        public int Count { get; }
+        public TNode this[int index] { get; }
+        public System.Collections.Generic.List<TNode> Items { get; set; }
+        public System.Collections.Generic.IEnumerator<TNode> GetEnumerator() { }
+    }
     public abstract class ASTNode
     {
         protected ASTNode() { }
@@ -77,16 +85,14 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.GraphQLValue? Value { get; set; }
     }
-    public class GraphQLArguments : GraphQLParser.AST.ASTNode
+    public class GraphQLArguments : GraphQLParser.AST.ASTListNode<GraphQLParser.AST.GraphQLArgument>
     {
         public GraphQLArguments() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLArgument> Items { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
-    public class GraphQLArgumentsDefinition : GraphQLParser.AST.ASTNode
+    public class GraphQLArgumentsDefinition : GraphQLParser.AST.ASTListNode<GraphQLParser.AST.GraphQLInputValueDefinition>
     {
         public GraphQLArgumentsDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition> Items { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLComment : GraphQLParser.AST.ASTNode
@@ -116,10 +122,9 @@ namespace GraphQLParser.AST
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLName>? Locations { get; set; }
         public bool Repeatable { get; set; }
     }
-    public class GraphQLDirectives : GraphQLParser.AST.ASTNode
+    public class GraphQLDirectives : GraphQLParser.AST.ASTListNode<GraphQLParser.AST.GraphQLDirective>
     {
         public GraphQLDirectives() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective> Items { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLDocument : GraphQLParser.AST.ASTNode, System.IDisposable
@@ -151,10 +156,9 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
-    public class GraphQLEnumValuesDefinition : GraphQLParser.AST.ASTNode
+    public class GraphQLEnumValuesDefinition : GraphQLParser.AST.ASTListNode<GraphQLParser.AST.GraphQLEnumValueDefinition>
     {
         public GraphQLEnumValuesDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLEnumValueDefinition> Items { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLField : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasArgumentsNode, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.INamedNode
@@ -175,10 +179,9 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
     }
-    public class GraphQLFieldsDefinition : GraphQLParser.AST.ASTNode
+    public class GraphQLFieldsDefinition : GraphQLParser.AST.ASTListNode<GraphQLParser.AST.GraphQLFieldDefinition>
     {
         public GraphQLFieldsDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLFieldDefinition> Items { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLFragmentDefinition : GraphQLParser.AST.GraphQLInlineFragment, GraphQLParser.AST.INamedNode
@@ -194,10 +197,9 @@ namespace GraphQLParser.AST
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
-    public class GraphQLImplementsInterfaces : GraphQLParser.AST.ASTNode
+    public class GraphQLImplementsInterfaces : GraphQLParser.AST.ASTListNode<GraphQLParser.AST.GraphQLNamedType>
     {
         public GraphQLImplementsInterfaces() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType> Items { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLInlineFragment : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode
@@ -208,10 +210,9 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
         public GraphQLParser.AST.GraphQLTypeCondition? TypeCondition { get; set; }
     }
-    public class GraphQLInputFieldsDefinition : GraphQLParser.AST.ASTNode
+    public class GraphQLInputFieldsDefinition : GraphQLParser.AST.ASTListNode<GraphQLParser.AST.GraphQLInputValueDefinition>
     {
         public GraphQLInputFieldsDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition> Items { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLInputObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
@@ -432,10 +433,9 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
         public GraphQLParser.AST.GraphQLVariable? Variable { get; set; }
     }
-    public class GraphQLVariablesDefinition : GraphQLParser.AST.ASTNode
+    public class GraphQLVariablesDefinition : GraphQLParser.AST.ASTListNode<GraphQLParser.AST.GraphQLVariableDefinition>
     {
         public GraphQLVariablesDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLVariableDefinition> Items { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public interface IHasArgumentsDefinitionNode

--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -61,6 +61,7 @@ namespace GraphQLParser.AST
         VariablesDefinition = 49,
         EnumValuesDefinition = 50,
         FieldsDefinition = 51,
+        Directives = 52,
     }
     public class GraphQLAlias : GraphQLParser.AST.ASTNode
     {
@@ -114,6 +115,12 @@ namespace GraphQLParser.AST
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLName>? Locations { get; set; }
         public bool Repeatable { get; set; }
     }
+    public class GraphQLDirectives : GraphQLParser.AST.ASTNode
+    {
+        public GraphQLDirectives() { }
+        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective> Items { get; set; }
+        public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+    }
     public class GraphQLDocument : GraphQLParser.AST.ASTNode, System.IDisposable
     {
         public GraphQLDocument() { }
@@ -126,21 +133,21 @@ namespace GraphQLParser.AST
     public class GraphQLEnumTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLEnumTypeDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLEnumValuesDefinition? Values { get; set; }
     }
     public class GraphQLEnumTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLEnumTypeExtension() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLEnumValuesDefinition? Values { get; set; }
     }
     public class GraphQLEnumValueDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLEnumValueDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLEnumValuesDefinition : GraphQLParser.AST.ASTNode
@@ -154,7 +161,7 @@ namespace GraphQLParser.AST
         public GraphQLField() { }
         public GraphQLParser.AST.GraphQLAlias? Alias { get; set; }
         public GraphQLParser.AST.GraphQLArguments? Arguments { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
@@ -163,7 +170,7 @@ namespace GraphQLParser.AST
     {
         public GraphQLFieldDefinition() { }
         public GraphQLParser.AST.GraphQLArgumentsDefinition? Arguments { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
     }
@@ -182,14 +189,14 @@ namespace GraphQLParser.AST
     public class GraphQLFragmentSpread : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.INamedNode
     {
         public GraphQLFragmentSpread() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
     }
     public class GraphQLInlineFragment : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInlineFragment() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLSelectionSet? SelectionSet { get; set; }
         public GraphQLParser.AST.GraphQLTypeCondition? TypeCondition { get; set; }
@@ -203,14 +210,14 @@ namespace GraphQLParser.AST
     public class GraphQLInputObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInputObjectTypeDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public GraphQLParser.AST.GraphQLInputFieldsDefinition? Fields { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLInputObjectTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLInputObjectTypeExtension() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public GraphQLParser.AST.GraphQLInputFieldsDefinition? Fields { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
@@ -218,14 +225,14 @@ namespace GraphQLParser.AST
     {
         public GraphQLInputValueDefinition() { }
         public GraphQLParser.AST.GraphQLValue? DefaultValue { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
     }
     public class GraphQLInterfaceTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasFieldsDefinitionNode, GraphQLParser.AST.IHasInterfacesNode
     {
         public GraphQLInterfaceTypeDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
@@ -233,7 +240,7 @@ namespace GraphQLParser.AST
     public class GraphQLInterfaceTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasFieldsDefinitionNode, GraphQLParser.AST.IHasInterfacesNode
     {
         public GraphQLInterfaceTypeExtension() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
@@ -295,7 +302,7 @@ namespace GraphQLParser.AST
     public class GraphQLObjectTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasFieldsDefinitionNode, GraphQLParser.AST.IHasInterfacesNode
     {
         public GraphQLObjectTypeDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
@@ -303,7 +310,7 @@ namespace GraphQLParser.AST
     public class GraphQLObjectTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.IHasFieldsDefinitionNode, GraphQLParser.AST.IHasInterfacesNode
     {
         public GraphQLObjectTypeExtension() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public GraphQLParser.AST.GraphQLFieldsDefinition? Fields { get; set; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Interfaces { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
@@ -317,7 +324,7 @@ namespace GraphQLParser.AST
     public class GraphQLOperationDefinition : GraphQLParser.AST.ASTNode, GraphQLParser.AST.IHasDirectivesNode, GraphQLParser.AST.INamedNode
     {
         public GraphQLOperationDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLName? Name { get; set; }
         public GraphQLParser.AST.OperationType Operation { get; set; }
@@ -334,13 +341,13 @@ namespace GraphQLParser.AST
     public class GraphQLScalarTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLScalarTypeDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLScalarTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLScalarTypeExtension() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
     }
     public class GraphQLScalarValue : GraphQLParser.AST.GraphQLValue
@@ -354,7 +361,7 @@ namespace GraphQLParser.AST
     {
         public GraphQLSchemaDefinition() { }
         public GraphQLParser.AST.GraphQLDescription? Description { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLRootOperationTypeDefinition>? OperationTypes { get; set; }
     }
@@ -388,14 +395,14 @@ namespace GraphQLParser.AST
     public class GraphQLUnionTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLUnionTypeDefinition() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Types { get; set; }
     }
     public class GraphQLUnionTypeExtension : GraphQLParser.AST.GraphQLTypeExtension, GraphQLParser.AST.IHasDirectivesNode
     {
         public GraphQLUnionTypeExtension() { }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public System.Collections.Generic.List<GraphQLParser.AST.GraphQLNamedType>? Types { get; set; }
     }
@@ -413,7 +420,7 @@ namespace GraphQLParser.AST
     {
         public GraphQLVariableDefinition() { }
         public GraphQLParser.AST.GraphQLValue? DefaultValue { get; set; }
-        public System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.AST.GraphQLType? Type { get; set; }
         public GraphQLParser.AST.GraphQLVariable? Variable { get; set; }
@@ -438,7 +445,7 @@ namespace GraphQLParser.AST
     }
     public interface IHasDirectivesNode
     {
-        System.Collections.Generic.List<GraphQLParser.AST.GraphQLDirective>? Directives { get; set; }
+        GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }
     }
     public interface IHasFieldsDefinitionNode
     {
@@ -575,6 +582,7 @@ namespace GraphQLParser.Visitors
         public virtual System.Threading.Tasks.ValueTask VisitDescription(GraphQLParser.AST.GraphQLDescription description, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitDirective(GraphQLParser.AST.GraphQLDirective directive, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitDirectiveDefinition(GraphQLParser.AST.GraphQLDirectiveDefinition directiveDefinition, TContext context) { }
+        public virtual System.Threading.Tasks.ValueTask VisitDirectives(GraphQLParser.AST.GraphQLDirectives directives, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitDocument(GraphQLParser.AST.GraphQLDocument document, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitEnumTypeDefinition(GraphQLParser.AST.GraphQLEnumTypeDefinition enumTypeDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitEnumTypeExtension(GraphQLParser.AST.GraphQLEnumTypeExtension enumTypeExtension, TContext context) { }
@@ -635,6 +643,7 @@ namespace GraphQLParser.Visitors
         System.Threading.Tasks.ValueTask VisitDescription(GraphQLParser.AST.GraphQLDescription description, TContext context);
         System.Threading.Tasks.ValueTask VisitDirective(GraphQLParser.AST.GraphQLDirective directive, TContext context);
         System.Threading.Tasks.ValueTask VisitDirectiveDefinition(GraphQLParser.AST.GraphQLDirectiveDefinition directiveDefinition, TContext context);
+        System.Threading.Tasks.ValueTask VisitDirectives(GraphQLParser.AST.GraphQLDirectives directives, TContext context);
         System.Threading.Tasks.ValueTask VisitDocument(GraphQLParser.AST.GraphQLDocument document, TContext context);
         System.Threading.Tasks.ValueTask VisitEnumTypeDefinition(GraphQLParser.AST.GraphQLEnumTypeDefinition enumTypeDefinition, TContext context);
         System.Threading.Tasks.ValueTask VisitEnumTypeExtension(GraphQLParser.AST.GraphQLEnumTypeExtension enumTypeExtension, TContext context);
@@ -698,6 +707,7 @@ namespace GraphQLParser.Visitors
         public override System.Threading.Tasks.ValueTask VisitDescription(GraphQLParser.AST.GraphQLDescription description, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitDirective(GraphQLParser.AST.GraphQLDirective directive, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitDirectiveDefinition(GraphQLParser.AST.GraphQLDirectiveDefinition directiveDefinition, TContext context) { }
+        public override System.Threading.Tasks.ValueTask VisitDirectives(GraphQLParser.AST.GraphQLDirectives directives, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitDocument(GraphQLParser.AST.GraphQLDocument document, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitEnumTypeDefinition(GraphQLParser.AST.GraphQLEnumTypeDefinition enumTypeDefinition, TContext context) { }
         public override System.Threading.Tasks.ValueTask VisitEnumTypeExtension(GraphQLParser.AST.GraphQLEnumTypeExtension enumTypeExtension, TContext context) { }

--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -1,6 +1,6 @@
 namespace GraphQLParser.AST
 {
-    public abstract class ASTListNode<TNode> : GraphQLParser.AST.ASTNode, System.Collections.Generic.IEnumerable<TNode>, System.Collections.IEnumerable
+    public abstract class ASTListNode<TNode> : GraphQLParser.AST.ASTNode, System.Collections.Generic.IEnumerable<TNode>, System.Collections.Generic.IReadOnlyCollection<TNode>, System.Collections.Generic.IReadOnlyList<TNode>, System.Collections.IEnumerable
     {
         protected ASTListNode() { }
         public int Count { get; }

--- a/src/GraphQLParser.Tests/Issue2478_GraphQL_NET.cs
+++ b/src/GraphQLParser.Tests/Issue2478_GraphQL_NET.cs
@@ -36,7 +36,7 @@ namespace GraphQLParser.Tests
             using var document = query.Parse(new ParserOptions { Ignore = options });
             document.Definitions.Count.ShouldBe(4);
             var def = document.Definitions.Last() as GraphQLObjectTypeDefinition;
-            def.Interfaces.Count.ShouldBe(2);
+            def.Interfaces.Items.Count.ShouldBe(2);
         }
     }
 }

--- a/src/GraphQLParser.Tests/Issue2478_GraphQL_NET.cs
+++ b/src/GraphQLParser.Tests/Issue2478_GraphQL_NET.cs
@@ -36,7 +36,7 @@ namespace GraphQLParser.Tests
             using var document = query.Parse(new ParserOptions { Ignore = options });
             document.Definitions.Count.ShouldBe(4);
             var def = document.Definitions.Last() as GraphQLObjectTypeDefinition;
-            def.Interfaces.Items.Count.ShouldBe(2);
+            def.Interfaces.Count.ShouldBe(2);
         }
     }
 }

--- a/src/GraphQLParser.Tests/Issue82.cs
+++ b/src/GraphQLParser.Tests/Issue82.cs
@@ -28,9 +28,9 @@ namespace GraphQLParser.Tests
             def.VariableDefinitions[0].Variable.Name.Value.ShouldBe("username");
 
             var selection = def.SelectionSet.Selections[0].ShouldBeAssignableTo<GraphQLField>();
-            selection.Arguments.Count.ShouldBe(2);
-            selection.Arguments[0].Value.ShouldBeAssignableTo<GraphQLVariable>().Name.Value.ShouldBe("username");
-            selection.Arguments[1].Value.ShouldBeAssignableTo<GraphQLScalarValue>().Value.ShouldBe("Pete");
+            selection.Arguments.Items.Count.ShouldBe(2);
+            selection.Arguments.Items[0].Value.ShouldBeAssignableTo<GraphQLVariable>().Name.Value.ShouldBe("username");
+            selection.Arguments.Items[1].Value.ShouldBeAssignableTo<GraphQLScalarValue>().Value.ShouldBe("Pete");
         }
     }
 }

--- a/src/GraphQLParser.Tests/Issue82.cs
+++ b/src/GraphQLParser.Tests/Issue82.cs
@@ -23,14 +23,14 @@ namespace GraphQLParser.Tests
             using var document = _query.Parse(new ParserOptions { Ignore = options });
 
             var def = document.Definitions[0] as GraphQLOperationDefinition;
-            def.Variables.Items.Count.ShouldBe(1);
-            def.Variables.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            def.Variables.Items[0].Variable.Name.Value.ShouldBe("username");
+            def.Variables.Count.ShouldBe(1);
+            def.Variables[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            def.Variables[0].Variable.Name.Value.ShouldBe("username");
 
             var selection = def.SelectionSet.Selections[0].ShouldBeAssignableTo<GraphQLField>();
-            selection.Arguments.Items.Count.ShouldBe(2);
-            selection.Arguments.Items[0].Value.ShouldBeAssignableTo<GraphQLVariable>().Name.Value.ShouldBe("username");
-            selection.Arguments.Items[1].Value.ShouldBeAssignableTo<GraphQLScalarValue>().Value.ShouldBe("Pete");
+            selection.Arguments.Count.ShouldBe(2);
+            selection.Arguments[0].Value.ShouldBeAssignableTo<GraphQLVariable>().Name.Value.ShouldBe("username");
+            selection.Arguments[1].Value.ShouldBeAssignableTo<GraphQLScalarValue>().Value.ShouldBe("Pete");
         }
     }
 }

--- a/src/GraphQLParser.Tests/Issue82.cs
+++ b/src/GraphQLParser.Tests/Issue82.cs
@@ -23,9 +23,9 @@ namespace GraphQLParser.Tests
             using var document = _query.Parse(new ParserOptions { Ignore = options });
 
             var def = document.Definitions[0] as GraphQLOperationDefinition;
-            def.VariableDefinitions.Count.ShouldBe(1);
-            def.VariableDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            def.VariableDefinitions[0].Variable.Name.Value.ShouldBe("username");
+            def.Variables.Items.Count.ShouldBe(1);
+            def.Variables.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            def.Variables.Items[0].Variable.Name.Value.ShouldBe("username");
 
             var selection = def.SelectionSet.Selections[0].ShouldBeAssignableTo<GraphQLField>();
             selection.Arguments.Items.Count.ShouldBe(2);

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -104,33 +104,33 @@ namespace GraphQLParser.Tests
             def.SelectionSet.Selections.Count.ShouldBe(1);
             var field = def.SelectionSet.Selections.First() as GraphQLField;
             field.SelectionSet.Selections.Count.ShouldBe(1);
-            field.Arguments.Count.ShouldBe(9);
+            field.Arguments.Items.Count.ShouldBe(9);
 
-            var boolValue = field.Arguments[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var boolValue = field.Arguments.Items[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             boolValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for bool");
 
-            var nullValue = field.Arguments[1].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var nullValue = field.Arguments.Items[1].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             nullValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for null");
 
-            var enumValue = field.Arguments[2].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var enumValue = field.Arguments.Items[2].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             enumValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for enum");
 
-            var listValue = field.Arguments[3].Value.ShouldBeAssignableTo<GraphQLListValue>();
+            var listValue = field.Arguments.Items[3].Value.ShouldBeAssignableTo<GraphQLListValue>();
             listValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for list");
 
-            var objValue = field.Arguments[4].Value.ShouldBeAssignableTo<GraphQLObjectValue>();
+            var objValue = field.Arguments.Items[4].Value.ShouldBeAssignableTo<GraphQLObjectValue>();
             objValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for object");
 
-            var intValue = field.Arguments[5].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var intValue = field.Arguments.Items[5].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             intValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for int");
 
-            var floatValue = field.Arguments[6].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var floatValue = field.Arguments.Items[6].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             floatValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for float");
 
-            var stringValue = field.Arguments[7].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var stringValue = field.Arguments.Items[7].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             stringValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for string");
 
-            var varValue = field.Arguments[8].Value.ShouldBeAssignableTo<GraphQLVariable>();
+            var varValue = field.Arguments.Items[8].Value.ShouldBeAssignableTo<GraphQLVariable>();
             varValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for variable");
         }
 
@@ -585,7 +585,7 @@ scalar JSON
                 def.VariableDefinitions[0].Directives.Count.ShouldBe(2);
                 def.VariableDefinitions[0].Directives[0].Name.Value.ShouldBe("a");
                 def.VariableDefinitions[0].Directives[1].Name.Value.ShouldBe("b");
-                def.VariableDefinitions[0].Directives[1].Arguments.Count.ShouldBe(2);
+                def.VariableDefinitions[0].Directives[1].Arguments.Items.Count.ShouldBe(2);
             }
         }
 
@@ -688,9 +688,9 @@ FIELD_DEFINITION
             var def = document.Definitions[0].ShouldBeAssignableTo<GraphQLScalarTypeDefinition>();
             def.Directives.Count.ShouldBe(1);
             def.Directives[0].Name.Value.ShouldBe("specifiedBy");
-            def.Directives[0].Arguments.Count.ShouldBe(1);
-            def.Directives[0].Arguments[0].Name.Value.ShouldBe("url");
-            var value = def.Directives[0].Arguments[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            def.Directives[0].Arguments.Items.Count.ShouldBe(1);
+            def.Directives[0].Arguments.Items[0].Name.Value.ShouldBe("url");
+            var value = def.Directives[0].Arguments.Items[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             value.Value.ShouldBe("https://tools.ietf.org/html/rfc4122");
         }
 
@@ -939,10 +939,10 @@ directive @TestDirective (
             objectDef.Fields[1].Name.Value.ShouldBe("test");
             objectDef.Fields[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             objectDef.Fields[1].Description.Value.ShouldBe("Test");
-            objectDef.Fields[1].Arguments.InputValueDefinitions.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Arguments.Items.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
@@ -979,10 +979,10 @@ directive @TestDirective (
             var directiveDef = defs.Single(x => x is GraphQLDirectiveDefinition) as GraphQLDirectiveDefinition;
             directiveDef.Name.Value.ShouldBe("TestDirective");
             directiveDef.Description.Value.ShouldBe("Test directive");
-            directiveDef.Arguments.InputValueDefinitions.Count.ShouldBe(1);
-            directiveDef.Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.Items.Count.ShouldBe(1);
+            directiveDef.Arguments.Items[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments.Items[0].Description.Value.ShouldBe("Example");
         }
 
         [Theory]
@@ -1117,12 +1117,12 @@ directive @TestDirective (
             objectDef.Fields[1].Description.Value.ShouldBe("Test");
             if (parseComments)
                 objectDef.Fields[1].Comment.Text.ShouldBe(" comment 8");
-            objectDef.Fields[1].Arguments.InputValueDefinitions.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Arguments.Items.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields[1].Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 10");
+                objectDef.Fields[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 10");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
@@ -1177,12 +1177,12 @@ directive @TestDirective (
             directiveDef.Description.Value.ShouldBe("Test directive");
             if (parseComments)
                 directiveDef.Comment.Text.ShouldBe(" comment 28");
-            directiveDef.Arguments.InputValueDefinitions.Count.ShouldBe(1);
-            directiveDef.Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.Items.Count.ShouldBe(1);
+            directiveDef.Arguments.Items[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments.Items[0].Description.Value.ShouldBe("Example");
             if (parseComments)
-                directiveDef.Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 30");
+                directiveDef.Arguments.Items[0].Comment.Text.ShouldBe(" comment 30");
         }
 
         [Theory]
@@ -1301,12 +1301,12 @@ directive @TestDirective (
             objectDef.Fields[1].Description.Value.ShouldBe("Test");
             if (parseComments)
                 objectDef.Fields[1].Comment.Text.ShouldBe(" comment 8");
-            objectDef.Fields[1].Arguments.InputValueDefinitions.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Arguments.Items.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields[1].Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 10");
+                objectDef.Fields[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 10");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
@@ -1361,12 +1361,12 @@ directive @TestDirective (
             directiveDef.Description.Value.ShouldBe("Test directive");
             if (parseComments)
                 directiveDef.Comment.Text.ShouldBe(" comment 28");
-            directiveDef.Arguments.InputValueDefinitions.Count.ShouldBe(1);
-            directiveDef.Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.Items.Count.ShouldBe(1);
+            directiveDef.Arguments.Items[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments.Items[0].Description.Value.ShouldBe("Example");
             if (parseComments)
-                directiveDef.Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 30");
+                directiveDef.Arguments.Items[0].Comment.Text.ShouldBe(" comment 30");
         }
 
         [Theory]
@@ -1485,12 +1485,12 @@ directive @TestDirective (
             objectDef.Fields[1].Description.Value.ShouldBe("Test");
             if (parseComments)
                 objectDef.Fields[1].Comment.Text.ShouldBe(" comment 7");
-            objectDef.Fields[1].Arguments.InputValueDefinitions.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Arguments.Items.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields[1].Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 9");
+                objectDef.Fields[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 9");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
@@ -1545,12 +1545,12 @@ directive @TestDirective (
             directiveDef.Description.Value.ShouldBe("Test directive");
             if (parseComments)
                 directiveDef.Comment.Text.ShouldBe(" comment 27");
-            directiveDef.Arguments.InputValueDefinitions.Count.ShouldBe(1);
-            directiveDef.Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.Items.Count.ShouldBe(1);
+            directiveDef.Arguments.Items[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments.Items[0].Description.Value.ShouldBe("Example");
             if (parseComments)
-                directiveDef.Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 29");
+                directiveDef.Arguments.Items[0].Comment.Text.ShouldBe(" comment 29");
         }
     }
 }

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -171,7 +171,7 @@ namespace GraphQLParser.Tests
             frag.TypeCondition.Type.Comment.Text.ShouldBe("comment for named type from TypeCondition");
 
             var def2 = document.Definitions[1] as GraphQLObjectTypeDefinition;
-            def2.Interfaces[0].Comment.Text.ShouldBe("comment for named type from ImplementsInterfaces");
+            def2.Interfaces.Items[0].Comment.Text.ShouldBe("comment for named type from ImplementsInterfaces");
 
             var def3 = document.Definitions[2] as GraphQLSchemaDefinition;
             def3.OperationTypes[0].Type.Comment.Text.ShouldBe("comment for named type from RootOperationTypeDefinition");
@@ -722,20 +722,20 @@ FIELD_DEFINITION
 
             var def2 = document.Definitions[1].ShouldBeAssignableTo<GraphQLInterfaceTypeDefinition>();
             def2.Name.Value.ShouldBe("Dog");
-            def2.Interfaces.Count.ShouldBe(1);
-            def2.Interfaces[0].Name.Value.ShouldBe("Eat");
+            def2.Interfaces.Items.Count.ShouldBe(1);
+            def2.Interfaces.Items[0].Name.Value.ShouldBe("Eat");
 
             var def3 = document.Definitions[2].ShouldBeAssignableTo<GraphQLInterfaceTypeDefinition>();
             def3.Name.Value.ShouldBe("Dog");
-            def3.Interfaces.Count.ShouldBe(2);
-            def3.Interfaces[0].Name.Value.ShouldBe("Eat");
-            def3.Interfaces[1].Name.Value.ShouldBe("Sleep");
+            def3.Interfaces.Items.Count.ShouldBe(2);
+            def3.Interfaces.Items[0].Name.Value.ShouldBe("Eat");
+            def3.Interfaces.Items[1].Name.Value.ShouldBe("Sleep");
 
             var def4 = document.Definitions[3].ShouldBeAssignableTo<GraphQLInterfaceTypeDefinition>();
             def4.Name.Value.ShouldBe("Dog");
-            def4.Interfaces.Count.ShouldBe(2);
-            def4.Interfaces[0].Name.Value.ShouldBe("Eat");
-            def4.Interfaces[1].Name.Value.ShouldBe("Sleep");
+            def4.Interfaces.Items.Count.ShouldBe(2);
+            def4.Interfaces.Items[0].Name.Value.ShouldBe("Eat");
+            def4.Interfaces.Items[1].Name.Value.ShouldBe("Sleep");
             def4.Fields.Items.Count.ShouldBe(1);
             def4.Fields.Items[0].Name.Value.ShouldBe("name");
         }

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -350,8 +350,8 @@ scalar JSON
             var d2 = document.Definitions.Skip(1).First() as GraphQLInputObjectTypeDefinition;
             d2.Name.Value.ShouldBe("Parameter");
             d2.Comment.ShouldBeNull();
-            d2.Fields.Count.ShouldBe(1);
-            d2.Fields.First().Comment.Text.ShouldBe("any value");
+            d2.Fields.Items.Count.ShouldBe(1);
+            d2.Fields.Items.First().Comment.Text.ShouldBe("any value");
         }
 
         [Theory]
@@ -971,10 +971,10 @@ directive @TestDirective (
             var inputDef = defs.Single(x => x is GraphQLInputObjectTypeDefinition) as GraphQLInputObjectTypeDefinition;
             inputDef.Name.Value.ShouldBe("TestInputObject");
             inputDef.Description.Value.ShouldBe("This is an example input object\nLine two of the description");
-            inputDef.Fields.Count.ShouldBe(1);
-            inputDef.Fields[0].Name.Value.ShouldBe("Value");
-            inputDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
-            inputDef.Fields[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
+            inputDef.Fields.Items.Count.ShouldBe(1);
+            inputDef.Fields.Items[0].Name.Value.ShouldBe("Value");
+            inputDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
+            inputDef.Fields.Items[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
 
             var directiveDef = defs.Single(x => x is GraphQLDirectiveDefinition) as GraphQLDirectiveDefinition;
             directiveDef.Name.Value.ShouldBe("TestDirective");
@@ -1165,12 +1165,12 @@ directive @TestDirective (
             inputDef.Description.Value.ShouldBe("This is an example input object\nLine two of the description");
             if (parseComments)
                 inputDef.Comment.Text.ShouldBe(" comment 24");
-            inputDef.Fields.Count.ShouldBe(1);
-            inputDef.Fields[0].Name.Value.ShouldBe("Value");
-            inputDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
-            inputDef.Fields[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
+            inputDef.Fields.Items.Count.ShouldBe(1);
+            inputDef.Fields.Items[0].Name.Value.ShouldBe("Value");
+            inputDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
+            inputDef.Fields.Items[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
             if (parseComments)
-                inputDef.Fields[0].Comment.Text.ShouldBe(" comment 26");
+                inputDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 26");
 
             var directiveDef = defs.Single(x => x is GraphQLDirectiveDefinition) as GraphQLDirectiveDefinition;
             directiveDef.Name.Value.ShouldBe("TestDirective");
@@ -1349,12 +1349,12 @@ directive @TestDirective (
             inputDef.Description.Value.ShouldBe("This is an example input object\nLine two of the description");
             if (parseComments)
                 inputDef.Comment.Text.ShouldBe(" comment 24");
-            inputDef.Fields.Count.ShouldBe(1);
-            inputDef.Fields[0].Name.Value.ShouldBe("Value");
-            inputDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
-            inputDef.Fields[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
+            inputDef.Fields.Items.Count.ShouldBe(1);
+            inputDef.Fields.Items[0].Name.Value.ShouldBe("Value");
+            inputDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
+            inputDef.Fields.Items[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
             if (parseComments)
-                inputDef.Fields[0].Comment.Text.ShouldBe(" comment 26");
+                inputDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 26");
 
             var directiveDef = defs.Single(x => x is GraphQLDirectiveDefinition) as GraphQLDirectiveDefinition;
             directiveDef.Name.Value.ShouldBe("TestDirective");
@@ -1533,12 +1533,12 @@ directive @TestDirective (
             inputDef.Description.Value.ShouldBe("This is an example input object\nLine two of the description");
             if (parseComments)
                 inputDef.Comment.Text.ShouldBe(" comment 23");
-            inputDef.Fields.Count.ShouldBe(1);
-            inputDef.Fields[0].Name.Value.ShouldBe("Value");
-            inputDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
-            inputDef.Fields[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
+            inputDef.Fields.Items.Count.ShouldBe(1);
+            inputDef.Fields.Items[0].Name.Value.ShouldBe("Value");
+            inputDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
+            inputDef.Fields.Items[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
             if (parseComments)
-                inputDef.Fields[0].Comment.Text.ShouldBe(" comment 25");
+                inputDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 25");
 
             var directiveDef = defs.Single(x => x is GraphQLDirectiveDefinition) as GraphQLDirectiveDefinition;
             directiveDef.Name.Value.ShouldBe("TestDirective");

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -177,7 +177,7 @@ namespace GraphQLParser.Tests
             def3.OperationTypes[0].Type.Comment.Text.ShouldBe("comment for named type from RootOperationTypeDefinition");
 
             var def4 = document.Definitions[3] as GraphQLObjectTypeDefinition;
-            def4.Fields[0].Type.Comment.Text.ShouldBe("comment for named type from Type");
+            def4.Fields.Items[0].Type.Comment.Text.ShouldBe("comment for named type from Type");
 
             var def5 = document.Definitions[4] as GraphQLUnionTypeDefinition;
             def5.Types[1].Comment.Text.ShouldBe("comment for named type from UnionMemberTypes");
@@ -225,7 +225,7 @@ namespace GraphQLParser.Tests
             using var document = query.Parse(new ParserOptions { Ignore = options });
             document.Definitions.Count.ShouldBe(1);
             var def = document.Definitions[0] as GraphQLScalarTypeDefinition;
-            def.Directives[0].Comment.Text.ShouldBe("comment for directive");
+            def.Directives.Items[0].Comment.Text.ShouldBe("comment for directive");
         }
 
         [Theory]
@@ -240,10 +240,10 @@ namespace GraphQLParser.Tests
             using var document = query.Parse(new ParserOptions { Ignore = options });
             document.Definitions.Count.ShouldBe(1);
             var def = document.Definitions[0] as GraphQLObjectTypeDefinition;
-            def.Fields[0].Type.Comment.Text.ShouldBe("comment for named type");
-            def.Fields[1].Type.Comment.Text.ShouldBe("comment for nonnull type");
-            def.Fields[2].Type.Comment.Text.ShouldBe("comment for list type");
-            (def.Fields[2].Type as GraphQLListType).Type.Comment.Text.ShouldBe("comment for item type");
+            def.Fields.Items[0].Type.Comment.Text.ShouldBe("comment for named type");
+            def.Fields.Items[1].Type.Comment.Text.ShouldBe("comment for nonnull type");
+            def.Fields.Items[2].Type.Comment.Text.ShouldBe("comment for list type");
+            (def.Fields.Items[2].Type as GraphQLListType).Type.Comment.Text.ShouldBe("comment for item type");
         }
 
         [Theory]
@@ -281,10 +281,10 @@ namespace GraphQLParser.Tests
             using var document = query.Parse(new ParserOptions { Ignore = options });
             document.Definitions.Count.ShouldBe(1);
             var def = document.Definitions.First() as GraphQLOperationDefinition;
-            def.VariableDefinitions.Count.ShouldBe(3);
-            def.VariableDefinitions.First().Comment.ShouldNotBeNull().Text.ShouldBe("comment1");
-            def.VariableDefinitions.Skip(1).First().Comment.ShouldBeNull();
-            def.VariableDefinitions.Skip(2).First().Comment.ShouldNotBeNull().Text.ShouldBe("comment3");
+            def.Variables.Items.Count.ShouldBe(3);
+            def.Variables.Items.First().Comment.ShouldNotBeNull().Text.ShouldBe("comment1");
+            def.Variables.Items.Skip(1).First().Comment.ShouldBeNull();
+            def.Variables.Items.Skip(2).First().Comment.ShouldNotBeNull().Text.ShouldBe("comment3");
         }
 
         [Theory]
@@ -341,11 +341,11 @@ scalar JSON
             var d1 = document.Definitions.First() as GraphQLEnumTypeDefinition;
             d1.Name.Value.ShouldBe("Animal");
             d1.Comment.ShouldNotBeNull().Text.ShouldBe(" different animals");
-            d1.Values.First().Name.Value.ShouldBe("Cat");
-            d1.Values.First().Comment.ShouldNotBeNull();
-            d1.Values.First().Comment.Text.ShouldBe("a cat");
-            d1.Values.Skip(2).First().Name.Value.ShouldBe("Octopus");
-            d1.Values.Skip(2).First().Comment.ShouldBeNull();
+            d1.Values.Items.First().Name.Value.ShouldBe("Cat");
+            d1.Values.Items.First().Comment.ShouldNotBeNull();
+            d1.Values.Items.First().Comment.Text.ShouldBe("a cat");
+            d1.Values.Items.Skip(2).First().Name.Value.ShouldBe("Octopus");
+            d1.Values.Items.Skip(2).First().Comment.ShouldBeNull();
 
             var d2 = document.Definitions.Skip(1).First() as GraphQLInputObjectTypeDefinition;
             d2.Name.Value.ShouldBe("Parameter");
@@ -526,7 +526,7 @@ scalar JSON
         {
             using var document = "KitchenSink".ReadGraphQLFile().Parse(new ParserOptions { Ignore = options });
             var typeDef = document.Definitions.OfType<GraphQLObjectTypeDefinition>().First(d => d.Name.Value == "Foo");
-            var fieldDef = typeDef.Fields.First(d => d.Name.Value == "three");
+            var fieldDef = typeDef.Fields.Items.First(d => d.Name.Value == "three");
             if (options.HasFlag(IgnoreOptions.Comments))
                 fieldDef.Comment.ShouldBeNull();
             else
@@ -581,11 +581,11 @@ scalar JSON
             {
                 document.Definitions.Count.ShouldBe(1);
                 var def = document.Definitions[0].ShouldBeAssignableTo<GraphQLOperationDefinition>();
-                def.VariableDefinitions.Count.ShouldBe(1);
-                def.VariableDefinitions[0].Directives.Count.ShouldBe(2);
-                def.VariableDefinitions[0].Directives[0].Name.Value.ShouldBe("a");
-                def.VariableDefinitions[0].Directives[1].Name.Value.ShouldBe("b");
-                def.VariableDefinitions[0].Directives[1].Arguments.Items.Count.ShouldBe(2);
+                def.Variables.Items.Count.ShouldBe(1);
+                def.Variables.Items[0].Directives.Items.Count.ShouldBe(2);
+                def.Variables.Items[0].Directives.Items[0].Name.Value.ShouldBe("a");
+                def.Variables.Items[0].Directives.Items[1].Name.Value.ShouldBe("b");
+                def.Variables.Items[0].Directives.Items[1].Arguments.Items.Count.ShouldBe(2);
             }
         }
 
@@ -686,11 +686,11 @@ FIELD_DEFINITION
             document.ShouldNotBeNull();
             document.Definitions.Count.ShouldBe(1);
             var def = document.Definitions[0].ShouldBeAssignableTo<GraphQLScalarTypeDefinition>();
-            def.Directives.Count.ShouldBe(1);
-            def.Directives[0].Name.Value.ShouldBe("specifiedBy");
-            def.Directives[0].Arguments.Items.Count.ShouldBe(1);
-            def.Directives[0].Arguments.Items[0].Name.Value.ShouldBe("url");
-            var value = def.Directives[0].Arguments.Items[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            def.Directives.Items.Count.ShouldBe(1);
+            def.Directives.Items[0].Name.Value.ShouldBe("specifiedBy");
+            def.Directives.Items[0].Arguments.Items.Count.ShouldBe(1);
+            def.Directives.Items[0].Arguments.Items[0].Name.Value.ShouldBe("url");
+            var value = def.Directives.Items[0].Arguments.Items[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             value.Value.ShouldBe("https://tools.ietf.org/html/rfc4122");
         }
 
@@ -736,8 +736,8 @@ FIELD_DEFINITION
             def4.Interfaces.Count.ShouldBe(2);
             def4.Interfaces[0].Name.Value.ShouldBe("Eat");
             def4.Interfaces[1].Name.Value.ShouldBe("Sleep");
-            def4.Fields.Count.ShouldBe(1);
-            def4.Fields[0].Name.Value.ShouldBe("name");
+            def4.Fields.Items.Count.ShouldBe(1);
+            def4.Fields.Items[0].Name.Value.ShouldBe("name");
         }
 
         [Theory]
@@ -932,25 +932,25 @@ directive @TestDirective (
             var objectDef = defs.Single(x => x is GraphQLObjectTypeDefinition) as GraphQLObjectTypeDefinition;
             objectDef.Name.Value.ShouldBe("Human");
             objectDef.Description.Value.ShouldBe("Human type");
-            objectDef.Fields.Count.ShouldBe(2);
-            objectDef.Fields[0].Name.Value.ShouldBe("name");
-            objectDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            objectDef.Fields[0].Description.Value.ShouldBe("Name of human");
-            objectDef.Fields[1].Name.Value.ShouldBe("test");
-            objectDef.Fields[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            objectDef.Fields[1].Description.Value.ShouldBe("Test");
-            objectDef.Fields[1].Arguments.Items.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields.Items.Count.ShouldBe(2);
+            objectDef.Fields.Items[0].Name.Value.ShouldBe("name");
+            objectDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            objectDef.Fields.Items[0].Description.Value.ShouldBe("Name of human");
+            objectDef.Fields.Items[1].Name.Value.ShouldBe("test");
+            objectDef.Fields.Items[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields.Items[1].Description.Value.ShouldBe("Test");
+            objectDef.Fields.Items[1].Arguments.Items.Count.ShouldBe(1);
+            objectDef.Fields.Items[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields.Items[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields.Items[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
             interfaceDef.Description.Value.ShouldBe("Test interface");
-            interfaceDef.Fields.Count.ShouldBe(1);
-            interfaceDef.Fields[0].Name.Value.ShouldBe("name");
-            interfaceDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            interfaceDef.Fields[0].Description.Value.ShouldBe("Object name");
+            interfaceDef.Fields.Items.Count.ShouldBe(1);
+            interfaceDef.Fields.Items[0].Name.Value.ShouldBe("name");
+            interfaceDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            interfaceDef.Fields.Items[0].Description.Value.ShouldBe("Object name");
 
             var unionDef = defs.Single(x => x is GraphQLUnionTypeDefinition) as GraphQLUnionTypeDefinition;
             unionDef.Name.Value.ShouldBe("TestUnion");
@@ -962,11 +962,11 @@ directive @TestDirective (
             var enumDef = defs.Single(x => x is GraphQLEnumTypeDefinition) as GraphQLEnumTypeDefinition;
             enumDef.Name.Value.ShouldBe("Colors");
             enumDef.Description.Value.ShouldBe("Example enum");
-            enumDef.Values.Count.ShouldBe(2);
-            enumDef.Values[0].Name.Value.ShouldBe("RED");
-            enumDef.Values[0].Description.Value.ShouldBe("Red");
-            enumDef.Values[1].Name.Value.ShouldBe("BLUE");
-            enumDef.Values[1].Description.Value.ShouldBe("Blue");
+            enumDef.Values.Items.Count.ShouldBe(2);
+            enumDef.Values.Items[0].Name.Value.ShouldBe("RED");
+            enumDef.Values.Items[0].Description.Value.ShouldBe("Red");
+            enumDef.Values.Items[1].Name.Value.ShouldBe("BLUE");
+            enumDef.Values.Items[1].Description.Value.ShouldBe("Blue");
 
             var inputDef = defs.Single(x => x is GraphQLInputObjectTypeDefinition) as GraphQLInputObjectTypeDefinition;
             inputDef.Name.Value.ShouldBe("TestInputObject");
@@ -1106,35 +1106,35 @@ directive @TestDirective (
             objectDef.Description.Value.ShouldBe("Human type");
             if (parseComments)
                 objectDef.Comment.Text.ShouldBe(" comment 4");
-            objectDef.Fields.Count.ShouldBe(2);
-            objectDef.Fields[0].Name.Value.ShouldBe("name");
-            objectDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            objectDef.Fields[0].Description.Value.ShouldBe("Name of human");
+            objectDef.Fields.Items.Count.ShouldBe(2);
+            objectDef.Fields.Items[0].Name.Value.ShouldBe("name");
+            objectDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            objectDef.Fields.Items[0].Description.Value.ShouldBe("Name of human");
             if (parseComments)
-                objectDef.Fields[0].Comment.Text.ShouldBe(" comment 6");
-            objectDef.Fields[1].Name.Value.ShouldBe("test");
-            objectDef.Fields[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            objectDef.Fields[1].Description.Value.ShouldBe("Test");
+                objectDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 6");
+            objectDef.Fields.Items[1].Name.Value.ShouldBe("test");
+            objectDef.Fields.Items[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields.Items[1].Description.Value.ShouldBe("Test");
             if (parseComments)
-                objectDef.Fields[1].Comment.Text.ShouldBe(" comment 8");
-            objectDef.Fields[1].Arguments.Items.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+                objectDef.Fields.Items[1].Comment.Text.ShouldBe(" comment 8");
+            objectDef.Fields.Items[1].Arguments.Items.Count.ShouldBe(1);
+            objectDef.Fields.Items[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields.Items[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields.Items[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 10");
+                objectDef.Fields.Items[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 10");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
             interfaceDef.Description.Value.ShouldBe("Test interface");
             if (parseComments)
                 interfaceDef.Comment.Text.ShouldBe(" comment 12");
-            interfaceDef.Fields.Count.ShouldBe(1);
-            interfaceDef.Fields[0].Name.Value.ShouldBe("name");
-            interfaceDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            interfaceDef.Fields[0].Description.Value.ShouldBe("Object name");
+            interfaceDef.Fields.Items.Count.ShouldBe(1);
+            interfaceDef.Fields.Items[0].Name.Value.ShouldBe("name");
+            interfaceDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            interfaceDef.Fields.Items[0].Description.Value.ShouldBe("Object name");
             if (parseComments)
-                interfaceDef.Fields[0].Comment.Text.ShouldBe(" comment 14");
+                interfaceDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 14");
 
             var unionDef = defs.Single(x => x is GraphQLUnionTypeDefinition) as GraphQLUnionTypeDefinition;
             unionDef.Name.Value.ShouldBe("TestUnion");
@@ -1150,15 +1150,15 @@ directive @TestDirective (
             enumDef.Description.Value.ShouldBe("Example enum");
             if (parseComments)
                 enumDef.Comment.Text.ShouldBe(" comment 18");
-            enumDef.Values.Count.ShouldBe(2);
-            enumDef.Values[0].Name.Value.ShouldBe("RED");
-            enumDef.Values[0].Description.Value.ShouldBe("Red");
+            enumDef.Values.Items.Count.ShouldBe(2);
+            enumDef.Values.Items[0].Name.Value.ShouldBe("RED");
+            enumDef.Values.Items[0].Description.Value.ShouldBe("Red");
             if (parseComments)
-                enumDef.Values[0].Comment.Text.ShouldBe(" comment 20");
-            enumDef.Values[1].Name.Value.ShouldBe("BLUE");
-            enumDef.Values[1].Description.Value.ShouldBe("Blue");
+                enumDef.Values.Items[0].Comment.Text.ShouldBe(" comment 20");
+            enumDef.Values.Items[1].Name.Value.ShouldBe("BLUE");
+            enumDef.Values.Items[1].Description.Value.ShouldBe("Blue");
             if (parseComments)
-                enumDef.Values[1].Comment.Text.ShouldBe(" comment 22");
+                enumDef.Values.Items[1].Comment.Text.ShouldBe(" comment 22");
 
             var inputDef = defs.Single(x => x is GraphQLInputObjectTypeDefinition) as GraphQLInputObjectTypeDefinition;
             inputDef.Name.Value.ShouldBe("TestInputObject");
@@ -1290,35 +1290,35 @@ directive @TestDirective (
             objectDef.Description.Value.ShouldBe("Human type");
             if (parseComments)
                 objectDef.Comment.Text.ShouldBe(" comment 4");
-            objectDef.Fields.Count.ShouldBe(2);
-            objectDef.Fields[0].Name.Value.ShouldBe("name");
-            objectDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            objectDef.Fields[0].Description.Value.ShouldBe("Name of human");
+            objectDef.Fields.Items.Count.ShouldBe(2);
+            objectDef.Fields.Items[0].Name.Value.ShouldBe("name");
+            objectDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            objectDef.Fields.Items[0].Description.Value.ShouldBe("Name of human");
             if (parseComments)
-                objectDef.Fields[0].Comment.Text.ShouldBe(" comment 6");
-            objectDef.Fields[1].Name.Value.ShouldBe("test");
-            objectDef.Fields[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            objectDef.Fields[1].Description.Value.ShouldBe("Test");
+                objectDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 6");
+            objectDef.Fields.Items[1].Name.Value.ShouldBe("test");
+            objectDef.Fields.Items[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields.Items[1].Description.Value.ShouldBe("Test");
             if (parseComments)
-                objectDef.Fields[1].Comment.Text.ShouldBe(" comment 8");
-            objectDef.Fields[1].Arguments.Items.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+                objectDef.Fields.Items[1].Comment.Text.ShouldBe(" comment 8");
+            objectDef.Fields.Items[1].Arguments.Items.Count.ShouldBe(1);
+            objectDef.Fields.Items[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields.Items[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields.Items[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 10");
+                objectDef.Fields.Items[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 10");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
             interfaceDef.Description.Value.ShouldBe("Test interface");
             if (parseComments)
                 interfaceDef.Comment.Text.ShouldBe(" comment 12");
-            interfaceDef.Fields.Count.ShouldBe(1);
-            interfaceDef.Fields[0].Name.Value.ShouldBe("name");
-            interfaceDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            interfaceDef.Fields[0].Description.Value.ShouldBe("Object name");
+            interfaceDef.Fields.Items.Count.ShouldBe(1);
+            interfaceDef.Fields.Items[0].Name.Value.ShouldBe("name");
+            interfaceDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            interfaceDef.Fields.Items[0].Description.Value.ShouldBe("Object name");
             if (parseComments)
-                interfaceDef.Fields[0].Comment.Text.ShouldBe(" comment 14");
+                interfaceDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 14");
 
             var unionDef = defs.Single(x => x is GraphQLUnionTypeDefinition) as GraphQLUnionTypeDefinition;
             unionDef.Name.Value.ShouldBe("TestUnion");
@@ -1334,15 +1334,15 @@ directive @TestDirective (
             enumDef.Description.Value.ShouldBe("Example enum");
             if (parseComments)
                 enumDef.Comment.Text.ShouldBe(" comment 18");
-            enumDef.Values.Count.ShouldBe(2);
-            enumDef.Values[0].Name.Value.ShouldBe("RED");
-            enumDef.Values[0].Description.Value.ShouldBe("Red");
+            enumDef.Values.Items.Count.ShouldBe(2);
+            enumDef.Values.Items[0].Name.Value.ShouldBe("RED");
+            enumDef.Values.Items[0].Description.Value.ShouldBe("Red");
             if (parseComments)
-                enumDef.Values[0].Comment.Text.ShouldBe(" comment 20");
-            enumDef.Values[1].Name.Value.ShouldBe("BLUE");
-            enumDef.Values[1].Description.Value.ShouldBe("Blue");
+                enumDef.Values.Items[0].Comment.Text.ShouldBe(" comment 20");
+            enumDef.Values.Items[1].Name.Value.ShouldBe("BLUE");
+            enumDef.Values.Items[1].Description.Value.ShouldBe("Blue");
             if (parseComments)
-                enumDef.Values[1].Comment.Text.ShouldBe(" comment 22");
+                enumDef.Values.Items[1].Comment.Text.ShouldBe(" comment 22");
 
             var inputDef = defs.Single(x => x is GraphQLInputObjectTypeDefinition) as GraphQLInputObjectTypeDefinition;
             inputDef.Name.Value.ShouldBe("TestInputObject");
@@ -1474,35 +1474,35 @@ directive @TestDirective (
             objectDef.Description.Value.ShouldBe("Human type");
             if (parseComments)
                 objectDef.Comment.Text.ShouldBe(" comment 3");
-            objectDef.Fields.Count.ShouldBe(2);
-            objectDef.Fields[0].Name.Value.ShouldBe("name");
-            objectDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            objectDef.Fields[0].Description.Value.ShouldBe("Name of human");
+            objectDef.Fields.Items.Count.ShouldBe(2);
+            objectDef.Fields.Items[0].Name.Value.ShouldBe("name");
+            objectDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            objectDef.Fields.Items[0].Description.Value.ShouldBe("Name of human");
             if (parseComments)
-                objectDef.Fields[0].Comment.Text.ShouldBe(" comment 5");
-            objectDef.Fields[1].Name.Value.ShouldBe("test");
-            objectDef.Fields[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            objectDef.Fields[1].Description.Value.ShouldBe("Test");
+                objectDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 5");
+            objectDef.Fields.Items[1].Name.Value.ShouldBe("test");
+            objectDef.Fields.Items[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields.Items[1].Description.Value.ShouldBe("Test");
             if (parseComments)
-                objectDef.Fields[1].Comment.Text.ShouldBe(" comment 7");
-            objectDef.Fields[1].Arguments.Items.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+                objectDef.Fields.Items[1].Comment.Text.ShouldBe(" comment 7");
+            objectDef.Fields.Items[1].Arguments.Items.Count.ShouldBe(1);
+            objectDef.Fields.Items[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields.Items[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields.Items[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 9");
+                objectDef.Fields.Items[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 9");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
             interfaceDef.Description.Value.ShouldBe("Test interface");
             if (parseComments)
                 interfaceDef.Comment.Text.ShouldBe(" comment 11");
-            interfaceDef.Fields.Count.ShouldBe(1);
-            interfaceDef.Fields[0].Name.Value.ShouldBe("name");
-            interfaceDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            interfaceDef.Fields[0].Description.Value.ShouldBe("Object name");
+            interfaceDef.Fields.Items.Count.ShouldBe(1);
+            interfaceDef.Fields.Items[0].Name.Value.ShouldBe("name");
+            interfaceDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            interfaceDef.Fields.Items[0].Description.Value.ShouldBe("Object name");
             if (parseComments)
-                interfaceDef.Fields[0].Comment.Text.ShouldBe(" comment 13");
+                interfaceDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 13");
 
             var unionDef = defs.Single(x => x is GraphQLUnionTypeDefinition) as GraphQLUnionTypeDefinition;
             unionDef.Name.Value.ShouldBe("TestUnion");
@@ -1518,15 +1518,15 @@ directive @TestDirective (
             enumDef.Description.Value.ShouldBe("Example enum");
             if (parseComments)
                 enumDef.Comment.Text.ShouldBe(" comment 17");
-            enumDef.Values.Count.ShouldBe(2);
-            enumDef.Values[0].Name.Value.ShouldBe("RED");
-            enumDef.Values[0].Description.Value.ShouldBe("Red");
+            enumDef.Values.Items.Count.ShouldBe(2);
+            enumDef.Values.Items[0].Name.Value.ShouldBe("RED");
+            enumDef.Values.Items[0].Description.Value.ShouldBe("Red");
             if (parseComments)
-                enumDef.Values[0].Comment.Text.ShouldBe(" comment 19");
-            enumDef.Values[1].Name.Value.ShouldBe("BLUE");
-            enumDef.Values[1].Description.Value.ShouldBe("Blue");
+                enumDef.Values.Items[0].Comment.Text.ShouldBe(" comment 19");
+            enumDef.Values.Items[1].Name.Value.ShouldBe("BLUE");
+            enumDef.Values.Items[1].Description.Value.ShouldBe("Blue");
             if (parseComments)
-                enumDef.Values[1].Comment.Text.ShouldBe(" comment 21");
+                enumDef.Values.Items[1].Comment.Text.ShouldBe(" comment 21");
 
             var inputDef = defs.Single(x => x is GraphQLInputObjectTypeDefinition) as GraphQLInputObjectTypeDefinition;
             inputDef.Name.Value.ShouldBe("TestInputObject");

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -939,10 +939,10 @@ directive @TestDirective (
             objectDef.Fields[1].Name.Value.ShouldBe("test");
             objectDef.Fields[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             objectDef.Fields[1].Description.Value.ShouldBe("Test");
-            objectDef.Fields[1].Arguments.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Arguments.InputValueDefinitions.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
@@ -979,10 +979,10 @@ directive @TestDirective (
             var directiveDef = defs.Single(x => x is GraphQLDirectiveDefinition) as GraphQLDirectiveDefinition;
             directiveDef.Name.Value.ShouldBe("TestDirective");
             directiveDef.Description.Value.ShouldBe("Test directive");
-            directiveDef.Arguments.Count.ShouldBe(1);
-            directiveDef.Arguments[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.InputValueDefinitions.Count.ShouldBe(1);
+            directiveDef.Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("Example");
         }
 
         [Theory]
@@ -1117,12 +1117,12 @@ directive @TestDirective (
             objectDef.Fields[1].Description.Value.ShouldBe("Test");
             if (parseComments)
                 objectDef.Fields[1].Comment.Text.ShouldBe(" comment 8");
-            objectDef.Fields[1].Arguments.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Arguments.InputValueDefinitions.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields[1].Arguments[0].Comment.Text.ShouldBe(" comment 10");
+                objectDef.Fields[1].Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 10");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
@@ -1177,12 +1177,12 @@ directive @TestDirective (
             directiveDef.Description.Value.ShouldBe("Test directive");
             if (parseComments)
                 directiveDef.Comment.Text.ShouldBe(" comment 28");
-            directiveDef.Arguments.Count.ShouldBe(1);
-            directiveDef.Arguments[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.InputValueDefinitions.Count.ShouldBe(1);
+            directiveDef.Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("Example");
             if (parseComments)
-                directiveDef.Arguments[0].Comment.Text.ShouldBe(" comment 30");
+                directiveDef.Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 30");
         }
 
         [Theory]
@@ -1301,12 +1301,12 @@ directive @TestDirective (
             objectDef.Fields[1].Description.Value.ShouldBe("Test");
             if (parseComments)
                 objectDef.Fields[1].Comment.Text.ShouldBe(" comment 8");
-            objectDef.Fields[1].Arguments.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Arguments.InputValueDefinitions.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields[1].Arguments[0].Comment.Text.ShouldBe(" comment 10");
+                objectDef.Fields[1].Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 10");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
@@ -1361,12 +1361,12 @@ directive @TestDirective (
             directiveDef.Description.Value.ShouldBe("Test directive");
             if (parseComments)
                 directiveDef.Comment.Text.ShouldBe(" comment 28");
-            directiveDef.Arguments.Count.ShouldBe(1);
-            directiveDef.Arguments[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.InputValueDefinitions.Count.ShouldBe(1);
+            directiveDef.Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("Example");
             if (parseComments)
-                directiveDef.Arguments[0].Comment.Text.ShouldBe(" comment 30");
+                directiveDef.Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 30");
         }
 
         [Theory]
@@ -1485,12 +1485,12 @@ directive @TestDirective (
             objectDef.Fields[1].Description.Value.ShouldBe("Test");
             if (parseComments)
                 objectDef.Fields[1].Comment.Text.ShouldBe(" comment 7");
-            objectDef.Fields[1].Arguments.Count.ShouldBe(1);
-            objectDef.Fields[1].Arguments[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields[1].Arguments[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields[1].Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Arguments.InputValueDefinitions.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields[1].Arguments[0].Comment.Text.ShouldBe(" comment 9");
+                objectDef.Fields[1].Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 9");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
@@ -1545,12 +1545,12 @@ directive @TestDirective (
             directiveDef.Description.Value.ShouldBe("Test directive");
             if (parseComments)
                 directiveDef.Comment.Text.ShouldBe(" comment 27");
-            directiveDef.Arguments.Count.ShouldBe(1);
-            directiveDef.Arguments[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.InputValueDefinitions.Count.ShouldBe(1);
+            directiveDef.Arguments.InputValueDefinitions[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments.InputValueDefinitions[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments.InputValueDefinitions[0].Description.Value.ShouldBe("Example");
             if (parseComments)
-                directiveDef.Arguments[0].Comment.Text.ShouldBe(" comment 29");
+                directiveDef.Arguments.InputValueDefinitions[0].Comment.Text.ShouldBe(" comment 29");
         }
     }
 }

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -104,33 +104,33 @@ namespace GraphQLParser.Tests
             def.SelectionSet.Selections.Count.ShouldBe(1);
             var field = def.SelectionSet.Selections.First() as GraphQLField;
             field.SelectionSet.Selections.Count.ShouldBe(1);
-            field.Arguments.Items.Count.ShouldBe(9);
+            field.Arguments.Count.ShouldBe(9);
 
-            var boolValue = field.Arguments.Items[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var boolValue = field.Arguments[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             boolValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for bool");
 
-            var nullValue = field.Arguments.Items[1].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var nullValue = field.Arguments[1].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             nullValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for null");
 
-            var enumValue = field.Arguments.Items[2].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var enumValue = field.Arguments[2].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             enumValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for enum");
 
-            var listValue = field.Arguments.Items[3].Value.ShouldBeAssignableTo<GraphQLListValue>();
+            var listValue = field.Arguments[3].Value.ShouldBeAssignableTo<GraphQLListValue>();
             listValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for list");
 
-            var objValue = field.Arguments.Items[4].Value.ShouldBeAssignableTo<GraphQLObjectValue>();
+            var objValue = field.Arguments[4].Value.ShouldBeAssignableTo<GraphQLObjectValue>();
             objValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for object");
 
-            var intValue = field.Arguments.Items[5].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var intValue = field.Arguments[5].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             intValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for int");
 
-            var floatValue = field.Arguments.Items[6].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var floatValue = field.Arguments[6].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             floatValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for float");
 
-            var stringValue = field.Arguments.Items[7].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            var stringValue = field.Arguments[7].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             stringValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for string");
 
-            var varValue = field.Arguments.Items[8].Value.ShouldBeAssignableTo<GraphQLVariable>();
+            var varValue = field.Arguments[8].Value.ShouldBeAssignableTo<GraphQLVariable>();
             varValue.Comment.ShouldNotBeNull().Text.ShouldBe("comment for variable");
         }
 
@@ -171,13 +171,13 @@ namespace GraphQLParser.Tests
             frag.TypeCondition.Type.Comment.Text.ShouldBe("comment for named type from TypeCondition");
 
             var def2 = document.Definitions[1] as GraphQLObjectTypeDefinition;
-            def2.Interfaces.Items[0].Comment.Text.ShouldBe("comment for named type from ImplementsInterfaces");
+            def2.Interfaces[0].Comment.Text.ShouldBe("comment for named type from ImplementsInterfaces");
 
             var def3 = document.Definitions[2] as GraphQLSchemaDefinition;
             def3.OperationTypes[0].Type.Comment.Text.ShouldBe("comment for named type from RootOperationTypeDefinition");
 
             var def4 = document.Definitions[3] as GraphQLObjectTypeDefinition;
-            def4.Fields.Items[0].Type.Comment.Text.ShouldBe("comment for named type from Type");
+            def4.Fields[0].Type.Comment.Text.ShouldBe("comment for named type from Type");
 
             var def5 = document.Definitions[4] as GraphQLUnionTypeDefinition;
             def5.Types[1].Comment.Text.ShouldBe("comment for named type from UnionMemberTypes");
@@ -225,7 +225,7 @@ namespace GraphQLParser.Tests
             using var document = query.Parse(new ParserOptions { Ignore = options });
             document.Definitions.Count.ShouldBe(1);
             var def = document.Definitions[0] as GraphQLScalarTypeDefinition;
-            def.Directives.Items[0].Comment.Text.ShouldBe("comment for directive");
+            def.Directives[0].Comment.Text.ShouldBe("comment for directive");
         }
 
         [Theory]
@@ -240,10 +240,10 @@ namespace GraphQLParser.Tests
             using var document = query.Parse(new ParserOptions { Ignore = options });
             document.Definitions.Count.ShouldBe(1);
             var def = document.Definitions[0] as GraphQLObjectTypeDefinition;
-            def.Fields.Items[0].Type.Comment.Text.ShouldBe("comment for named type");
-            def.Fields.Items[1].Type.Comment.Text.ShouldBe("comment for nonnull type");
-            def.Fields.Items[2].Type.Comment.Text.ShouldBe("comment for list type");
-            (def.Fields.Items[2].Type as GraphQLListType).Type.Comment.Text.ShouldBe("comment for item type");
+            def.Fields[0].Type.Comment.Text.ShouldBe("comment for named type");
+            def.Fields[1].Type.Comment.Text.ShouldBe("comment for nonnull type");
+            def.Fields[2].Type.Comment.Text.ShouldBe("comment for list type");
+            (def.Fields[2].Type as GraphQLListType).Type.Comment.Text.ShouldBe("comment for item type");
         }
 
         [Theory]
@@ -281,10 +281,10 @@ namespace GraphQLParser.Tests
             using var document = query.Parse(new ParserOptions { Ignore = options });
             document.Definitions.Count.ShouldBe(1);
             var def = document.Definitions.First() as GraphQLOperationDefinition;
-            def.Variables.Items.Count.ShouldBe(3);
-            def.Variables.Items.First().Comment.ShouldNotBeNull().Text.ShouldBe("comment1");
-            def.Variables.Items.Skip(1).First().Comment.ShouldBeNull();
-            def.Variables.Items.Skip(2).First().Comment.ShouldNotBeNull().Text.ShouldBe("comment3");
+            def.Variables.Count.ShouldBe(3);
+            def.Variables.First().Comment.ShouldNotBeNull().Text.ShouldBe("comment1");
+            def.Variables.Skip(1).First().Comment.ShouldBeNull();
+            def.Variables.Skip(2).First().Comment.ShouldNotBeNull().Text.ShouldBe("comment3");
         }
 
         [Theory]
@@ -341,17 +341,17 @@ scalar JSON
             var d1 = document.Definitions.First() as GraphQLEnumTypeDefinition;
             d1.Name.Value.ShouldBe("Animal");
             d1.Comment.ShouldNotBeNull().Text.ShouldBe(" different animals");
-            d1.Values.Items.First().Name.Value.ShouldBe("Cat");
-            d1.Values.Items.First().Comment.ShouldNotBeNull();
-            d1.Values.Items.First().Comment.Text.ShouldBe("a cat");
-            d1.Values.Items.Skip(2).First().Name.Value.ShouldBe("Octopus");
-            d1.Values.Items.Skip(2).First().Comment.ShouldBeNull();
+            d1.Values.First().Name.Value.ShouldBe("Cat");
+            d1.Values.First().Comment.ShouldNotBeNull();
+            d1.Values.First().Comment.Text.ShouldBe("a cat");
+            d1.Values.Skip(2).First().Name.Value.ShouldBe("Octopus");
+            d1.Values.Skip(2).First().Comment.ShouldBeNull();
 
             var d2 = document.Definitions.Skip(1).First() as GraphQLInputObjectTypeDefinition;
             d2.Name.Value.ShouldBe("Parameter");
             d2.Comment.ShouldBeNull();
-            d2.Fields.Items.Count.ShouldBe(1);
-            d2.Fields.Items.First().Comment.Text.ShouldBe("any value");
+            d2.Fields.Count.ShouldBe(1);
+            d2.Fields.First().Comment.Text.ShouldBe("any value");
         }
 
         [Theory]
@@ -526,7 +526,7 @@ scalar JSON
         {
             using var document = "KitchenSink".ReadGraphQLFile().Parse(new ParserOptions { Ignore = options });
             var typeDef = document.Definitions.OfType<GraphQLObjectTypeDefinition>().First(d => d.Name.Value == "Foo");
-            var fieldDef = typeDef.Fields.Items.First(d => d.Name.Value == "three");
+            var fieldDef = typeDef.Fields.First(d => d.Name.Value == "three");
             if (options.HasFlag(IgnoreOptions.Comments))
                 fieldDef.Comment.ShouldBeNull();
             else
@@ -581,11 +581,11 @@ scalar JSON
             {
                 document.Definitions.Count.ShouldBe(1);
                 var def = document.Definitions[0].ShouldBeAssignableTo<GraphQLOperationDefinition>();
-                def.Variables.Items.Count.ShouldBe(1);
-                def.Variables.Items[0].Directives.Items.Count.ShouldBe(2);
-                def.Variables.Items[0].Directives.Items[0].Name.Value.ShouldBe("a");
-                def.Variables.Items[0].Directives.Items[1].Name.Value.ShouldBe("b");
-                def.Variables.Items[0].Directives.Items[1].Arguments.Items.Count.ShouldBe(2);
+                def.Variables.Count.ShouldBe(1);
+                def.Variables[0].Directives.Count.ShouldBe(2);
+                def.Variables[0].Directives[0].Name.Value.ShouldBe("a");
+                def.Variables[0].Directives[1].Name.Value.ShouldBe("b");
+                def.Variables[0].Directives[1].Arguments.Count.ShouldBe(2);
             }
         }
 
@@ -686,11 +686,11 @@ FIELD_DEFINITION
             document.ShouldNotBeNull();
             document.Definitions.Count.ShouldBe(1);
             var def = document.Definitions[0].ShouldBeAssignableTo<GraphQLScalarTypeDefinition>();
-            def.Directives.Items.Count.ShouldBe(1);
-            def.Directives.Items[0].Name.Value.ShouldBe("specifiedBy");
-            def.Directives.Items[0].Arguments.Items.Count.ShouldBe(1);
-            def.Directives.Items[0].Arguments.Items[0].Name.Value.ShouldBe("url");
-            var value = def.Directives.Items[0].Arguments.Items[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
+            def.Directives.Count.ShouldBe(1);
+            def.Directives[0].Name.Value.ShouldBe("specifiedBy");
+            def.Directives[0].Arguments.Count.ShouldBe(1);
+            def.Directives[0].Arguments[0].Name.Value.ShouldBe("url");
+            var value = def.Directives[0].Arguments[0].Value.ShouldBeAssignableTo<GraphQLScalarValue>();
             value.Value.ShouldBe("https://tools.ietf.org/html/rfc4122");
         }
 
@@ -722,22 +722,22 @@ FIELD_DEFINITION
 
             var def2 = document.Definitions[1].ShouldBeAssignableTo<GraphQLInterfaceTypeDefinition>();
             def2.Name.Value.ShouldBe("Dog");
-            def2.Interfaces.Items.Count.ShouldBe(1);
-            def2.Interfaces.Items[0].Name.Value.ShouldBe("Eat");
+            def2.Interfaces.Count.ShouldBe(1);
+            def2.Interfaces[0].Name.Value.ShouldBe("Eat");
 
             var def3 = document.Definitions[2].ShouldBeAssignableTo<GraphQLInterfaceTypeDefinition>();
             def3.Name.Value.ShouldBe("Dog");
-            def3.Interfaces.Items.Count.ShouldBe(2);
-            def3.Interfaces.Items[0].Name.Value.ShouldBe("Eat");
-            def3.Interfaces.Items[1].Name.Value.ShouldBe("Sleep");
+            def3.Interfaces.Count.ShouldBe(2);
+            def3.Interfaces[0].Name.Value.ShouldBe("Eat");
+            def3.Interfaces[1].Name.Value.ShouldBe("Sleep");
 
             var def4 = document.Definitions[3].ShouldBeAssignableTo<GraphQLInterfaceTypeDefinition>();
             def4.Name.Value.ShouldBe("Dog");
-            def4.Interfaces.Items.Count.ShouldBe(2);
-            def4.Interfaces.Items[0].Name.Value.ShouldBe("Eat");
-            def4.Interfaces.Items[1].Name.Value.ShouldBe("Sleep");
-            def4.Fields.Items.Count.ShouldBe(1);
-            def4.Fields.Items[0].Name.Value.ShouldBe("name");
+            def4.Interfaces.Count.ShouldBe(2);
+            def4.Interfaces[0].Name.Value.ShouldBe("Eat");
+            def4.Interfaces[1].Name.Value.ShouldBe("Sleep");
+            def4.Fields.Count.ShouldBe(1);
+            def4.Fields[0].Name.Value.ShouldBe("name");
         }
 
         [Theory]
@@ -932,25 +932,25 @@ directive @TestDirective (
             var objectDef = defs.Single(x => x is GraphQLObjectTypeDefinition) as GraphQLObjectTypeDefinition;
             objectDef.Name.Value.ShouldBe("Human");
             objectDef.Description.Value.ShouldBe("Human type");
-            objectDef.Fields.Items.Count.ShouldBe(2);
-            objectDef.Fields.Items[0].Name.Value.ShouldBe("name");
-            objectDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            objectDef.Fields.Items[0].Description.Value.ShouldBe("Name of human");
-            objectDef.Fields.Items[1].Name.Value.ShouldBe("test");
-            objectDef.Fields.Items[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            objectDef.Fields.Items[1].Description.Value.ShouldBe("Test");
-            objectDef.Fields.Items[1].Arguments.Items.Count.ShouldBe(1);
-            objectDef.Fields.Items[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields.Items[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields.Items[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields.Count.ShouldBe(2);
+            objectDef.Fields[0].Name.Value.ShouldBe("name");
+            objectDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            objectDef.Fields[0].Description.Value.ShouldBe("Name of human");
+            objectDef.Fields[1].Name.Value.ShouldBe("test");
+            objectDef.Fields[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Description.Value.ShouldBe("Test");
+            objectDef.Fields[1].Arguments.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
             interfaceDef.Description.Value.ShouldBe("Test interface");
-            interfaceDef.Fields.Items.Count.ShouldBe(1);
-            interfaceDef.Fields.Items[0].Name.Value.ShouldBe("name");
-            interfaceDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            interfaceDef.Fields.Items[0].Description.Value.ShouldBe("Object name");
+            interfaceDef.Fields.Count.ShouldBe(1);
+            interfaceDef.Fields[0].Name.Value.ShouldBe("name");
+            interfaceDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            interfaceDef.Fields[0].Description.Value.ShouldBe("Object name");
 
             var unionDef = defs.Single(x => x is GraphQLUnionTypeDefinition) as GraphQLUnionTypeDefinition;
             unionDef.Name.Value.ShouldBe("TestUnion");
@@ -962,27 +962,27 @@ directive @TestDirective (
             var enumDef = defs.Single(x => x is GraphQLEnumTypeDefinition) as GraphQLEnumTypeDefinition;
             enumDef.Name.Value.ShouldBe("Colors");
             enumDef.Description.Value.ShouldBe("Example enum");
-            enumDef.Values.Items.Count.ShouldBe(2);
-            enumDef.Values.Items[0].Name.Value.ShouldBe("RED");
-            enumDef.Values.Items[0].Description.Value.ShouldBe("Red");
-            enumDef.Values.Items[1].Name.Value.ShouldBe("BLUE");
-            enumDef.Values.Items[1].Description.Value.ShouldBe("Blue");
+            enumDef.Values.Count.ShouldBe(2);
+            enumDef.Values[0].Name.Value.ShouldBe("RED");
+            enumDef.Values[0].Description.Value.ShouldBe("Red");
+            enumDef.Values[1].Name.Value.ShouldBe("BLUE");
+            enumDef.Values[1].Description.Value.ShouldBe("Blue");
 
             var inputDef = defs.Single(x => x is GraphQLInputObjectTypeDefinition) as GraphQLInputObjectTypeDefinition;
             inputDef.Name.Value.ShouldBe("TestInputObject");
             inputDef.Description.Value.ShouldBe("This is an example input object\nLine two of the description");
-            inputDef.Fields.Items.Count.ShouldBe(1);
-            inputDef.Fields.Items[0].Name.Value.ShouldBe("Value");
-            inputDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
-            inputDef.Fields.Items[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
+            inputDef.Fields.Count.ShouldBe(1);
+            inputDef.Fields[0].Name.Value.ShouldBe("Value");
+            inputDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
+            inputDef.Fields[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
 
             var directiveDef = defs.Single(x => x is GraphQLDirectiveDefinition) as GraphQLDirectiveDefinition;
             directiveDef.Name.Value.ShouldBe("TestDirective");
             directiveDef.Description.Value.ShouldBe("Test directive");
-            directiveDef.Arguments.Items.Count.ShouldBe(1);
-            directiveDef.Arguments.Items[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments.Items[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.Count.ShouldBe(1);
+            directiveDef.Arguments[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments[0].Description.Value.ShouldBe("Example");
         }
 
         [Theory]
@@ -1106,35 +1106,35 @@ directive @TestDirective (
             objectDef.Description.Value.ShouldBe("Human type");
             if (parseComments)
                 objectDef.Comment.Text.ShouldBe(" comment 4");
-            objectDef.Fields.Items.Count.ShouldBe(2);
-            objectDef.Fields.Items[0].Name.Value.ShouldBe("name");
-            objectDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            objectDef.Fields.Items[0].Description.Value.ShouldBe("Name of human");
+            objectDef.Fields.Count.ShouldBe(2);
+            objectDef.Fields[0].Name.Value.ShouldBe("name");
+            objectDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            objectDef.Fields[0].Description.Value.ShouldBe("Name of human");
             if (parseComments)
-                objectDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 6");
-            objectDef.Fields.Items[1].Name.Value.ShouldBe("test");
-            objectDef.Fields.Items[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            objectDef.Fields.Items[1].Description.Value.ShouldBe("Test");
+                objectDef.Fields[0].Comment.Text.ShouldBe(" comment 6");
+            objectDef.Fields[1].Name.Value.ShouldBe("test");
+            objectDef.Fields[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Description.Value.ShouldBe("Test");
             if (parseComments)
-                objectDef.Fields.Items[1].Comment.Text.ShouldBe(" comment 8");
-            objectDef.Fields.Items[1].Arguments.Items.Count.ShouldBe(1);
-            objectDef.Fields.Items[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields.Items[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields.Items[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+                objectDef.Fields[1].Comment.Text.ShouldBe(" comment 8");
+            objectDef.Fields[1].Arguments.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields.Items[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 10");
+                objectDef.Fields[1].Arguments[0].Comment.Text.ShouldBe(" comment 10");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
             interfaceDef.Description.Value.ShouldBe("Test interface");
             if (parseComments)
                 interfaceDef.Comment.Text.ShouldBe(" comment 12");
-            interfaceDef.Fields.Items.Count.ShouldBe(1);
-            interfaceDef.Fields.Items[0].Name.Value.ShouldBe("name");
-            interfaceDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            interfaceDef.Fields.Items[0].Description.Value.ShouldBe("Object name");
+            interfaceDef.Fields.Count.ShouldBe(1);
+            interfaceDef.Fields[0].Name.Value.ShouldBe("name");
+            interfaceDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            interfaceDef.Fields[0].Description.Value.ShouldBe("Object name");
             if (parseComments)
-                interfaceDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 14");
+                interfaceDef.Fields[0].Comment.Text.ShouldBe(" comment 14");
 
             var unionDef = defs.Single(x => x is GraphQLUnionTypeDefinition) as GraphQLUnionTypeDefinition;
             unionDef.Name.Value.ShouldBe("TestUnion");
@@ -1150,39 +1150,39 @@ directive @TestDirective (
             enumDef.Description.Value.ShouldBe("Example enum");
             if (parseComments)
                 enumDef.Comment.Text.ShouldBe(" comment 18");
-            enumDef.Values.Items.Count.ShouldBe(2);
-            enumDef.Values.Items[0].Name.Value.ShouldBe("RED");
-            enumDef.Values.Items[0].Description.Value.ShouldBe("Red");
+            enumDef.Values.Count.ShouldBe(2);
+            enumDef.Values[0].Name.Value.ShouldBe("RED");
+            enumDef.Values[0].Description.Value.ShouldBe("Red");
             if (parseComments)
-                enumDef.Values.Items[0].Comment.Text.ShouldBe(" comment 20");
-            enumDef.Values.Items[1].Name.Value.ShouldBe("BLUE");
-            enumDef.Values.Items[1].Description.Value.ShouldBe("Blue");
+                enumDef.Values[0].Comment.Text.ShouldBe(" comment 20");
+            enumDef.Values[1].Name.Value.ShouldBe("BLUE");
+            enumDef.Values[1].Description.Value.ShouldBe("Blue");
             if (parseComments)
-                enumDef.Values.Items[1].Comment.Text.ShouldBe(" comment 22");
+                enumDef.Values[1].Comment.Text.ShouldBe(" comment 22");
 
             var inputDef = defs.Single(x => x is GraphQLInputObjectTypeDefinition) as GraphQLInputObjectTypeDefinition;
             inputDef.Name.Value.ShouldBe("TestInputObject");
             inputDef.Description.Value.ShouldBe("This is an example input object\nLine two of the description");
             if (parseComments)
                 inputDef.Comment.Text.ShouldBe(" comment 24");
-            inputDef.Fields.Items.Count.ShouldBe(1);
-            inputDef.Fields.Items[0].Name.Value.ShouldBe("Value");
-            inputDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
-            inputDef.Fields.Items[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
+            inputDef.Fields.Count.ShouldBe(1);
+            inputDef.Fields[0].Name.Value.ShouldBe("Value");
+            inputDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
+            inputDef.Fields[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
             if (parseComments)
-                inputDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 26");
+                inputDef.Fields[0].Comment.Text.ShouldBe(" comment 26");
 
             var directiveDef = defs.Single(x => x is GraphQLDirectiveDefinition) as GraphQLDirectiveDefinition;
             directiveDef.Name.Value.ShouldBe("TestDirective");
             directiveDef.Description.Value.ShouldBe("Test directive");
             if (parseComments)
                 directiveDef.Comment.Text.ShouldBe(" comment 28");
-            directiveDef.Arguments.Items.Count.ShouldBe(1);
-            directiveDef.Arguments.Items[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments.Items[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.Count.ShouldBe(1);
+            directiveDef.Arguments[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments[0].Description.Value.ShouldBe("Example");
             if (parseComments)
-                directiveDef.Arguments.Items[0].Comment.Text.ShouldBe(" comment 30");
+                directiveDef.Arguments[0].Comment.Text.ShouldBe(" comment 30");
         }
 
         [Theory]
@@ -1290,35 +1290,35 @@ directive @TestDirective (
             objectDef.Description.Value.ShouldBe("Human type");
             if (parseComments)
                 objectDef.Comment.Text.ShouldBe(" comment 4");
-            objectDef.Fields.Items.Count.ShouldBe(2);
-            objectDef.Fields.Items[0].Name.Value.ShouldBe("name");
-            objectDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            objectDef.Fields.Items[0].Description.Value.ShouldBe("Name of human");
+            objectDef.Fields.Count.ShouldBe(2);
+            objectDef.Fields[0].Name.Value.ShouldBe("name");
+            objectDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            objectDef.Fields[0].Description.Value.ShouldBe("Name of human");
             if (parseComments)
-                objectDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 6");
-            objectDef.Fields.Items[1].Name.Value.ShouldBe("test");
-            objectDef.Fields.Items[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            objectDef.Fields.Items[1].Description.Value.ShouldBe("Test");
+                objectDef.Fields[0].Comment.Text.ShouldBe(" comment 6");
+            objectDef.Fields[1].Name.Value.ShouldBe("test");
+            objectDef.Fields[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Description.Value.ShouldBe("Test");
             if (parseComments)
-                objectDef.Fields.Items[1].Comment.Text.ShouldBe(" comment 8");
-            objectDef.Fields.Items[1].Arguments.Items.Count.ShouldBe(1);
-            objectDef.Fields.Items[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields.Items[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields.Items[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+                objectDef.Fields[1].Comment.Text.ShouldBe(" comment 8");
+            objectDef.Fields[1].Arguments.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields.Items[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 10");
+                objectDef.Fields[1].Arguments[0].Comment.Text.ShouldBe(" comment 10");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
             interfaceDef.Description.Value.ShouldBe("Test interface");
             if (parseComments)
                 interfaceDef.Comment.Text.ShouldBe(" comment 12");
-            interfaceDef.Fields.Items.Count.ShouldBe(1);
-            interfaceDef.Fields.Items[0].Name.Value.ShouldBe("name");
-            interfaceDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            interfaceDef.Fields.Items[0].Description.Value.ShouldBe("Object name");
+            interfaceDef.Fields.Count.ShouldBe(1);
+            interfaceDef.Fields[0].Name.Value.ShouldBe("name");
+            interfaceDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            interfaceDef.Fields[0].Description.Value.ShouldBe("Object name");
             if (parseComments)
-                interfaceDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 14");
+                interfaceDef.Fields[0].Comment.Text.ShouldBe(" comment 14");
 
             var unionDef = defs.Single(x => x is GraphQLUnionTypeDefinition) as GraphQLUnionTypeDefinition;
             unionDef.Name.Value.ShouldBe("TestUnion");
@@ -1334,39 +1334,39 @@ directive @TestDirective (
             enumDef.Description.Value.ShouldBe("Example enum");
             if (parseComments)
                 enumDef.Comment.Text.ShouldBe(" comment 18");
-            enumDef.Values.Items.Count.ShouldBe(2);
-            enumDef.Values.Items[0].Name.Value.ShouldBe("RED");
-            enumDef.Values.Items[0].Description.Value.ShouldBe("Red");
+            enumDef.Values.Count.ShouldBe(2);
+            enumDef.Values[0].Name.Value.ShouldBe("RED");
+            enumDef.Values[0].Description.Value.ShouldBe("Red");
             if (parseComments)
-                enumDef.Values.Items[0].Comment.Text.ShouldBe(" comment 20");
-            enumDef.Values.Items[1].Name.Value.ShouldBe("BLUE");
-            enumDef.Values.Items[1].Description.Value.ShouldBe("Blue");
+                enumDef.Values[0].Comment.Text.ShouldBe(" comment 20");
+            enumDef.Values[1].Name.Value.ShouldBe("BLUE");
+            enumDef.Values[1].Description.Value.ShouldBe("Blue");
             if (parseComments)
-                enumDef.Values.Items[1].Comment.Text.ShouldBe(" comment 22");
+                enumDef.Values[1].Comment.Text.ShouldBe(" comment 22");
 
             var inputDef = defs.Single(x => x is GraphQLInputObjectTypeDefinition) as GraphQLInputObjectTypeDefinition;
             inputDef.Name.Value.ShouldBe("TestInputObject");
             inputDef.Description.Value.ShouldBe("This is an example input object\nLine two of the description");
             if (parseComments)
                 inputDef.Comment.Text.ShouldBe(" comment 24");
-            inputDef.Fields.Items.Count.ShouldBe(1);
-            inputDef.Fields.Items[0].Name.Value.ShouldBe("Value");
-            inputDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
-            inputDef.Fields.Items[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
+            inputDef.Fields.Count.ShouldBe(1);
+            inputDef.Fields[0].Name.Value.ShouldBe("Value");
+            inputDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
+            inputDef.Fields[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
             if (parseComments)
-                inputDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 26");
+                inputDef.Fields[0].Comment.Text.ShouldBe(" comment 26");
 
             var directiveDef = defs.Single(x => x is GraphQLDirectiveDefinition) as GraphQLDirectiveDefinition;
             directiveDef.Name.Value.ShouldBe("TestDirective");
             directiveDef.Description.Value.ShouldBe("Test directive");
             if (parseComments)
                 directiveDef.Comment.Text.ShouldBe(" comment 28");
-            directiveDef.Arguments.Items.Count.ShouldBe(1);
-            directiveDef.Arguments.Items[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments.Items[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.Count.ShouldBe(1);
+            directiveDef.Arguments[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments[0].Description.Value.ShouldBe("Example");
             if (parseComments)
-                directiveDef.Arguments.Items[0].Comment.Text.ShouldBe(" comment 30");
+                directiveDef.Arguments[0].Comment.Text.ShouldBe(" comment 30");
         }
 
         [Theory]
@@ -1474,35 +1474,35 @@ directive @TestDirective (
             objectDef.Description.Value.ShouldBe("Human type");
             if (parseComments)
                 objectDef.Comment.Text.ShouldBe(" comment 3");
-            objectDef.Fields.Items.Count.ShouldBe(2);
-            objectDef.Fields.Items[0].Name.Value.ShouldBe("name");
-            objectDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            objectDef.Fields.Items[0].Description.Value.ShouldBe("Name of human");
+            objectDef.Fields.Count.ShouldBe(2);
+            objectDef.Fields[0].Name.Value.ShouldBe("name");
+            objectDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            objectDef.Fields[0].Description.Value.ShouldBe("Name of human");
             if (parseComments)
-                objectDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 5");
-            objectDef.Fields.Items[1].Name.Value.ShouldBe("test");
-            objectDef.Fields.Items[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            objectDef.Fields.Items[1].Description.Value.ShouldBe("Test");
+                objectDef.Fields[0].Comment.Text.ShouldBe(" comment 5");
+            objectDef.Fields[1].Name.Value.ShouldBe("test");
+            objectDef.Fields[1].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            objectDef.Fields[1].Description.Value.ShouldBe("Test");
             if (parseComments)
-                objectDef.Fields.Items[1].Comment.Text.ShouldBe(" comment 7");
-            objectDef.Fields.Items[1].Arguments.Items.Count.ShouldBe(1);
-            objectDef.Fields.Items[1].Arguments.Items[0].Name.Value.ShouldBe("arg");
-            objectDef.Fields.Items[1].Arguments.Items[0].Description.Value.ShouldBe("desc");
-            objectDef.Fields.Items[1].Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+                objectDef.Fields[1].Comment.Text.ShouldBe(" comment 7");
+            objectDef.Fields[1].Arguments.Count.ShouldBe(1);
+            objectDef.Fields[1].Arguments[0].Name.Value.ShouldBe("arg");
+            objectDef.Fields[1].Arguments[0].Description.Value.ShouldBe("desc");
+            objectDef.Fields[1].Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
             if (parseComments)
-                objectDef.Fields.Items[1].Arguments.Items[0].Comment.Text.ShouldBe(" comment 9");
+                objectDef.Fields[1].Arguments[0].Comment.Text.ShouldBe(" comment 9");
 
             var interfaceDef = defs.Single(x => x is GraphQLInterfaceTypeDefinition) as GraphQLInterfaceTypeDefinition;
             interfaceDef.Name.Value.ShouldBe("TestInterface");
             interfaceDef.Description.Value.ShouldBe("Test interface");
             if (parseComments)
                 interfaceDef.Comment.Text.ShouldBe(" comment 11");
-            interfaceDef.Fields.Items.Count.ShouldBe(1);
-            interfaceDef.Fields.Items[0].Name.Value.ShouldBe("name");
-            interfaceDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
-            interfaceDef.Fields.Items[0].Description.Value.ShouldBe("Object name");
+            interfaceDef.Fields.Count.ShouldBe(1);
+            interfaceDef.Fields[0].Name.Value.ShouldBe("name");
+            interfaceDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("String");
+            interfaceDef.Fields[0].Description.Value.ShouldBe("Object name");
             if (parseComments)
-                interfaceDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 13");
+                interfaceDef.Fields[0].Comment.Text.ShouldBe(" comment 13");
 
             var unionDef = defs.Single(x => x is GraphQLUnionTypeDefinition) as GraphQLUnionTypeDefinition;
             unionDef.Name.Value.ShouldBe("TestUnion");
@@ -1518,39 +1518,39 @@ directive @TestDirective (
             enumDef.Description.Value.ShouldBe("Example enum");
             if (parseComments)
                 enumDef.Comment.Text.ShouldBe(" comment 17");
-            enumDef.Values.Items.Count.ShouldBe(2);
-            enumDef.Values.Items[0].Name.Value.ShouldBe("RED");
-            enumDef.Values.Items[0].Description.Value.ShouldBe("Red");
+            enumDef.Values.Count.ShouldBe(2);
+            enumDef.Values[0].Name.Value.ShouldBe("RED");
+            enumDef.Values[0].Description.Value.ShouldBe("Red");
             if (parseComments)
-                enumDef.Values.Items[0].Comment.Text.ShouldBe(" comment 19");
-            enumDef.Values.Items[1].Name.Value.ShouldBe("BLUE");
-            enumDef.Values.Items[1].Description.Value.ShouldBe("Blue");
+                enumDef.Values[0].Comment.Text.ShouldBe(" comment 19");
+            enumDef.Values[1].Name.Value.ShouldBe("BLUE");
+            enumDef.Values[1].Description.Value.ShouldBe("Blue");
             if (parseComments)
-                enumDef.Values.Items[1].Comment.Text.ShouldBe(" comment 21");
+                enumDef.Values[1].Comment.Text.ShouldBe(" comment 21");
 
             var inputDef = defs.Single(x => x is GraphQLInputObjectTypeDefinition) as GraphQLInputObjectTypeDefinition;
             inputDef.Name.Value.ShouldBe("TestInputObject");
             inputDef.Description.Value.ShouldBe("This is an example input object\nLine two of the description");
             if (parseComments)
                 inputDef.Comment.Text.ShouldBe(" comment 23");
-            inputDef.Fields.Items.Count.ShouldBe(1);
-            inputDef.Fields.Items[0].Name.Value.ShouldBe("Value");
-            inputDef.Fields.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
-            inputDef.Fields.Items[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
+            inputDef.Fields.Count.ShouldBe(1);
+            inputDef.Fields[0].Name.Value.ShouldBe("Value");
+            inputDef.Fields[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("JSON");
+            inputDef.Fields[0].Description.Value.ShouldBe("The value of the input object\n  (any JSON value is accepted)");
             if (parseComments)
-                inputDef.Fields.Items[0].Comment.Text.ShouldBe(" comment 25");
+                inputDef.Fields[0].Comment.Text.ShouldBe(" comment 25");
 
             var directiveDef = defs.Single(x => x is GraphQLDirectiveDefinition) as GraphQLDirectiveDefinition;
             directiveDef.Name.Value.ShouldBe("TestDirective");
             directiveDef.Description.Value.ShouldBe("Test directive");
             if (parseComments)
                 directiveDef.Comment.Text.ShouldBe(" comment 27");
-            directiveDef.Arguments.Items.Count.ShouldBe(1);
-            directiveDef.Arguments.Items[0].Name.Value.ShouldBe("Value");
-            directiveDef.Arguments.Items[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
-            directiveDef.Arguments.Items[0].Description.Value.ShouldBe("Example");
+            directiveDef.Arguments.Count.ShouldBe(1);
+            directiveDef.Arguments[0].Name.Value.ShouldBe("Value");
+            directiveDef.Arguments[0].Type.ShouldBeAssignableTo<GraphQLNamedType>().Name.Value.ShouldBe("Int");
+            directiveDef.Arguments[0].Description.Value.ShouldBe("Example");
             if (parseComments)
-                directiveDef.Arguments.Items[0].Comment.Text.ShouldBe(" comment 29");
+                directiveDef.Arguments[0].Comment.Text.ShouldBe(" comment 29");
         }
     }
 }

--- a/src/GraphQLParser.Tests/Visitors/StructureWriterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/StructureWriterTests.cs
@@ -34,8 +34,9 @@ namespace GraphQLParser.Tests.Visitors
         [InlineData("scalar JSON @exportable", @"Document
   ScalarTypeDefinition
     Name [JSON]
-    Directive
-      Name [exportable]
+    Directives
+      Directive
+        Name [exportable]
 ")]
         public async Task WriteTreeVisitor_Should_Print_Tree(string text, string expected)
         {

--- a/src/GraphQLParser/AST/ASTListNode.cs
+++ b/src/GraphQLParser/AST/ASTListNode.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace GraphQLParser.AST
+{
+    /// <summary>
+    /// Represents a AST node that holds a list of other (nested) AST nodes.
+    /// </summary>
+    public abstract class ASTListNode<TNode> : ASTNode, IEnumerable<TNode>
+    {
+        /// <summary>
+        /// A list of nested AST nodes.
+        /// </summary>
+        public List<TNode> Items { get; set; } = null!;
+
+        /// <summary>
+        /// Get the number of AST nodes in the list.
+        /// </summary>
+        public int Count => Items.Count;
+
+        /// <summary>
+        /// Gets nested AST node by its index in the list.
+        /// </summary>
+        public TNode this[int index] => Items[index];
+
+        public IEnumerator<TNode> GetEnumerator() => Items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => Items.GetEnumerator();
+    }
+}

--- a/src/GraphQLParser/AST/ASTListNode.cs
+++ b/src/GraphQLParser/AST/ASTListNode.cs
@@ -6,7 +6,7 @@ namespace GraphQLParser.AST
     /// <summary>
     /// Represents a AST node that holds a list of other (nested) AST nodes.
     /// </summary>
-    public abstract class ASTListNode<TNode> : ASTNode, IEnumerable<TNode>
+    public abstract class ASTListNode<TNode> : ASTNode, IReadOnlyList<TNode>
     {
         /// <summary>
         /// A list of nested AST nodes.

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -125,7 +125,7 @@ namespace GraphQLParser.AST
         /// <summary>
         /// Boolean value. The two keywords true and false represent the two boolean values.
         /// <br/>
-        /// <see href="http://spec.graphql.org/October2021/#ObjectField"/>
+        /// <see href="http://spec.graphql.org/October2021/#BooleanValue"/>
         /// </summary>
         BooleanValue,
 
@@ -396,5 +396,14 @@ namespace GraphQLParser.AST
         /// <see href="http://spec.graphql.org/October2021/#InputObjectTypeExtension"/>
         /// </summary>
         InputObjectTypeExtension,
+
+        /// <summary>
+        /// Occasionally object fields/directives can accept arguments to further specify
+        /// the return value. Object field arguments are defined as a list of all possible
+        /// argument names and their expected input types.
+        /// <br/>
+        /// <see href="http://spec.graphql.org/October2021/#ArgumentsDefinition"/>
+        /// </summary>
+        ArgumentsDefinition,
     }
 }

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -430,5 +430,13 @@ namespace GraphQLParser.AST
         /// <see href="http://spec.graphql.org/October2021/#VariableDefinitions"/>
         /// </summary>
         VariablesDefinition, // https://github.com/graphql/graphql-spec/issues/915
+
+        /// <summary>
+        /// GraphQL Enum types, like Scalar types, also represent leaf values in
+        /// a GraphQL type system. However Enum types describe the set of possible values.
+        /// <br/>
+        /// <see href="http://spec.graphql.org/October2021/#EnumValuesDefinition"/>
+        /// </summary>
+        EnumValuesDefinition
     }
 }

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -411,6 +411,8 @@ namespace GraphQLParser.AST
         /// accept arguments which alter their behavior.
         /// <br/>
         /// <see href="http://spec.graphql.org/October2021/#Arguments"/>
+        /// <br/>
+        /// This node represents a list of <see cref="Argument"/>.
         /// </summary>
         Arguments,
 
@@ -420,6 +422,8 @@ namespace GraphQLParser.AST
         /// to accept arbitrarily complex structs.
         /// <br/>
         /// <see href="http://spec.graphql.org/October2021/#InputFieldsDefinition"/>
+        /// <br/>
+        /// This node represents a list of <see cref="InputValueDefinition"/>.
         /// </summary>
         InputFieldsDefinition,
 
@@ -428,14 +432,18 @@ namespace GraphQLParser.AST
         /// and avoiding costly string building in clients at runtime.
         /// <br/>
         /// <see href="http://spec.graphql.org/October2021/#VariableDefinitions"/>
+        /// <br/>
+        /// This node represents a list of <see cref="VariableDefinition"/>.
         /// </summary>
-        VariablesDefinition, // https://github.com/graphql/graphql-spec/issues/915
+        VariablesDefinition, // TODO: https://github.com/graphql/graphql-spec/issues/915
 
         /// <summary>
         /// GraphQL Enum types, like Scalar types, also represent leaf values in
         /// a GraphQL type system. However Enum types describe the set of possible values.
         /// <br/>
         /// <see href="http://spec.graphql.org/October2021/#EnumValuesDefinition"/>
+        /// <br/>
+        /// This node represents a list of <see cref="EnumValueDefinition"/>.
         /// </summary>
         EnumValuesDefinition,
 
@@ -444,7 +452,20 @@ namespace GraphQLParser.AST
         /// each of which yield a value of a specific type.
         /// <br/>
         /// <see href="http://spec.graphql.org/October2021/#FieldsDefinition"/>
+        /// <br/>
+        /// This node represents a list of <see cref="FieldDefinition"/>.
         /// </summary>
-        FieldsDefinition
+        FieldsDefinition,
+
+        /// <summary>
+        /// Applied directive. Directives provide a way to describe alternate runtime execution
+        /// and type validation behavior in a GraphQL document. Directives can be used to describe
+        /// additional information for types, fields, fragments, operations, etc.
+        /// <br/>
+        /// <see href="http://spec.graphql.org/October2021/#Directives"/>
+        /// <br/>
+        /// This node represents a list of <see cref="Directive"/>.
+        /// </summary>
+        Directives
     }
 }

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -437,6 +437,14 @@ namespace GraphQLParser.AST
         /// <br/>
         /// <see href="http://spec.graphql.org/October2021/#EnumValuesDefinition"/>
         /// </summary>
-        EnumValuesDefinition
+        EnumValuesDefinition,
+
+        /// <summary>
+        /// GraphQL Objects represent a list of named fields,
+        /// each of which yield a value of a specific type.
+        /// <br/>
+        /// <see href="http://spec.graphql.org/October2021/#FieldsDefinition"/>
+        /// </summary>
+        FieldsDefinition
     }
 }

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -412,6 +412,15 @@ namespace GraphQLParser.AST
         /// <br/>
         /// <see href="http://spec.graphql.org/October2021/#Arguments"/>
         /// </summary>
-        Arguments
+        Arguments,
+
+        /// <summary>
+        /// A GraphQL Input Object defines a set of input fields; the input fields
+        /// are either scalars, enums, or other input objects. This allows arguments
+        /// to accept arbitrarily complex structs.
+        /// <br/>
+        /// <see href="http://spec.graphql.org/October2021/#InputFieldsDefinition"/>
+        /// </summary>
+        InputFieldsDefinition
     }
 }

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -421,6 +421,14 @@ namespace GraphQLParser.AST
         /// <br/>
         /// <see href="http://spec.graphql.org/October2021/#InputFieldsDefinition"/>
         /// </summary>
-        InputFieldsDefinition
+        InputFieldsDefinition,
+
+        /// <summary>
+        /// A GraphQL operation can be parameterized with variables, maximizing reuse,
+        /// and avoiding costly string building in clients at runtime.
+        /// <br/>
+        /// <see href="http://spec.graphql.org/October2021/#VariableDefinitions"/>
+        /// </summary>
+        VariablesDefinition, // https://github.com/graphql/graphql-spec/issues/915
     }
 }

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -405,5 +405,13 @@ namespace GraphQLParser.AST
         /// <see href="http://spec.graphql.org/October2021/#ArgumentsDefinition"/>
         /// </summary>
         ArgumentsDefinition,
+
+        /// <summary>
+        /// Fields are conceptually functions which return values, and occasionally
+        /// accept arguments which alter their behavior.
+        /// <br/>
+        /// <see href="http://spec.graphql.org/October2021/#Arguments"/>
+        /// </summary>
+        Arguments
     }
 }

--- a/src/GraphQLParser/AST/ASTNodeKind.cs
+++ b/src/GraphQLParser/AST/ASTNodeKind.cs
@@ -466,6 +466,15 @@ namespace GraphQLParser.AST
         /// <br/>
         /// This node represents a list of <see cref="Directive"/>.
         /// </summary>
-        Directives
+        Directives,
+
+        /// <summary>
+        /// A list of implemented interfaces.
+        /// <br/>
+        /// <see href="http://spec.graphql.org/October2021/#ImplementsInterfaces"/>
+        /// <br/>
+        /// This node represents a list of <see cref="NamedType"/>.
+        /// </summary>
+        ImplementsInterfaces
     }
 }

--- a/src/GraphQLParser/AST/GraphQLArguments.cs
+++ b/src/GraphQLParser/AST/GraphQLArguments.cs
@@ -1,23 +1,22 @@
+using System.Collections.Generic;
+
 namespace GraphQLParser.AST
 {
     /// <summary>
-    /// AST node for <see cref="ASTNodeKind.Directive"/>.
+    /// AST node for <see cref="ASTNodeKind.Arguments"/>.
     /// </summary>
-    public class GraphQLDirective : ASTNode, INamedNode, IHasArgumentsNode
+    public class GraphQLArguments : ASTNode
     {
         /// <inheritdoc/>
-        public override ASTNodeKind Kind => ASTNodeKind.Directive;
-
-        /// <inheritdoc/>
-        public GraphQLName? Name { get; set; }
+        public override ASTNodeKind Kind => ASTNodeKind.Arguments;
 
         /// <summary>
-        /// Arguments for this directive.
+        /// List of arguments for this node.
         /// </summary>
-        public GraphQLArguments? Arguments { get; set; }
+        public List<GraphQLArgument> Items { get; set; } = null!;
     }
 
-    internal sealed class GraphQLDirectiveWithLocation : GraphQLDirective
+    internal sealed class GraphQLArgumentsWithLocation : GraphQLArguments
     {
         private GraphQLLocation _location;
 
@@ -28,7 +27,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLDirectiveWithComment : GraphQLDirective
+    internal sealed class GraphQLArgumentsWithComment : GraphQLArguments
     {
         private GraphQLComment? _comment;
 
@@ -39,7 +38,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLDirectiveFull : GraphQLDirective
+    internal sealed class GraphQLArgumentsFull : GraphQLArguments
     {
         private GraphQLLocation _location;
         private GraphQLComment? _comment;

--- a/src/GraphQLParser/AST/GraphQLArguments.cs
+++ b/src/GraphQLParser/AST/GraphQLArguments.cs
@@ -1,19 +1,12 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.Arguments"/>.
     /// </summary>
-    public class GraphQLArguments : ASTNode
+    public class GraphQLArguments : ASTListNode<GraphQLArgument>
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.Arguments;
-
-        /// <summary>
-        /// List of arguments for this node.
-        /// </summary>
-        public List<GraphQLArgument> Items { get; set; } = null!;
     }
 
     internal sealed class GraphQLArgumentsWithLocation : GraphQLArguments

--- a/src/GraphQLParser/AST/GraphQLArgumentsDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLArgumentsDefinition.cs
@@ -1,19 +1,12 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.ArgumentsDefinition"/>.
     /// </summary>
-    public class GraphQLArgumentsDefinition : ASTNode
+    public class GraphQLArgumentsDefinition : ASTListNode<GraphQLInputValueDefinition>
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.ArgumentsDefinition;
-
-        /// <summary>
-        /// List of arguments definitions for this node.
-        /// </summary>
-        public List<GraphQLInputValueDefinition> Items { get; set; } = null!;
     }
 
     internal sealed class GraphQLArgumentsDefinitionWithLocation : GraphQLArgumentsDefinition

--- a/src/GraphQLParser/AST/GraphQLArgumentsDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLArgumentsDefinition.cs
@@ -3,25 +3,20 @@ using System.Collections.Generic;
 namespace GraphQLParser.AST
 {
     /// <summary>
-    /// AST node for <see cref="ASTNodeKind.FieldDefinition"/>.
+    /// AST node for <see cref="ASTNodeKind.ArgumentsDefinition"/>.
     /// </summary>
-    public class GraphQLFieldDefinition : GraphQLTypeDefinition, IHasDirectivesNode, IHasArgumentsDefinitionNode
+    public class GraphQLArgumentsDefinition : ASTNode
     {
         /// <inheritdoc/>
-        public override ASTNodeKind Kind => ASTNodeKind.FieldDefinition;
+        public override ASTNodeKind Kind => ASTNodeKind.ArgumentsDefinition;
 
         /// <summary>
-        /// Arguments for this field definition.
+        /// List of arguments definitions for this node.
         /// </summary>
-        public GraphQLArgumentsDefinition? Arguments { get; set; }
-
-        public GraphQLType? Type { get; set; }
-
-        /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public List<GraphQLInputValueDefinition> InputValueDefinitions { get; set; } = null!;
     }
 
-    internal sealed class GraphQLFieldDefinitionWithLocation : GraphQLFieldDefinition
+    internal sealed class GraphQLArgumentsDefinitionWithLocation : GraphQLArgumentsDefinition
     {
         private GraphQLLocation _location;
 
@@ -32,7 +27,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLFieldDefinitionWithComment : GraphQLFieldDefinition
+    internal sealed class GraphQLArgumentsDefinitionWithComment : GraphQLArgumentsDefinition
     {
         private GraphQLComment? _comment;
 
@@ -43,7 +38,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLFieldDefinitionFull : GraphQLFieldDefinition
+    internal sealed class GraphQLArgumentsDefinitionFull : GraphQLArgumentsDefinition
     {
         private GraphQLLocation _location;
         private GraphQLComment? _comment;

--- a/src/GraphQLParser/AST/GraphQLArgumentsDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLArgumentsDefinition.cs
@@ -13,7 +13,7 @@ namespace GraphQLParser.AST
         /// <summary>
         /// List of arguments definitions for this node.
         /// </summary>
-        public List<GraphQLInputValueDefinition> InputValueDefinitions { get; set; } = null!;
+        public List<GraphQLInputValueDefinition> Items { get; set; } = null!;
     }
 
     internal sealed class GraphQLArgumentsDefinitionWithLocation : GraphQLArgumentsDefinition

--- a/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLDirectiveDefinition.cs
@@ -5,15 +5,15 @@ namespace GraphQLParser.AST
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.DirectiveDefinition"/>.
     /// </summary>
-    public class GraphQLDirectiveDefinition : GraphQLTypeDefinition
+    public class GraphQLDirectiveDefinition : GraphQLTypeDefinition, IHasArgumentsDefinitionNode
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.DirectiveDefinition;
 
         /// <summary>
-        /// List of arguments for this directive definition.
+        /// Arguments for this directive definition.
         /// </summary>
-        public List<GraphQLInputValueDefinition>? Arguments { get; set; }
+        public GraphQLArgumentsDefinition? Arguments { get; set; }
 
         /// <summary>
         /// Indicates if the directive may be used repeatedly at a single location.

--- a/src/GraphQLParser/AST/GraphQLDirectives.cs
+++ b/src/GraphQLParser/AST/GraphQLDirectives.cs
@@ -1,21 +1,19 @@
+using System.Collections.Generic;
+
 namespace GraphQLParser.AST
 {
     /// <summary>
-    /// AST node for <see cref="ASTNodeKind.FragmentSpread"/>.
+    /// AST node for <see cref="ASTNodeKind.Directives"/>.
     /// </summary>
-    public class GraphQLFragmentSpread : ASTNode, IHasDirectivesNode, INamedNode
+    public class GraphQLDirectives : ASTNode
     {
         /// <inheritdoc/>
-        public override ASTNodeKind Kind => ASTNodeKind.FragmentSpread;
+        public override ASTNodeKind Kind => ASTNodeKind.Directives;
 
-        /// <inheritdoc/>
-        public GraphQLName? Name { get; set; }
-
-        /// <inheritdoc/>
-        public GraphQLDirectives? Directives { get; set; }
+        public List<GraphQLDirective> Items { get; set; } = null!;
     }
 
-    internal sealed class GraphQLFragmentSpreadWithLocation : GraphQLFragmentSpread
+    internal sealed class GraphQLDirectivesWithLocation : GraphQLDirectives
     {
         private GraphQLLocation _location;
 
@@ -26,7 +24,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLFragmentSpreadWithComment : GraphQLFragmentSpread
+    internal sealed class GraphQLDirectivesWithComment : GraphQLDirectives
     {
         private GraphQLComment? _comment;
 
@@ -37,7 +35,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLFragmentSpreadFull : GraphQLFragmentSpread
+    internal sealed class GraphQLDirectivesFull : GraphQLDirectives
     {
         private GraphQLLocation _location;
         private GraphQLComment? _comment;

--- a/src/GraphQLParser/AST/GraphQLDirectives.cs
+++ b/src/GraphQLParser/AST/GraphQLDirectives.cs
@@ -1,16 +1,12 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.Directives"/>.
     /// </summary>
-    public class GraphQLDirectives : ASTNode
+    public class GraphQLDirectives : ASTListNode<GraphQLDirective>
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.Directives;
-
-        public List<GraphQLDirective> Items { get; set; } = null!;
     }
 
     internal sealed class GraphQLDirectivesWithLocation : GraphQLDirectives

--- a/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
@@ -13,7 +13,7 @@ namespace GraphQLParser.AST
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }
 
-        public List<GraphQLEnumValueDefinition>? Values { get; set; }
+        public GraphQLEnumValuesDefinition? Values { get; set; }
     }
 
     internal sealed class GraphQLEnumTypeDefinitionWithLocation : GraphQLEnumTypeDefinition

--- a/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumTypeDefinition.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -11,7 +9,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.EnumTypeDefinition;
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLEnumValuesDefinition? Values { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLEnumTypeExtension.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumTypeExtension.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -11,7 +9,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.EnumTypeExtension;
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLEnumValuesDefinition? Values { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumValueDefinition.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -11,7 +9,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.EnumValueDefinition;
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
     }
 
     internal sealed class GraphQLEnumValueDefinitionWithLocation : GraphQLEnumValueDefinition

--- a/src/GraphQLParser/AST/GraphQLEnumValuesDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumValuesDefinition.cs
@@ -1,16 +1,12 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.EnumValuesDefinition"/>.
     /// </summary>
-    public class GraphQLEnumValuesDefinition : ASTNode
+    public class GraphQLEnumValuesDefinition : ASTListNode<GraphQLEnumValueDefinition>
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.EnumValuesDefinition;
-
-        public List<GraphQLEnumValueDefinition> Items { get; set; } = null!;
     }
 
     internal sealed class GraphQLEnumValuesDefinitionWithLocation : GraphQLEnumValuesDefinition

--- a/src/GraphQLParser/AST/GraphQLEnumValuesDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLEnumValuesDefinition.cs
@@ -3,20 +3,17 @@ using System.Collections.Generic;
 namespace GraphQLParser.AST
 {
     /// <summary>
-    /// AST node for <see cref="ASTNodeKind.EnumTypeExtension"/>.
+    /// AST node for <see cref="ASTNodeKind.EnumValuesDefinition"/>.
     /// </summary>
-    public class GraphQLEnumTypeExtension : GraphQLTypeExtension, IHasDirectivesNode
+    public class GraphQLEnumValuesDefinition : ASTNode
     {
         /// <inheritdoc/>
-        public override ASTNodeKind Kind => ASTNodeKind.EnumTypeExtension;
+        public override ASTNodeKind Kind => ASTNodeKind.EnumValuesDefinition;
 
-        /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
-
-        public GraphQLEnumValuesDefinition? Values { get; set; }
+        public List<GraphQLEnumValueDefinition> Items { get; set; } = null!;
     }
 
-    internal sealed class GraphQLEnumTypeExtensionWithLocation : GraphQLEnumTypeExtension
+    internal sealed class GraphQLEnumValuesDefinitionWithLocation : GraphQLEnumValuesDefinition
     {
         private GraphQLLocation _location;
 
@@ -27,7 +24,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLEnumTypeExtensionWithComment : GraphQLEnumTypeExtension
+    internal sealed class GraphQLEnumValuesDefinitionWithComment : GraphQLEnumValuesDefinition
     {
         private GraphQLComment? _comment;
 
@@ -38,7 +35,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLEnumTypeExtensionFull : GraphQLEnumTypeExtension
+    internal sealed class GraphQLEnumValuesDefinitionFull : GraphQLEnumValuesDefinition
     {
         private GraphQLLocation _location;
         private GraphQLComment? _comment;

--- a/src/GraphQLParser/AST/GraphQLField.cs
+++ b/src/GraphQLParser/AST/GraphQLField.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -21,7 +19,7 @@ namespace GraphQLParser.AST
         public GraphQLArguments? Arguments { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLSelectionSet? SelectionSet { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLField.cs
+++ b/src/GraphQLParser/AST/GraphQLField.cs
@@ -15,7 +15,10 @@ namespace GraphQLParser.AST
         /// <inheritdoc/>
         public GraphQLName? Name { get; set; }
 
-        public List<GraphQLArgument>? Arguments { get; set; }
+        /// <summary>
+        /// Arguments for this field.
+        /// </summary>
+        public GraphQLArguments? Arguments { get; set; }
 
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldDefinition.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -18,7 +16,7 @@ namespace GraphQLParser.AST
         public GraphQLType? Type { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
     }
 
     internal sealed class GraphQLFieldDefinitionWithLocation : GraphQLFieldDefinition

--- a/src/GraphQLParser/AST/GraphQLFieldsDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldsDefinition.cs
@@ -1,16 +1,12 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.FieldsDefinition"/>.
     /// </summary>
-    public class GraphQLFieldsDefinition : ASTNode
+    public class GraphQLFieldsDefinition : ASTListNode<GraphQLFieldDefinition>
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.FieldsDefinition;
-
-        public List<GraphQLFieldDefinition> Items { get; set; } = null!;
     }
 
     internal sealed class GraphQLFieldsDefinitionWithLocation : GraphQLFieldsDefinition

--- a/src/GraphQLParser/AST/GraphQLFieldsDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLFieldsDefinition.cs
@@ -3,23 +3,17 @@ using System.Collections.Generic;
 namespace GraphQLParser.AST
 {
     /// <summary>
-    /// AST node for <see cref="ASTNodeKind.ObjectTypeDefinition"/>.
+    /// AST node for <see cref="ASTNodeKind.FieldsDefinition"/>.
     /// </summary>
-    public class GraphQLObjectTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, IHasInterfacesNode, IHasFieldsDefinitionNode
+    public class GraphQLFieldsDefinition : ASTNode
     {
         /// <inheritdoc/>
-        public override ASTNodeKind Kind => ASTNodeKind.ObjectTypeDefinition;
+        public override ASTNodeKind Kind => ASTNodeKind.FieldsDefinition;
 
-        /// <inheritdoc />
-        public List<GraphQLNamedType>? Interfaces { get; set; }
-
-        /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
-
-        public GraphQLFieldsDefinition? Fields { get; set; }
+        public List<GraphQLFieldDefinition> Items { get; set; } = null!;
     }
 
-    internal sealed class GraphQLObjectTypeDefinitionWithLocation : GraphQLObjectTypeDefinition
+    internal sealed class GraphQLFieldsDefinitionWithLocation : GraphQLFieldsDefinition
     {
         private GraphQLLocation _location;
 
@@ -30,7 +24,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLObjectTypeDefinitionWithComment : GraphQLObjectTypeDefinition
+    internal sealed class GraphQLFieldsDefinitionWithComment : GraphQLFieldsDefinition
     {
         private GraphQLComment? _comment;
 
@@ -41,7 +35,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLObjectTypeDefinitionFull : GraphQLObjectTypeDefinition
+    internal sealed class GraphQLFieldsDefinitionFull : GraphQLFieldsDefinition
     {
         private GraphQLLocation _location;
         private GraphQLComment? _comment;

--- a/src/GraphQLParser/AST/GraphQLImplementsInterfaces.cs
+++ b/src/GraphQLParser/AST/GraphQLImplementsInterfaces.cs
@@ -1,16 +1,12 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.ImplementsInterfaces"/>.
     /// </summary>
-    public class GraphQLImplementsInterfaces : ASTNode
+    public class GraphQLImplementsInterfaces : ASTListNode<GraphQLNamedType>
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.ImplementsInterfaces;
-
-        public List<GraphQLNamedType> Items { get; set; } = null!;
     }
 
     internal sealed class GraphQLImplementsInterfacesWithLocation : GraphQLImplementsInterfaces

--- a/src/GraphQLParser/AST/GraphQLImplementsInterfaces.cs
+++ b/src/GraphQLParser/AST/GraphQLImplementsInterfaces.cs
@@ -1,22 +1,19 @@
+using System.Collections.Generic;
+
 namespace GraphQLParser.AST
 {
     /// <summary>
-    /// AST node for <see cref="ASTNodeKind.InterfaceTypeExtension"/>.
+    /// AST node for <see cref="ASTNodeKind.ImplementsInterfaces"/>.
     /// </summary>
-    public class GraphQLInterfaceTypeExtension : GraphQLTypeExtension, IHasDirectivesNode, IHasInterfacesNode, IHasFieldsDefinitionNode
+    public class GraphQLImplementsInterfaces : ASTNode
     {
         /// <inheritdoc/>
-        public override ASTNodeKind Kind => ASTNodeKind.InterfaceTypeExtension;
+        public override ASTNodeKind Kind => ASTNodeKind.ImplementsInterfaces;
 
-        public GraphQLImplementsInterfaces? Interfaces { get; set; }
-
-        /// <inheritdoc/>
-        public GraphQLDirectives? Directives { get; set; }
-
-        public GraphQLFieldsDefinition? Fields { get; set; }
+        public List<GraphQLNamedType> Items { get; set; } = null!;
     }
 
-    internal sealed class GraphQLInterfaceTypeExtensionWithLocation : GraphQLInterfaceTypeExtension
+    internal sealed class GraphQLImplementsInterfacesWithLocation : GraphQLImplementsInterfaces
     {
         private GraphQLLocation _location;
 
@@ -27,7 +24,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLInterfaceTypeExtensionWithComment : GraphQLInterfaceTypeExtension
+    internal sealed class GraphQLImplementsInterfacesWithComment : GraphQLImplementsInterfaces
     {
         private GraphQLComment? _comment;
 
@@ -38,7 +35,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLInterfaceTypeExtensionFull : GraphQLInterfaceTypeExtension
+    internal sealed class GraphQLImplementsInterfacesFull : GraphQLImplementsInterfaces
     {
         private GraphQLLocation _location;
         private GraphQLComment? _comment;

--- a/src/GraphQLParser/AST/GraphQLInlineFragment.cs
+++ b/src/GraphQLParser/AST/GraphQLInlineFragment.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -13,7 +11,7 @@ namespace GraphQLParser.AST
         public GraphQLTypeCondition? TypeCondition { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLSelectionSet? SelectionSet { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLInputFieldsDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputFieldsDefinition.cs
@@ -3,20 +3,20 @@ using System.Collections.Generic;
 namespace GraphQLParser.AST
 {
     /// <summary>
-    /// AST node for <see cref="ASTNodeKind.InputObjectTypeExtension"/>.
+    /// AST node for <see cref="ASTNodeKind.InputFieldsDefinition"/>.
     /// </summary>
-    public class GraphQLInputObjectTypeExtension : GraphQLTypeExtension, IHasDirectivesNode
+    public class GraphQLInputFieldsDefinition : ASTNode
     {
         /// <inheritdoc/>
-        public override ASTNodeKind Kind => ASTNodeKind.InputObjectTypeExtension;
+        public override ASTNodeKind Kind => ASTNodeKind.InputFieldsDefinition;
 
-        /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
-
-        public GraphQLInputFieldsDefinition? Fields { get; set; }
+        /// <summary>
+        /// List of arguments definitions for this node.
+        /// </summary>
+        public List<GraphQLInputValueDefinition> Items { get; set; } = null!;
     }
 
-    internal sealed class GraphQLInputObjectTypeExtensionWithLocation : GraphQLInputObjectTypeExtension
+    internal sealed class GraphQLInputFieldsDefinitionWithLocation : GraphQLInputFieldsDefinition
     {
         private GraphQLLocation _location;
 
@@ -27,7 +27,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLInputObjectTypeExtensionWithComment : GraphQLInputObjectTypeExtension
+    internal sealed class GraphQLInputFieldsDefinitionWithComment : GraphQLInputFieldsDefinition
     {
         private GraphQLComment? _comment;
 
@@ -38,7 +38,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLInputObjectTypeExtensionFull : GraphQLInputObjectTypeExtension
+    internal sealed class GraphQLInputFieldsDefinitionFull : GraphQLInputFieldsDefinition
     {
         private GraphQLLocation _location;
         private GraphQLComment? _comment;

--- a/src/GraphQLParser/AST/GraphQLInputFieldsDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputFieldsDefinition.cs
@@ -1,19 +1,12 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.InputFieldsDefinition"/>.
     /// </summary>
-    public class GraphQLInputFieldsDefinition : ASTNode
+    public class GraphQLInputFieldsDefinition : ASTListNode<GraphQLInputValueDefinition>
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.InputFieldsDefinition;
-
-        /// <summary>
-        /// List of arguments definitions for this node.
-        /// </summary>
-        public List<GraphQLInputValueDefinition> Items { get; set; } = null!;
     }
 
     internal sealed class GraphQLInputFieldsDefinitionWithLocation : GraphQLInputFieldsDefinition

--- a/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -11,7 +9,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.InputObjectTypeDefinition;
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLInputFieldsDefinition? Fields { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputObjectTypeDefinition.cs
@@ -13,7 +13,7 @@ namespace GraphQLParser.AST
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }
 
-        public List<GraphQLInputValueDefinition>? Fields { get; set; }
+        public GraphQLInputFieldsDefinition? Fields { get; set; }
     }
 
     internal sealed class GraphQLInputObjectTypeDefinitionWithLocation : GraphQLInputObjectTypeDefinition

--- a/src/GraphQLParser/AST/GraphQLInputObjectTypeExtension.cs
+++ b/src/GraphQLParser/AST/GraphQLInputObjectTypeExtension.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -11,7 +9,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.InputObjectTypeExtension;
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLInputFieldsDefinition? Fields { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInputValueDefinition.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -15,7 +13,7 @@ namespace GraphQLParser.AST
         public GraphQLValue? DefaultValue { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
     }
 
     internal sealed class GraphQLInputValueDefinitionWithLocation : GraphQLInputValueDefinition

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
@@ -13,7 +13,7 @@ namespace GraphQLParser.AST
         public List<GraphQLNamedType>? Interfaces { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLFieldsDefinition? Fields { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -10,7 +8,7 @@ namespace GraphQLParser.AST
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.InterfaceTypeDefinition;
 
-        public List<GraphQLNamedType>? Interfaces { get; set; }
+        public GraphQLImplementsInterfaces? Interfaces { get; set; }
 
         /// <inheritdoc/>
         public GraphQLDirectives? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeDefinition.cs
@@ -5,7 +5,7 @@ namespace GraphQLParser.AST
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.InterfaceTypeDefinition"/>.
     /// </summary>
-    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, IHasInterfacesNode
+    public class GraphQLInterfaceTypeDefinition : GraphQLTypeDefinition, IHasDirectivesNode, IHasInterfacesNode, IHasFieldsDefinitionNode
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.InterfaceTypeDefinition;
@@ -15,7 +15,7 @@ namespace GraphQLParser.AST
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }
 
-        public List<GraphQLFieldDefinition>? Fields { get; set; }
+        public GraphQLFieldsDefinition? Fields { get; set; }
     }
 
     internal sealed class GraphQLInterfaceTypeDefinitionWithLocation : GraphQLInterfaceTypeDefinition

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeExtension.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeExtension.cs
@@ -5,7 +5,7 @@ namespace GraphQLParser.AST
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.InterfaceTypeExtension"/>.
     /// </summary>
-    public class GraphQLInterfaceTypeExtension : GraphQLTypeExtension, IHasDirectivesNode, IHasInterfacesNode
+    public class GraphQLInterfaceTypeExtension : GraphQLTypeExtension, IHasDirectivesNode, IHasInterfacesNode, IHasFieldsDefinitionNode
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.InterfaceTypeExtension;
@@ -15,7 +15,7 @@ namespace GraphQLParser.AST
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }
 
-        public List<GraphQLFieldDefinition>? Fields { get; set; }
+        public GraphQLFieldsDefinition? Fields { get; set; }
     }
 
     internal sealed class GraphQLInterfaceTypeExtensionWithLocation : GraphQLInterfaceTypeExtension

--- a/src/GraphQLParser/AST/GraphQLInterfaceTypeExtension.cs
+++ b/src/GraphQLParser/AST/GraphQLInterfaceTypeExtension.cs
@@ -13,7 +13,7 @@ namespace GraphQLParser.AST
         public List<GraphQLNamedType>? Interfaces { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLFieldsDefinition? Fields { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -11,7 +9,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.ObjectTypeDefinition;
 
         /// <inheritdoc />
-        public List<GraphQLNamedType>? Interfaces { get; set; }
+        public GraphQLImplementsInterfaces? Interfaces { get; set; }
 
         /// <inheritdoc/>
         public GraphQLDirectives? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeDefinition.cs
@@ -14,7 +14,7 @@ namespace GraphQLParser.AST
         public List<GraphQLNamedType>? Interfaces { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLFieldsDefinition? Fields { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLObjectTypeExtension.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeExtension.cs
@@ -13,7 +13,7 @@ namespace GraphQLParser.AST
         public List<GraphQLNamedType>? Interfaces { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLFieldsDefinition? Fields { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLObjectTypeExtension.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeExtension.cs
@@ -5,7 +5,7 @@ namespace GraphQLParser.AST
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.ObjectTypeExtension"/>.
     /// </summary>
-    public class GraphQLObjectTypeExtension : GraphQLTypeExtension, IHasDirectivesNode, IHasInterfacesNode
+    public class GraphQLObjectTypeExtension : GraphQLTypeExtension, IHasDirectivesNode, IHasInterfacesNode, IHasFieldsDefinitionNode
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.ObjectTypeExtension;
@@ -15,7 +15,7 @@ namespace GraphQLParser.AST
         /// <inheritdoc/>
         public List<GraphQLDirective>? Directives { get; set; }
 
-        public List<GraphQLFieldDefinition>? Fields { get; set; }
+        public GraphQLFieldsDefinition? Fields { get; set; }
     }
 
     internal sealed class GraphQLObjectTypeExtensionWithLocation : GraphQLObjectTypeExtension

--- a/src/GraphQLParser/AST/GraphQLObjectTypeExtension.cs
+++ b/src/GraphQLParser/AST/GraphQLObjectTypeExtension.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -10,7 +8,7 @@ namespace GraphQLParser.AST
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.ObjectTypeExtension;
 
-        public List<GraphQLNamedType>? Interfaces { get; set; }
+        public GraphQLImplementsInterfaces? Interfaces { get; set; }
 
         /// <inheritdoc/>
         public GraphQLDirectives? Directives { get; set; }

--- a/src/GraphQLParser/AST/GraphQLOperationDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLOperationDefinition.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -18,7 +16,7 @@ namespace GraphQLParser.AST
         public GraphQLVariablesDefinition? Variables { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public GraphQLSelectionSet? SelectionSet { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLScalarTypeDefinition.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -11,7 +9,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.ScalarTypeDefinition;
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
     }
 
     internal sealed class GraphQLScalarTypeDefinitionWithLocation : GraphQLScalarTypeDefinition

--- a/src/GraphQLParser/AST/GraphQLScalarTypeExtension.cs
+++ b/src/GraphQLParser/AST/GraphQLScalarTypeExtension.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -11,7 +9,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.ScalarTypeExtension;
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
     }
 
     internal sealed class GraphQLScalarTypeExtensionWithLocation : GraphQLScalarTypeExtension

--- a/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLSchemaDefinition.cs
@@ -14,7 +14,7 @@ namespace GraphQLParser.AST
         public GraphQLDescription? Description { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public List<GraphQLRootOperationTypeDefinition>? OperationTypes { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLUnionTypeDefinition.cs
@@ -11,7 +11,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.UnionTypeDefinition;
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public List<GraphQLNamedType>? Types { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLUnionTypeExtension.cs
+++ b/src/GraphQLParser/AST/GraphQLUnionTypeExtension.cs
@@ -11,7 +11,7 @@ namespace GraphQLParser.AST
         public override ASTNodeKind Kind => ASTNodeKind.UnionTypeExtension;
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
 
         public List<GraphQLNamedType>? Types { get; set; }
     }

--- a/src/GraphQLParser/AST/GraphQLVariableDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLVariableDefinition.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -17,7 +15,7 @@ namespace GraphQLParser.AST
         public GraphQLValue? DefaultValue { get; set; }
 
         /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
+        public GraphQLDirectives? Directives { get; set; }
     }
 
     internal sealed class GraphQLVariableDefinitionWithLocation : GraphQLVariableDefinition

--- a/src/GraphQLParser/AST/GraphQLVariablesDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLVariablesDefinition.cs
@@ -1,16 +1,12 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
     /// AST node for <see cref="ASTNodeKind.VariablesDefinition"/>.
     /// </summary>
-    public class GraphQLVariablesDefinition : ASTNode
+    public class GraphQLVariablesDefinition : ASTListNode<GraphQLVariableDefinition>
     {
         /// <inheritdoc/>
         public override ASTNodeKind Kind => ASTNodeKind.VariablesDefinition;
-
-        public List<GraphQLVariableDefinition> Items { get; set; } = null!;
     }
 
     internal sealed class GraphQLVariablesDefinitionWithLocation : GraphQLVariablesDefinition

--- a/src/GraphQLParser/AST/GraphQLVariablesDefinition.cs
+++ b/src/GraphQLParser/AST/GraphQLVariablesDefinition.cs
@@ -3,27 +3,17 @@ using System.Collections.Generic;
 namespace GraphQLParser.AST
 {
     /// <summary>
-    /// AST node for <see cref="ASTNodeKind.OperationDefinition"/>.
+    /// AST node for <see cref="ASTNodeKind.VariablesDefinition"/>.
     /// </summary>
-    public class GraphQLOperationDefinition : ASTNode, IHasDirectivesNode, INamedNode
+    public class GraphQLVariablesDefinition : ASTNode
     {
         /// <inheritdoc/>
-        public override ASTNodeKind Kind => ASTNodeKind.OperationDefinition;
+        public override ASTNodeKind Kind => ASTNodeKind.VariablesDefinition;
 
-        public OperationType Operation { get; set; }
-
-        /// <inheritdoc/>
-        public GraphQLName? Name { get; set; }
-
-        public GraphQLVariablesDefinition? Variables { get; set; }
-
-        /// <inheritdoc/>
-        public List<GraphQLDirective>? Directives { get; set; }
-
-        public GraphQLSelectionSet? SelectionSet { get; set; }
+        public List<GraphQLVariableDefinition> Items { get; set; } = null!;
     }
 
-    internal sealed class GraphQLOperationDefinitionWithLocation : GraphQLOperationDefinition
+    internal sealed class GraphQLVariablesDefinitionWithLocation : GraphQLVariablesDefinition
     {
         private GraphQLLocation _location;
 
@@ -34,7 +24,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLOperationDefinitionWithComment : GraphQLOperationDefinition
+    internal sealed class GraphQLVariablesDefinitionWithComment : GraphQLVariablesDefinition
     {
         private GraphQLComment? _comment;
 
@@ -45,7 +35,7 @@ namespace GraphQLParser.AST
         }
     }
 
-    internal sealed class GraphQLOperationDefinitionFull : GraphQLOperationDefinition
+    internal sealed class GraphQLVariablesDefinitionFull : GraphQLVariablesDefinition
     {
         private GraphQLLocation _location;
         private GraphQLComment? _comment;

--- a/src/GraphQLParser/AST/IHasArgumentsDefinitionNode.cs
+++ b/src/GraphQLParser/AST/IHasArgumentsDefinitionNode.cs
@@ -1,0 +1,13 @@
+namespace GraphQLParser.AST
+{
+    /// <summary>
+    /// Represents an AST node that may have arguments definition.
+    /// </summary>
+    public interface IHasArgumentsDefinitionNode
+    {
+        /// <summary>
+        /// Arguments definition of the node represented as a list of nested nodes.
+        /// </summary>
+        GraphQLArgumentsDefinition? Arguments { get; set; }
+    }
+}

--- a/src/GraphQLParser/AST/IHasArgumentsDefinitionNode.cs
+++ b/src/GraphQLParser/AST/IHasArgumentsDefinitionNode.cs
@@ -6,7 +6,7 @@ namespace GraphQLParser.AST
     public interface IHasArgumentsDefinitionNode
     {
         /// <summary>
-        /// Arguments definition of the node represented as a list of nested nodes.
+        /// Arguments definition of the node represented as a nested node.
         /// </summary>
         GraphQLArgumentsDefinition? Arguments { get; set; }
     }

--- a/src/GraphQLParser/AST/IHasArgumentsNode.cs
+++ b/src/GraphQLParser/AST/IHasArgumentsNode.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -8,8 +6,8 @@ namespace GraphQLParser.AST
     public interface IHasArgumentsNode
     {
         /// <summary>
-        /// Arguments of the node represented as a list of nested nodes.
+        /// Arguments of the node represented as a nested node.
         /// </summary>
-        List<GraphQLArgument>? Arguments { get; set; }
+        GraphQLArguments? Arguments { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/IHasDirectivesNode.cs
+++ b/src/GraphQLParser/AST/IHasDirectivesNode.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -8,8 +6,8 @@ namespace GraphQLParser.AST
     public interface IHasDirectivesNode
     {
         /// <summary>
-        /// Directives of the node represented as a list of nested nodes.
+        /// Directives of the node represented as a nested node.
         /// </summary>
-        List<GraphQLDirective>? Directives { get; set; }
+        GraphQLDirectives? Directives { get; set; }
     }
 }

--- a/src/GraphQLParser/AST/IHasFieldsDefinitionNode.cs
+++ b/src/GraphQLParser/AST/IHasFieldsDefinitionNode.cs
@@ -1,0 +1,13 @@
+namespace GraphQLParser.AST
+{
+    /// <summary>
+    /// Represents an AST node that may have fields definition.
+    /// </summary>
+    public interface IHasFieldsDefinitionNode
+    {
+        /// <summary>
+        /// Fields definition of the node represented as a nested node.
+        /// </summary>
+        GraphQLFieldsDefinition? Fields { get; set; }
+    }
+}

--- a/src/GraphQLParser/AST/IHasInterfacesNode.cs
+++ b/src/GraphQLParser/AST/IHasInterfacesNode.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace GraphQLParser.AST
 {
     /// <summary>
@@ -8,8 +6,8 @@ namespace GraphQLParser.AST
     public interface IHasInterfacesNode
     {
         /// <summary>
-        /// Implemented interfaces of the node represented as a list of nested nodes.
+        /// Implemented interfaces of the node represented as a nested node.
         /// </summary>
-        List<GraphQLNamedType>? Interfaces { get; set; }
+        GraphQLImplementsInterfaces? Interfaces { get; set; }
     }
 }

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -540,6 +540,18 @@ namespace GraphQLParser
             };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLVariablesDefinition CreateGraphQLVariablesDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLVariablesDefinition(),
+                IgnoreOptions.Comments => new GraphQLVariablesDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLVariablesDefinitionWithComment(),
+                _ => new GraphQLVariablesDefinitionFull(),
+            };
+        }
+
         #endregion
     }
 }

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -515,6 +515,19 @@ namespace GraphQLParser
             };
         }
 
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLArguments CreateGraphQLArguments(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLArguments(),
+                IgnoreOptions.Comments => new GraphQLArgumentsWithLocation(),
+                IgnoreOptions.Locations => new GraphQLArgumentsWithComment(),
+                _ => new GraphQLArgumentsFull(),
+            };
+        }
+
         #endregion
     }
 }

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -552,6 +552,18 @@ namespace GraphQLParser
             };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLEnumValuesDefinition CreateGraphQLEnumValuesDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLEnumValuesDefinition(),
+                IgnoreOptions.Comments => new GraphQLEnumValuesDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLEnumValuesDefinitionWithComment(),
+                _ => new GraphQLEnumValuesDefinitionFull(),
+            };
+        }
+
         #endregion
     }
 }

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -564,6 +564,18 @@ namespace GraphQLParser
             };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLFieldsDefinition CreateGraphQLFieldsDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLFieldsDefinition(),
+                IgnoreOptions.Comments => new GraphQLFieldsDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLFieldsDefinitionWithComment(),
+                _ => new GraphQLFieldsDefinitionFull(),
+            };
+        }
+
         #endregion
     }
 }

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -576,6 +576,18 @@ namespace GraphQLParser
             };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLDirectives CreateGraphQLDirectives(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLDirectives(),
+                IgnoreOptions.Comments => new GraphQLDirectivesWithLocation(),
+                IgnoreOptions.Locations => new GraphQLDirectivesWithComment(),
+                _ => new GraphQLDirectivesFull(),
+            };
+        }
+
         #endregion
     }
 }

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -503,6 +503,18 @@ namespace GraphQLParser
             };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLArgumentsDefinition CreateGraphQLArgumentsDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLArgumentsDefinition(),
+                IgnoreOptions.Comments => new GraphQLArgumentsDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLArgumentsDefinitionWithComment(),
+                _ => new GraphQLArgumentsDefinitionFull(),
+            };
+        }
+
         #endregion
     }
 }

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -528,6 +528,18 @@ namespace GraphQLParser
             };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static GraphQLInputFieldsDefinition CreateGraphQLInputFieldsDefinition(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLInputFieldsDefinition(),
+                IgnoreOptions.Comments => new GraphQLInputFieldsDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLInputFieldsDefinitionWithComment(),
+                _ => new GraphQLInputFieldsDefinitionFull(),
+            };
+        }
+
         #endregion
     }
 }

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -588,6 +588,17 @@ namespace GraphQLParser
             };
         }
 
+        public static GraphQLImplementsInterfaces CreateGraphQLImplementsInterfaces(IgnoreOptions options)
+        {
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLImplementsInterfaces(),
+                IgnoreOptions.Comments => new GraphQLImplementsInterfacesWithLocation(),
+                IgnoreOptions.Locations => new GraphQLImplementsInterfacesWithComment(),
+                _ => new GraphQLImplementsInterfacesFull(),
+            };
+        }
+
         #endregion
     }
 }

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -98,9 +98,11 @@ namespace GraphQLParser
         }
 
         // http://spec.graphql.org/October2021/#VariableDefinitions
-        private List<GraphQLVariableDefinition> ParseVariableDefinitions()
+        private GraphQLVariablesDefinition ParseVariablesDefinition()
         {
-            return OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseVariableDefinition(), TokenKind.PAREN_R);
+            var variablesDef = NodeHelper.CreateGraphQLVariablesDefinition(_ignoreOptions);
+            variablesDef.Items = OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseVariableDefinition(), TokenKind.PAREN_R);
+            return variablesDef;
         }
 
         // http://spec.graphql.org/October2021/#BooleanValue
@@ -988,7 +990,7 @@ namespace GraphQLParser
             {
                 def.Operation = ParseOperationType();
                 def.Name = Peek(TokenKind.NAME) ? ParseName() : null; // Peek(TokenKind.NAME) because of anonymous query
-                def.VariableDefinitions = Peek(TokenKind.PAREN_L) ? ParseVariableDefinitions() : null;
+                def.Variables = Peek(TokenKind.PAREN_L) ? ParseVariablesDefinition() : null;
                 def.Directives = ParseDirectives();
                 def.SelectionSet = ParseSelectionSet();
                 def.Location = GetLocation(start);

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -92,9 +92,11 @@ namespace GraphQLParser
         }
 
         // http://spec.graphql.org/October2021/#EnumValuesDefinition
-        private List<GraphQLEnumValueDefinition> ParseEnumValuesDefinition()
+        private GraphQLEnumValuesDefinition ParseEnumValuesDefinition()
         {
-            return OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseEnumValueDefinition(), TokenKind.BRACE_R);
+            var enumValuesDef = NodeHelper.CreateGraphQLEnumValuesDefinition(_ignoreOptions);
+            enumValuesDef.Items = OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseEnumValueDefinition(), TokenKind.BRACE_R);
+            return enumValuesDef;
         }
 
         // http://spec.graphql.org/October2021/#VariableDefinitions

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -61,27 +61,32 @@ namespace GraphQLParser
             return arg;
         }
 
-        private List<GraphQLInputValueDefinition> ParseArgumentDefs()
+        // http://spec.graphql.org/October2021/#ArgumentsDefinition
+        private List<GraphQLInputValueDefinition> ParseArgumentsDefinition()
         {
             return OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.PAREN_R);
         }
 
-        private List<GraphQLInputValueDefinition> ParseInputValueDefs()
+        // http://spec.graphql.org/October2021/#InputFieldsDefinition
+        private List<GraphQLInputValueDefinition> ParseInputFieldsDefinition()
         {
             return OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.BRACE_R);
         }
 
+        // http://spec.graphql.org/October2021/#Arguments
         private List<GraphQLArgument> ParseArguments()
         {
             return OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseArgument(), TokenKind.PAREN_R);
         }
 
-        private List<GraphQLFieldDefinition> ParseFieldDefinitions()
+        // http://spec.graphql.org/October2021/#FieldsDefinition
+        private List<GraphQLFieldDefinition> ParseFieldsDefinition()
         {
             return OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseFieldDefinition(), TokenKind.BRACE_R);
         }
 
-        private List<GraphQLEnumValueDefinition> ParseEnumValueDefinitions()
+        // http://spec.graphql.org/October2021/#EnumValuesDefinition
+        private List<GraphQLEnumValueDefinition> ParseEnumValuesDefinition()
         {
             return OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseEnumValueDefinition(), TokenKind.BRACE_R);
         }
@@ -251,7 +256,7 @@ namespace GraphQLParser
             var def = NodeHelper.CreateGraphQLDirectiveDefinition(_ignoreOptions);
 
             def.Name = ParseName();
-            def.Arguments = Peek(TokenKind.PAREN_L) ? ParseArgumentDefs() : null;
+            def.Arguments = Peek(TokenKind.PAREN_L) ? ParseArgumentsDefinition() : null;
             def.Repeatable = Peek(TokenKind.NAME) ? ParseRepeatable() : false;
             ExpectKeyword("on");
             def.Locations = ParseDirectiveLocations();
@@ -319,7 +324,7 @@ namespace GraphQLParser
             var def = NodeHelper.CreateGraphQLEnumTypeDefinition(_ignoreOptions);
             def.Name = ParseName();
             def.Directives = ParseDirectives();
-            def.Values = Peek(TokenKind.BRACE_L) ? ParseEnumValueDefinitions() : null;
+            def.Values = Peek(TokenKind.BRACE_L) ? ParseEnumValuesDefinition() : null;
             def.Description = description;
             def.Comment = comment;
             def.Location = GetLocation(start);
@@ -339,7 +344,7 @@ namespace GraphQLParser
 
             extension.Name = ParseName();
             extension.Directives = ParseDirectives();
-            extension.Values = Peek(TokenKind.BRACE_L) ? ParseEnumValueDefinitions() : null;
+            extension.Values = Peek(TokenKind.BRACE_L) ? ParseEnumValuesDefinition() : null;
             extension.Comment = comment;
             extension.Location = GetLocation(start);
 
@@ -399,7 +404,7 @@ namespace GraphQLParser
 
             def.Comment = GetComment();
             def.Name = ParseName();
-            def.Arguments = Peek(TokenKind.PAREN_L) ? ParseArgumentDefs() : null;
+            def.Arguments = Peek(TokenKind.PAREN_L) ? ParseArgumentsDefinition() : null;
             Expect(TokenKind.COLON);
             def.Type = ParseType();
             def.Directives = ParseDirectives();
@@ -588,7 +593,7 @@ namespace GraphQLParser
             ExpectKeyword("input");
             def.Name = ParseName();
             def.Directives = ParseDirectives();
-            def.Fields = Peek(TokenKind.BRACE_L) ? ParseInputValueDefs() : null;
+            def.Fields = Peek(TokenKind.BRACE_L) ? ParseInputFieldsDefinition() : null;
             def.Description = description;
             def.Location = GetLocation(start);
 
@@ -607,7 +612,7 @@ namespace GraphQLParser
             ExpectKeyword("input");
             extension.Name = ParseName();
             extension.Directives = ParseDirectives();
-            extension.Fields = Peek(TokenKind.BRACE_L) ? ParseInputValueDefs() : null;
+            extension.Fields = Peek(TokenKind.BRACE_L) ? ParseInputFieldsDefinition() : null;
             extension.Location = GetLocation(start);
 
             if (extension.Directives == null && extension.Fields == null)
@@ -671,7 +676,7 @@ namespace GraphQLParser
             def.Name = ParseName();
             def.Interfaces = ParseImplementsInterfaces();
             def.Directives = ParseDirectives();
-            def.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldDefinitions() : null;
+            def.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldsDefinition() : null;
             def.Description = description;
             def.Location = GetLocation(start);
 
@@ -691,7 +696,7 @@ namespace GraphQLParser
             extension.Name = ParseName();
             extension.Interfaces = ParseImplementsInterfaces();
             extension.Directives = ParseDirectives();
-            extension.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldDefinitions() : null;
+            extension.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldsDefinition() : null;
             extension.Location = GetLocation(start);
 
             if (extension.Directives == null && extension.Fields == null && extension.Interfaces == null)
@@ -929,7 +934,7 @@ namespace GraphQLParser
             def.Name = ParseName();
             def.Interfaces = ParseImplementsInterfaces();
             def.Directives = ParseDirectives();
-            def.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldDefinitions() : null;
+            def.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldsDefinition() : null;
             def.Description = description;
             def.Location = GetLocation(start);
 
@@ -949,7 +954,7 @@ namespace GraphQLParser
             extension.Name = ParseName();
             extension.Interfaces = ParseImplementsInterfaces();
             extension.Directives = ParseDirectives();
-            extension.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldDefinitions() : null;
+            extension.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldsDefinition() : null;
             extension.Location = GetLocation(start);
 
             if (extension.Directives == null && extension.Fields == null && extension.Interfaces == null)

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -78,9 +78,11 @@ namespace GraphQLParser
         }
 
         // http://spec.graphql.org/October2021/#InputFieldsDefinition
-        private List<GraphQLInputValueDefinition> ParseInputFieldsDefinition()
+        private GraphQLInputFieldsDefinition ParseInputFieldsDefinition()
         {
-            return OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.BRACE_R);
+            var inputFieldsDef = NodeHelper.CreateGraphQLInputFieldsDefinition(_ignoreOptions);
+            inputFieldsDef.Items = OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.BRACE_R);
+            return inputFieldsDef;
         }
 
         // http://spec.graphql.org/October2021/#FieldsDefinition

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -61,22 +61,24 @@ namespace GraphQLParser
             return arg;
         }
 
-        // http://spec.graphql.org/October2021/#ArgumentsDefinition
-        private List<GraphQLInputValueDefinition> ParseArgumentsDefinition()
+        // http://spec.graphql.org/October2021/#Arguments
+        private List<GraphQLArgument> ParseArguments()
         {
-            return OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.PAREN_R);
+            return OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseArgument(), TokenKind.PAREN_R);
+        }
+
+        // http://spec.graphql.org/October2021/#ArgumentsDefinition
+        private GraphQLArgumentsDefinition ParseArgumentsDefinition()
+        {
+            var argsDef = NodeHelper.CreateGraphQLArgumentsDefinition(_ignoreOptions);
+            argsDef.InputValueDefinitions = OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.PAREN_R);
+            return argsDef;
         }
 
         // http://spec.graphql.org/October2021/#InputFieldsDefinition
         private List<GraphQLInputValueDefinition> ParseInputFieldsDefinition()
         {
             return OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.BRACE_R);
-        }
-
-        // http://spec.graphql.org/October2021/#Arguments
-        private List<GraphQLArgument> ParseArguments()
-        {
-            return OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseArgument(), TokenKind.PAREN_R);
         }
 
         // http://spec.graphql.org/October2021/#FieldsDefinition

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -571,26 +571,26 @@ namespace GraphQLParser
         }
 
         // http://spec.graphql.org/October2021/#ImplementsInterfaces
-        private List<GraphQLNamedType>? ParseImplementsInterfaces()
+        private GraphQLImplementsInterfaces ParseImplementsInterfaces()
         {
-            List<GraphQLNamedType>? types = null;
-            if (_currentToken.Value == "implements")
+            ExpectKeyword("implements");
+
+            var implementsInterfaces = NodeHelper.CreateGraphQLImplementsInterfaces(_ignoreOptions);
+
+            List<GraphQLNamedType> types = new();
+
+            // Objects that implement interfaces may be defined with an optional leading & character
+            // to aid formatting when representing a longer list of implemented interfaces
+            Skip(TokenKind.AMPERSAND);
+
+            do
             {
-                types = new List<GraphQLNamedType>();
-                Advance();
-
-                // Objects that implement interfaces may be defined with an optional leading & character
-                // to aid formatting when representing a longer list of implemented interfaces
-                Skip(TokenKind.AMPERSAND);
-
-                do
-                {
-                    types.Add(ParseNamedType());
-                }
-                while (Skip(TokenKind.AMPERSAND));
+                types.Add(ParseNamedType());
             }
+            while (Skip(TokenKind.AMPERSAND));
 
-            return types;
+            implementsInterfaces.Items = types;
+            return implementsInterfaces;
         }
 
         // http://spec.graphql.org/October2021/#InputObjectTypeDefinition
@@ -690,7 +690,7 @@ namespace GraphQLParser
             def.Comment = GetComment();
             ExpectKeyword("interface");
             def.Name = ParseName();
-            def.Interfaces = ParseImplementsInterfaces();
+            def.Interfaces = _currentToken.Value == "implements" ? ParseImplementsInterfaces() : null;
             def.Directives = Peek(TokenKind.AT) ? ParseDirectives() : null;
             def.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldsDefinition() : null;
             def.Description = description;
@@ -710,7 +710,7 @@ namespace GraphQLParser
             extension.Comment = GetComment();
             ExpectKeyword("interface");
             extension.Name = ParseName();
-            extension.Interfaces = ParseImplementsInterfaces();
+            extension.Interfaces = _currentToken.Value == "implements" ? ParseImplementsInterfaces() : null;
             extension.Directives = Peek(TokenKind.AT) ? ParseDirectives() : null;
             extension.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldsDefinition() : null;
             extension.Location = GetLocation(start);
@@ -948,7 +948,7 @@ namespace GraphQLParser
             def.Comment = GetComment();
             ExpectKeyword("type");
             def.Name = ParseName();
-            def.Interfaces = ParseImplementsInterfaces();
+            def.Interfaces = _currentToken.Value == "implements" ? ParseImplementsInterfaces() : null;
             def.Directives = Peek(TokenKind.AT) ? ParseDirectives() : null;
             def.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldsDefinition() : null;
             def.Description = description;
@@ -968,7 +968,7 @@ namespace GraphQLParser
             extension.Comment = GetComment();
             ExpectKeyword("type");
             extension.Name = ParseName();
-            extension.Interfaces = ParseImplementsInterfaces();
+            extension.Interfaces = _currentToken.Value == "implements" ? ParseImplementsInterfaces() : null;
             extension.Directives = Peek(TokenKind.AT) ? ParseDirectives() : null;
             extension.Fields = Peek(TokenKind.BRACE_L) ? ParseFieldsDefinition() : null;
             extension.Location = GetLocation(start);

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -62,16 +62,18 @@ namespace GraphQLParser
         }
 
         // http://spec.graphql.org/October2021/#Arguments
-        private List<GraphQLArgument> ParseArguments()
+        private GraphQLArguments ParseArguments()
         {
-            return OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseArgument(), TokenKind.PAREN_R);
+            var args = NodeHelper.CreateGraphQLArguments(_ignoreOptions);
+            args.Items = OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseArgument(), TokenKind.PAREN_R);
+            return args;
         }
 
         // http://spec.graphql.org/October2021/#ArgumentsDefinition
         private GraphQLArgumentsDefinition ParseArgumentsDefinition()
         {
             var argsDef = NodeHelper.CreateGraphQLArgumentsDefinition(_ignoreOptions);
-            argsDef.InputValueDefinitions = OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.PAREN_R);
+            argsDef.Items = OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseInputValueDef(), TokenKind.PAREN_R);
             return argsDef;
         }
 

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -86,9 +86,11 @@ namespace GraphQLParser
         }
 
         // http://spec.graphql.org/October2021/#FieldsDefinition
-        private List<GraphQLFieldDefinition> ParseFieldsDefinition()
+        private GraphQLFieldsDefinition ParseFieldsDefinition()
         {
-            return OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseFieldDefinition(), TokenKind.BRACE_R);
+            var fieldsDef = NodeHelper.CreateGraphQLFieldsDefinition(_ignoreOptions);
+            fieldsDef.Items = OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseFieldDefinition(), TokenKind.BRACE_R);
+            return fieldsDef;
         }
 
         // http://spec.graphql.org/October2021/#EnumValuesDefinition

--- a/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
@@ -28,6 +28,12 @@ namespace GraphQLParser.Visitors
         }
 
         /// <inheritdoc/>
+        public virtual async ValueTask VisitArgumentsDefinition(GraphQLArgumentsDefinition argumentsDefinition, TContext context)
+        {
+            await Visit(argumentsDefinition.InputValueDefinitions, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
         public virtual ValueTask VisitComment(GraphQLComment comment, TContext context)
         {
             return new ValueTask(Task.CompletedTask);
@@ -333,6 +339,7 @@ namespace GraphQLParser.Visitors
             await Visit(directiveDefinition.Description, context).ConfigureAwait(false);
             await Visit(directiveDefinition.Name, context).ConfigureAwait(false);
             await Visit(directiveDefinition.Arguments, context).ConfigureAwait(false);
+            //TODO: add locations node
         }
 
         /// <inheritdoc/>

--- a/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
@@ -30,7 +30,15 @@ namespace GraphQLParser.Visitors
         /// <inheritdoc/>
         public virtual async ValueTask VisitArgumentsDefinition(GraphQLArgumentsDefinition argumentsDefinition, TContext context)
         {
-            await Visit(argumentsDefinition.InputValueDefinitions, context).ConfigureAwait(false);
+            await Visit(argumentsDefinition.Items, context).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Visits <see cref="GraphQLArguments"/> node.
+        /// </summary>
+        public virtual async ValueTask VisitArguments(GraphQLArguments arguments, TContext context)
+        {
+            await Visit(arguments.Items, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
@@ -212,6 +212,12 @@ namespace GraphQLParser.Visitors
         }
 
         /// <inheritdoc/>
+        public virtual async ValueTask VisitDirectives(GraphQLDirectives directives, TContext context)
+        {
+            await Visit(directives.Items, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
         public virtual async ValueTask VisitNamedType(GraphQLNamedType namedType, TContext context)
         {
             await Visit(namedType.Comment, context).ConfigureAwait(false);
@@ -493,6 +499,10 @@ namespace GraphQLParser.Visitors
                     GraphQLArgumentsDefinition argsDef => VisitArgumentsDefinition(argsDef, context),
                     GraphQLArguments args => VisitArguments(args, context),
                     GraphQLInputFieldsDefinition inputFieldsDef => VisitInputFieldsDefinition(inputFieldsDef, context),
+                    GraphQLDirectives directives => VisitDirectives(directives, context),
+                    GraphQLVariablesDefinition varsDef => VisitVariablesDefinition(varsDef, context),
+                    GraphQLEnumValuesDefinition enumValuesDef => VisitEnumValuesDefinition(enumValuesDef, context),
+                    GraphQLFieldsDefinition fieldsDef => VisitFieldsDefinition(fieldsDef, context),
                     _ => throw new NotSupportedException($"Unknown node '{node.GetType().Name}'."),
                 };
         }
@@ -502,7 +512,7 @@ namespace GraphQLParser.Visitors
         /// sibling nodes of some parent node, for example, argument nodes for
         /// parent field node or value nodes for parent list node.
         /// </summary>
-        protected async ValueTask Visit<T>(List<T>? nodes, TContext context) // TODO: remove
+        protected async ValueTask Visit<T>(List<T>? nodes, TContext context)
             where T : ASTNode
         {
             if (nodes != null)

--- a/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
@@ -343,6 +343,12 @@ namespace GraphQLParser.Visitors
         }
 
         /// <inheritdoc/>
+        public virtual async ValueTask VisitEnumValuesDefinition(GraphQLEnumValuesDefinition enumValuesDefinition, TContext context)
+        {
+            await Visit(enumValuesDefinition.Items, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
         public virtual async ValueTask VisitInputObjectTypeDefinition(GraphQLInputObjectTypeDefinition inputObjectTypeDefinition, TContext context)
         {
             await Visit(inputObjectTypeDefinition.Comment, context).ConfigureAwait(false);
@@ -490,7 +496,7 @@ namespace GraphQLParser.Visitors
         /// sibling nodes of some parent node, for example, argument nodes for
         /// parent field node or value nodes for parent list node.
         /// </summary>
-        protected async ValueTask Visit<T>(List<T>? nodes, TContext context)
+        protected async ValueTask Visit<T>(List<T>? nodes, TContext context) // TODO: remove
             where T : ASTNode
         {
             if (nodes != null)

--- a/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
@@ -58,7 +58,7 @@ namespace GraphQLParser.Visitors
         {
             await Visit(operationDefinition.Comment, context).ConfigureAwait(false);
             await Visit(operationDefinition.Name, context).ConfigureAwait(false);
-            await Visit(operationDefinition.VariableDefinitions, context).ConfigureAwait(false);
+            await Visit(operationDefinition.Variables, context).ConfigureAwait(false);
             await Visit(operationDefinition.Directives, context).ConfigureAwait(false);
             await Visit(operationDefinition.SelectionSet, context).ConfigureAwait(false);
         }
@@ -77,6 +77,12 @@ namespace GraphQLParser.Visitors
             await Visit(variableDefinition.Type, context).ConfigureAwait(false);
             await Visit(variableDefinition.DefaultValue, context).ConfigureAwait(false);
             await Visit(variableDefinition.Directives, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public virtual async ValueTask VisitVariablesDefinition(GraphQLVariablesDefinition variablesDefinition, TContext context)
+        {
+            await Visit(variablesDefinition.Items, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
@@ -466,6 +466,8 @@ namespace GraphQLParser.Visitors
                     GraphQLUnionTypeDefinition unionTypeDefinition => VisitUnionTypeDefinition(unionTypeDefinition, context),
                     GraphQLVariable variable => VisitVariable(variable, context),
                     GraphQLVariableDefinition variableDefinition => VisitVariableDefinition(variableDefinition, context),
+                    GraphQLArgumentsDefinition argsDef => VisitArgumentsDefinition(argsDef, context),
+                    GraphQLArguments args => VisitArguments(args, context),
                     _ => throw new NotSupportedException($"Unknown node '{node.GetType().Name}'."),
                 };
         }

--- a/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
@@ -286,6 +286,12 @@ namespace GraphQLParser.Visitors
         }
 
         /// <inheritdoc/>
+        public virtual async ValueTask VisitFieldsDefinition(GraphQLFieldsDefinition fieldsDefinition, TContext context)
+        {
+            await Visit(fieldsDefinition.Items, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
         public virtual async ValueTask VisitInputValueDefinition(GraphQLInputValueDefinition inputValueDefinition, TContext context)
         {
             await Visit(inputValueDefinition.Comment, context).ConfigureAwait(false);

--- a/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
@@ -291,6 +291,12 @@ namespace GraphQLParser.Visitors
         }
 
         /// <inheritdoc/>
+        public virtual async ValueTask VisitInputFieldsDefinition(GraphQLInputFieldsDefinition inputFieldsDefinition, TContext context)
+        {
+            await Visit(inputFieldsDefinition.Items, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
         public virtual async ValueTask VisitInterfaceTypeDefinition(GraphQLInterfaceTypeDefinition interfaceTypeDefinition, TContext context)
         {
             await Visit(interfaceTypeDefinition.Comment, context).ConfigureAwait(false);
@@ -468,6 +474,7 @@ namespace GraphQLParser.Visitors
                     GraphQLVariableDefinition variableDefinition => VisitVariableDefinition(variableDefinition, context),
                     GraphQLArgumentsDefinition argsDef => VisitArgumentsDefinition(argsDef, context),
                     GraphQLArguments args => VisitArguments(args, context),
+                    GraphQLInputFieldsDefinition inputFieldsDef => VisitInputFieldsDefinition(inputFieldsDef, context),
                     _ => throw new NotSupportedException($"Unknown node '{node.GetType().Name}'."),
                 };
         }

--- a/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/DefaultNodeVisitor.cs
@@ -142,6 +142,12 @@ namespace GraphQLParser.Visitors
         }
 
         /// <inheritdoc/>
+        public virtual async ValueTask VisitImplementsInterfaces(GraphQLImplementsInterfaces implementsInterfaces, TContext context)
+        {
+            await Visit(implementsInterfaces.Items, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
         public virtual async ValueTask VisitFragmentDefinition(GraphQLFragmentDefinition fragmentDefinition, TContext context)
         {
             await Visit(fragmentDefinition.Comment, context).ConfigureAwait(false);
@@ -503,6 +509,7 @@ namespace GraphQLParser.Visitors
                     GraphQLVariablesDefinition varsDef => VisitVariablesDefinition(varsDef, context),
                     GraphQLEnumValuesDefinition enumValuesDef => VisitEnumValuesDefinition(enumValuesDef, context),
                     GraphQLFieldsDefinition fieldsDef => VisitFieldsDefinition(fieldsDef, context),
+                    GraphQLImplementsInterfaces implements => VisitImplementsInterfaces(implements, context),
                     _ => throw new NotSupportedException($"Unknown node '{node.GetType().Name}'."),
                 };
         }

--- a/src/GraphQLParser/Visitors/INodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/INodeVisitor.cs
@@ -201,6 +201,11 @@ namespace GraphQLParser.Visitors
         ValueTask VisitEnumValueDefinition(GraphQLEnumValueDefinition enumValueDefinition, TContext context);
 
         /// <summary>
+        /// Visits <see cref="GraphQLEnumValuesDefinition"/> node.
+        /// </summary>
+        ValueTask VisitEnumValuesDefinition(GraphQLEnumValuesDefinition enumValuesDefinition, TContext context);
+
+        /// <summary>
         /// Visits <see cref="GraphQLInputObjectTypeDefinition"/> node.
         /// </summary>
         ValueTask VisitInputObjectTypeDefinition(GraphQLInputObjectTypeDefinition inputObjectTypeDefinition, TContext context);

--- a/src/GraphQLParser/Visitors/INodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/INodeVisitor.cs
@@ -171,6 +171,11 @@ namespace GraphQLParser.Visitors
         ValueTask VisitFieldDefinition(GraphQLFieldDefinition fieldDefinition, TContext context);
 
         /// <summary>
+        /// Visits <see cref="GraphQLFieldsDefinition"/> node.
+        /// </summary>
+        ValueTask VisitFieldsDefinition(GraphQLFieldsDefinition fieldsDefinition, TContext context);
+
+        /// <summary>
         /// Visits <see cref="GraphQLInputValueDefinition"/> node.
         /// </summary>
         ValueTask VisitInputValueDefinition(GraphQLInputValueDefinition inputValueDefinition, TContext context);

--- a/src/GraphQLParser/Visitors/INodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/INodeVisitor.cs
@@ -171,6 +171,11 @@ namespace GraphQLParser.Visitors
         ValueTask VisitInputValueDefinition(GraphQLInputValueDefinition inputValueDefinition, TContext context);
 
         /// <summary>
+        /// Visits <see cref="GraphQLInputFieldsDefinition"/> node.
+        /// </summary>
+        ValueTask VisitInputFieldsDefinition(GraphQLInputFieldsDefinition inputFieldsDefinition, TContext context);
+
+        /// <summary>
         /// Visits <see cref="GraphQLInterfaceTypeDefinition"/> node.
         /// </summary>
         ValueTask VisitInterfaceTypeDefinition(GraphQLInterfaceTypeDefinition interfaceTypeDefinition, TContext context);

--- a/src/GraphQLParser/Visitors/INodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/INodeVisitor.cs
@@ -56,6 +56,11 @@ namespace GraphQLParser.Visitors
         ValueTask VisitArgumentsDefinition(GraphQLArgumentsDefinition argumentsDefinition, TContext context);
 
         /// <summary>
+        /// Visits <see cref="GraphQLArguments"/> node.
+        /// </summary>
+        ValueTask VisitArguments(GraphQLArguments arguments, TContext context);
+
+        /// <summary>
         /// Visits <see cref="GraphQLFragmentSpread"/> node.
         /// </summary>
         ValueTask VisitFragmentSpread(GraphQLFragmentSpread fragmentSpread, TContext context);

--- a/src/GraphQLParser/Visitors/INodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/INodeVisitor.cs
@@ -241,6 +241,11 @@ namespace GraphQLParser.Visitors
         ValueTask VisitTypeCondition(GraphQLTypeCondition typeCondition, TContext context);
 
         /// <summary>
+        /// Visits <see cref="GraphQLImplementsInterfaces"/> node.
+        /// </summary>
+        ValueTask VisitImplementsInterfaces(GraphQLImplementsInterfaces implementsInterfaces, TContext context);
+
+        /// <summary>
         /// Visits <see cref="GraphQLAlias"/> node.
         /// </summary>
         ValueTask VisitAlias(GraphQLAlias alias, TContext context);

--- a/src/GraphQLParser/Visitors/INodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/INodeVisitor.cs
@@ -126,6 +126,11 @@ namespace GraphQLParser.Visitors
         ValueTask VisitDirective(GraphQLDirective directive, TContext context);
 
         /// <summary>
+        /// Visits <see cref="GraphQLDirectives"/> node.
+        /// </summary>
+        ValueTask VisitDirectives(GraphQLDirectives directives, TContext context);
+
+        /// <summary>
         /// Visits <see cref="GraphQLNamedType"/> node.
         /// </summary>
         ValueTask VisitNamedType(GraphQLNamedType namedType, TContext context);

--- a/src/GraphQLParser/Visitors/INodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/INodeVisitor.cs
@@ -51,6 +51,11 @@ namespace GraphQLParser.Visitors
         ValueTask VisitArgument(GraphQLArgument argument, TContext context);
 
         /// <summary>
+        /// Visits <see cref="GraphQLArgumentsDefinition"/> node.
+        /// </summary>
+        ValueTask VisitArgumentsDefinition(GraphQLArgumentsDefinition argumentsDefinition, TContext context);
+
+        /// <summary>
         /// Visits <see cref="GraphQLFragmentSpread"/> node.
         /// </summary>
         ValueTask VisitFragmentSpread(GraphQLFragmentSpread fragmentSpread, TContext context);

--- a/src/GraphQLParser/Visitors/INodeVisitor.cs
+++ b/src/GraphQLParser/Visitors/INodeVisitor.cs
@@ -31,6 +31,11 @@ namespace GraphQLParser.Visitors
         ValueTask VisitVariableDefinition(GraphQLVariableDefinition variableDefinition, TContext context);
 
         /// <summary>
+        /// Visits <see cref="GraphQLVariablesDefinition"/> node.
+        /// </summary>
+        ValueTask VisitVariablesDefinition(GraphQLVariablesDefinition variablesDefinition, TContext context);
+
+        /// <summary>
         /// Visits <see cref="GraphQLVariable"/> node.
         /// </summary>
         ValueTask VisitVariable(GraphQLVariable variable, TContext context);

--- a/src/GraphQLParser/Visitors/SDLWriter.cs
+++ b/src/GraphQLParser/Visitors/SDLWriter.cs
@@ -256,12 +256,7 @@ namespace GraphQLParser.Visitors
                 await WriteIndent(context, level).ConfigureAwait(false);
             }
             await Visit(field.Name, context).ConfigureAwait(false);
-            if (field.Arguments != null)
-            {
-                await context.Write("(").ConfigureAwait(false);
-                await VisitArguments(field, context).ConfigureAwait(false);
-                await context.Write(")").ConfigureAwait(false);
-            }
+            await Visit(field.Arguments, context).ConfigureAwait(false);
             await VisitDirectives(field, context).ConfigureAwait(false);
 
             if (field.SelectionSet == null)
@@ -714,12 +709,7 @@ namespace GraphQLParser.Visitors
             await Visit(directive.Comment, context).ConfigureAwait(false);
             await context.Write("@").ConfigureAwait(false);
             await Visit(directive.Name, context).ConfigureAwait(false);
-            if (directive.Arguments != null)
-            {
-                await context.Write("(").ConfigureAwait(false);
-                await VisitArguments(directive, context).ConfigureAwait(false);
-                await context.Write(")").ConfigureAwait(false);
-            }
+            await Visit(directive.Arguments, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -731,13 +721,27 @@ namespace GraphQLParser.Visitors
             await Visit(argument.Value, context).ConfigureAwait(false);
         }
 
+        /// <inheritdoc/>
         public override async ValueTask VisitArgumentsDefinition(GraphQLArgumentsDefinition argumentsDefinition, TContext context)
         {
             await context.Write("(").ConfigureAwait(false);
-            for (int i = 0; i < argumentsDefinition.InputValueDefinitions.Count; ++i)
+            for (int i = 0; i < argumentsDefinition.Items.Count; ++i)
             {
-                await Visit(argumentsDefinition.InputValueDefinitions[i], context).ConfigureAwait(false);
-                if (i < argumentsDefinition.InputValueDefinitions.Count - 1)
+                await Visit(argumentsDefinition.Items[i], context).ConfigureAwait(false);
+                if (i < argumentsDefinition.Items.Count - 1)
+                    await context.Write(", ").ConfigureAwait(false);
+            }
+            await context.Write(")").ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public override async ValueTask VisitArguments(GraphQLArguments arguments, TContext context)
+        {
+            await context.Write("(").ConfigureAwait(false);
+            for (int i = 0; i < arguments.Items.Count; ++i)
+            {
+                await Visit(arguments.Items[i], context).ConfigureAwait(false);
+                if (i < arguments.Items.Count - 1)
                     await context.Write(", ").ConfigureAwait(false);
             }
             await context.Write(")").ConfigureAwait(false);
@@ -860,19 +864,6 @@ namespace GraphQLParser.Visitors
             await base.Visit(node, context).ConfigureAwait(false);
 
             context.Parents.Pop();
-        }
-
-        private async ValueTask VisitArguments(IHasArgumentsNode node, TContext context)
-        {
-            if (node.Arguments?.Count > 0)
-            {
-                for (int i = 0; i < node.Arguments.Count; ++i)
-                {
-                    await Visit(node.Arguments[i], context).ConfigureAwait(false);
-                    if (i < node.Arguments.Count - 1)
-                        await context.Write(", ").ConfigureAwait(false);
-                }
-            }
         }
 
         private async ValueTask VisitInterfaces(IHasInterfacesNode node, TContext context)

--- a/src/GraphQLParser/Visitors/SDLWriter.cs
+++ b/src/GraphQLParser/Visitors/SDLWriter.cs
@@ -478,26 +478,9 @@ namespace GraphQLParser.Visitors
             await Visit(objectTypeDefinition.Name, context).ConfigureAwait(false);
             await VisitInterfaces(objectTypeDefinition, context).ConfigureAwait(false);
             await VisitDirectives(objectTypeDefinition, context).ConfigureAwait(false);
-
-            if (objectTypeDefinition.Fields?.Count > 0)
-            {
-                await context.WriteLine().ConfigureAwait(false);
-                await context.Write("{").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-
-                for (int i = 0; i < objectTypeDefinition.Fields.Count; ++i)
-                {
-                    await Visit(objectTypeDefinition.Fields[i], context).ConfigureAwait(false);
-                    await context.WriteLine().ConfigureAwait(false);
-                }
-
-                await context.Write("}").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-            }
-            else
-            {
-                await context.WriteLine().ConfigureAwait(false);
-            }
+            await Visit(objectTypeDefinition.Fields, context).ConfigureAwait(false);
+            if (objectTypeDefinition.Fields == null)
+                await context.WriteLine().ConfigureAwait(false); //TODO: ???
         }
 
         /// <inheritdoc/>
@@ -508,26 +491,9 @@ namespace GraphQLParser.Visitors
             await Visit(objectTypeExtension.Name, context).ConfigureAwait(false);
             await VisitInterfaces(objectTypeExtension, context).ConfigureAwait(false);
             await VisitDirectives(objectTypeExtension, context).ConfigureAwait(false);
-
-            if (objectTypeExtension.Fields?.Count > 0)
-            {
-                await context.WriteLine().ConfigureAwait(false);
-                await context.Write("{").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-
-                for (int i = 0; i < objectTypeExtension.Fields.Count; ++i)
-                {
-                    await Visit(objectTypeExtension.Fields[i], context).ConfigureAwait(false);
-                    await context.WriteLine().ConfigureAwait(false);
-                }
-
-                await context.Write("}").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-            }
-            else
-            {
-                await context.WriteLine().ConfigureAwait(false);
-            }
+            await Visit(objectTypeExtension.Fields, context).ConfigureAwait(false);
+            if (objectTypeExtension.Fields == null)
+                await context.WriteLine().ConfigureAwait(false); // TODO: ???
         }
 
         /// <inheritdoc/>
@@ -539,22 +505,7 @@ namespace GraphQLParser.Visitors
             await Visit(interfaceTypeDefinition.Name, context).ConfigureAwait(false);
             await VisitInterfaces(interfaceTypeDefinition, context).ConfigureAwait(false);
             await VisitDirectives(interfaceTypeDefinition, context).ConfigureAwait(false);
-
-            if (interfaceTypeDefinition.Fields?.Count > 0)
-            {
-                await context.WriteLine().ConfigureAwait(false);
-                await context.Write("{").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-
-                for (int i = 0; i < interfaceTypeDefinition.Fields.Count; ++i)
-                {
-                    await Visit(interfaceTypeDefinition.Fields[i], context).ConfigureAwait(false);
-                    await context.WriteLine().ConfigureAwait(false);
-                }
-
-                await context.Write("}").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-            }
+            await Visit(interfaceTypeDefinition.Fields, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -565,22 +516,7 @@ namespace GraphQLParser.Visitors
             await Visit(interfaceTypeExtension.Name, context).ConfigureAwait(false);
             await VisitInterfaces(interfaceTypeExtension, context).ConfigureAwait(false);
             await VisitDirectives(interfaceTypeExtension, context).ConfigureAwait(false);
-
-            if (interfaceTypeExtension.Fields?.Count > 0)
-            {
-                await context.WriteLine().ConfigureAwait(false);
-                await context.Write("{").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-
-                for (int i = 0; i < interfaceTypeExtension.Fields.Count; ++i)
-                {
-                    await Visit(interfaceTypeExtension.Fields[i], context).ConfigureAwait(false);
-                    await context.WriteLine().ConfigureAwait(false);
-                }
-
-                await context.Write("}").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-            }
+            await Visit(interfaceTypeExtension.Fields, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -597,6 +533,23 @@ namespace GraphQLParser.Visitors
             await context.Write(": ").ConfigureAwait(false);
             await Visit(fieldDefinition.Type, context).ConfigureAwait(false);
             await VisitDirectives(fieldDefinition, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public override async ValueTask VisitFieldsDefinition(GraphQLFieldsDefinition fieldsDefinition, TContext context)
+        {
+            await context.WriteLine().ConfigureAwait(false);
+            await context.Write("{").ConfigureAwait(false);
+            await context.WriteLine().ConfigureAwait(false);
+
+            for (int i = 0; i < fieldsDefinition.Items.Count; ++i)
+            {
+                await Visit(fieldsDefinition.Items[i], context).ConfigureAwait(false);
+                await context.WriteLine().ConfigureAwait(false);
+            }
+
+            await context.Write("}").ConfigureAwait(false);
+            await context.WriteLine().ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/GraphQLParser/Visitors/SDLWriter.cs
+++ b/src/GraphQLParser/Visitors/SDLWriter.cs
@@ -173,7 +173,7 @@ namespace GraphQLParser.Visitors
             await Visit(fragmentDefinition.Name, context).ConfigureAwait(false);
             await context.Write(" ").ConfigureAwait(false);
             await Visit(fragmentDefinition.TypeCondition, context).ConfigureAwait(false);
-            await VisitDirectives(fragmentDefinition, context).ConfigureAwait(false);
+            await Visit(fragmentDefinition.Directives, context).ConfigureAwait(false);
             await Visit(fragmentDefinition.SelectionSet, context).ConfigureAwait(false);
         }
 
@@ -187,7 +187,7 @@ namespace GraphQLParser.Visitors
 
             await context.Write("...").ConfigureAwait(false);
             await Visit(fragmentSpread.Name, context).ConfigureAwait(false);
-            await VisitDirectives(fragmentSpread, context).ConfigureAwait(false);
+            await Visit(fragmentSpread.Directives, context).ConfigureAwait(false);
             await context.WriteLine().ConfigureAwait(false);
         }
 
@@ -201,7 +201,7 @@ namespace GraphQLParser.Visitors
 
             await context.Write("... ").ConfigureAwait(false);
             await Visit(inlineFragment.TypeCondition, context).ConfigureAwait(false);
-            await VisitDirectives(inlineFragment, context).ConfigureAwait(false);
+            await Visit(inlineFragment.Directives, context).ConfigureAwait(false);
             await Visit(inlineFragment.SelectionSet, context).ConfigureAwait(false);
         }
 
@@ -257,7 +257,7 @@ namespace GraphQLParser.Visitors
             }
             await Visit(field.Name, context).ConfigureAwait(false);
             await Visit(field.Arguments, context).ConfigureAwait(false);
-            await VisitDirectives(field, context).ConfigureAwait(false);
+            await Visit(field.Directives, context).ConfigureAwait(false);
 
             if (field.SelectionSet == null)
                 await context.WriteLine().ConfigureAwait(false);
@@ -276,7 +276,7 @@ namespace GraphQLParser.Visitors
                 await Visit(operationDefinition.Name, context).ConfigureAwait(false);
             }
             await Visit(operationDefinition.Variables, context).ConfigureAwait(false);
-            await VisitDirectives(operationDefinition, context).ConfigureAwait(false);
+            await Visit(operationDefinition.Directives, context).ConfigureAwait(false);
             await Visit(operationDefinition.SelectionSet, context).ConfigureAwait(false);
         }
 
@@ -302,7 +302,7 @@ namespace GraphQLParser.Visitors
                 await context.Write(" = ").ConfigureAwait(false);
                 await Visit(variableDefinition.DefaultValue, context).ConfigureAwait(false);
             }
-            await VisitDirectives(variableDefinition, context).ConfigureAwait(false);
+            await Visit(variableDefinition.Directives, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -342,7 +342,7 @@ namespace GraphQLParser.Visitors
             await Visit(scalarTypeDefinition.Description, context).ConfigureAwait(false);
             await context.Write("scalar ").ConfigureAwait(false);
             await Visit(scalarTypeDefinition.Name, context).ConfigureAwait(false);
-            await VisitDirectives(scalarTypeDefinition, context).ConfigureAwait(false);
+            await Visit(scalarTypeDefinition.Directives, context).ConfigureAwait(false);
             await context.WriteLine().ConfigureAwait(false);
         }
 
@@ -352,7 +352,7 @@ namespace GraphQLParser.Visitors
             await Visit(scalarTypeExtension.Comment, context).ConfigureAwait(false);
             await context.Write("extend scalar ").ConfigureAwait(false);
             await Visit(scalarTypeExtension.Name, context).ConfigureAwait(false);
-            await VisitDirectives(scalarTypeExtension, context).ConfigureAwait(false);
+            await Visit(scalarTypeExtension.Directives, context).ConfigureAwait(false);
             await context.WriteLine().ConfigureAwait(false);
         }
 
@@ -363,7 +363,7 @@ namespace GraphQLParser.Visitors
             await Visit(enumTypeDefinition.Description, context).ConfigureAwait(false);
             await context.Write("enum ").ConfigureAwait(false);
             await Visit(enumTypeDefinition.Name, context).ConfigureAwait(false);
-            await VisitDirectives(enumTypeDefinition, context).ConfigureAwait(false);
+            await Visit(enumTypeDefinition.Directives, context).ConfigureAwait(false);
             await Visit(enumTypeDefinition.Values, context).ConfigureAwait(false);
         }
 
@@ -373,7 +373,7 @@ namespace GraphQLParser.Visitors
             await Visit(enumTypeExtension.Comment, context).ConfigureAwait(false);
             await context.Write("extend enum ").ConfigureAwait(false);
             await Visit(enumTypeExtension.Name, context).ConfigureAwait(false);
-            await VisitDirectives(enumTypeExtension, context).ConfigureAwait(false);
+            await Visit(enumTypeExtension.Directives, context).ConfigureAwait(false);
             await Visit(enumTypeExtension.Values, context).ConfigureAwait(false);
         }
 
@@ -387,7 +387,7 @@ namespace GraphQLParser.Visitors
             await WriteIndent(context, level).ConfigureAwait(false);
 
             await Visit(enumValueDefinition.Name, context).ConfigureAwait(false);
-            await VisitDirectives(enumValueDefinition, context).ConfigureAwait(false);
+            await Visit(enumValueDefinition.Directives, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -414,7 +414,7 @@ namespace GraphQLParser.Visitors
             await Visit(inputObjectTypeDefinition.Description, context).ConfigureAwait(false);
             await context.Write("input ").ConfigureAwait(false);
             await Visit(inputObjectTypeDefinition.Name, context).ConfigureAwait(false);
-            await VisitDirectives(inputObjectTypeDefinition, context).ConfigureAwait(false);
+            await Visit(inputObjectTypeDefinition.Directives, context).ConfigureAwait(false);
             await Visit(inputObjectTypeDefinition.Fields, context).ConfigureAwait(false);
             if (inputObjectTypeDefinition.Fields == null)
                 await context.WriteLine().ConfigureAwait(false); // TODO: ???
@@ -426,7 +426,7 @@ namespace GraphQLParser.Visitors
             await Visit(inputObjectTypeExtension.Comment, context).ConfigureAwait(false);
             await context.Write("extend input ").ConfigureAwait(false);
             await Visit(inputObjectTypeExtension.Name, context).ConfigureAwait(false);
-            await VisitDirectives(inputObjectTypeExtension, context).ConfigureAwait(false);
+            await Visit(inputObjectTypeExtension.Directives, context).ConfigureAwait(false);
             await Visit(inputObjectTypeExtension.Fields, context).ConfigureAwait(false);
             if (inputObjectTypeExtension.Fields == null)
                 await context.WriteLine().ConfigureAwait(false); // TODO: ???
@@ -449,7 +449,7 @@ namespace GraphQLParser.Visitors
                 await context.Write(" = ").ConfigureAwait(false);
                 await Visit(inputValueDefinition.DefaultValue, context).ConfigureAwait(false);
             }
-            await VisitDirectives(inputValueDefinition, context).ConfigureAwait(false);
+            await Visit(inputValueDefinition.Directives, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -477,7 +477,7 @@ namespace GraphQLParser.Visitors
             await context.Write("type ").ConfigureAwait(false);
             await Visit(objectTypeDefinition.Name, context).ConfigureAwait(false);
             await VisitInterfaces(objectTypeDefinition, context).ConfigureAwait(false);
-            await VisitDirectives(objectTypeDefinition, context).ConfigureAwait(false);
+            await Visit(objectTypeDefinition.Directives, context).ConfigureAwait(false);
             await Visit(objectTypeDefinition.Fields, context).ConfigureAwait(false);
             if (objectTypeDefinition.Fields == null)
                 await context.WriteLine().ConfigureAwait(false); //TODO: ???
@@ -490,7 +490,7 @@ namespace GraphQLParser.Visitors
             await context.Write("extend type ").ConfigureAwait(false);
             await Visit(objectTypeExtension.Name, context).ConfigureAwait(false);
             await VisitInterfaces(objectTypeExtension, context).ConfigureAwait(false);
-            await VisitDirectives(objectTypeExtension, context).ConfigureAwait(false);
+            await Visit(objectTypeExtension.Directives, context).ConfigureAwait(false);
             await Visit(objectTypeExtension.Fields, context).ConfigureAwait(false);
             if (objectTypeExtension.Fields == null)
                 await context.WriteLine().ConfigureAwait(false); // TODO: ???
@@ -504,7 +504,7 @@ namespace GraphQLParser.Visitors
             await context.Write("interface ").ConfigureAwait(false);
             await Visit(interfaceTypeDefinition.Name, context).ConfigureAwait(false);
             await VisitInterfaces(interfaceTypeDefinition, context).ConfigureAwait(false);
-            await VisitDirectives(interfaceTypeDefinition, context).ConfigureAwait(false);
+            await Visit(interfaceTypeDefinition.Directives, context).ConfigureAwait(false);
             await Visit(interfaceTypeDefinition.Fields, context).ConfigureAwait(false);
         }
 
@@ -515,7 +515,7 @@ namespace GraphQLParser.Visitors
             await context.Write("extend interface ").ConfigureAwait(false);
             await Visit(interfaceTypeExtension.Name, context).ConfigureAwait(false);
             await VisitInterfaces(interfaceTypeExtension, context).ConfigureAwait(false);
-            await VisitDirectives(interfaceTypeExtension, context).ConfigureAwait(false);
+            await Visit(interfaceTypeExtension.Directives, context).ConfigureAwait(false);
             await Visit(interfaceTypeExtension.Fields, context).ConfigureAwait(false);
         }
 
@@ -532,7 +532,7 @@ namespace GraphQLParser.Visitors
             await Visit(fieldDefinition.Arguments, context).ConfigureAwait(false);
             await context.Write(": ").ConfigureAwait(false);
             await Visit(fieldDefinition.Type, context).ConfigureAwait(false);
-            await VisitDirectives(fieldDefinition, context).ConfigureAwait(false);
+            await Visit(fieldDefinition.Directives, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -558,7 +558,7 @@ namespace GraphQLParser.Visitors
             await Visit(schemaDefinition.Comment, context).ConfigureAwait(false);
             await Visit(schemaDefinition.Description, context).ConfigureAwait(false);
             await context.Write("schema").ConfigureAwait(false);
-            await VisitDirectives(schemaDefinition, context).ConfigureAwait(false);
+            await Visit(schemaDefinition.Directives, context).ConfigureAwait(false);
 
             await context.WriteLine().ConfigureAwait(false);
             await context.Write("{").ConfigureAwait(false);
@@ -597,7 +597,7 @@ namespace GraphQLParser.Visitors
             await Visit(unionTypeDefinition.Description, context).ConfigureAwait(false);
             await context.Write("union ").ConfigureAwait(false);
             await Visit(unionTypeDefinition.Name, context).ConfigureAwait(false);
-            await VisitDirectives(unionTypeDefinition, context).ConfigureAwait(false);
+            await Visit(unionTypeDefinition.Directives, context).ConfigureAwait(false);
 
             if (unionTypeDefinition.Types?.Count > 0)
             {
@@ -618,7 +618,7 @@ namespace GraphQLParser.Visitors
             await Visit(unionTypeExtension.Comment, context).ConfigureAwait(false);
             await context.Write("extend union ").ConfigureAwait(false);
             await Visit(unionTypeExtension.Name, context).ConfigureAwait(false);
-            await VisitDirectives(unionTypeExtension, context).ConfigureAwait(false);
+            await Visit(unionTypeExtension.Directives, context).ConfigureAwait(false);
 
             if (unionTypeExtension.Types?.Count > 0)
             {
@@ -640,6 +640,19 @@ namespace GraphQLParser.Visitors
             await context.Write("@").ConfigureAwait(false);
             await Visit(directive.Name, context).ConfigureAwait(false);
             await Visit(directive.Arguments, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public override async ValueTask VisitDirectives(GraphQLDirectives directives, TContext context)
+        {
+            await context.Write(" ").ConfigureAwait(false);
+
+            for (int i = 0; i < directives.Items.Count; ++i)
+            {
+                await Visit(directives.Items[i], context).ConfigureAwait(false);
+                if (i < directives.Items.Count - 1)
+                    await context.Write(" ").ConfigureAwait(false);
+            }
         }
 
         /// <inheritdoc/>
@@ -798,7 +811,7 @@ namespace GraphQLParser.Visitors
             context.Parents.Pop();
         }
 
-        private async ValueTask VisitInterfaces(IHasInterfacesNode node, TContext context)
+        private async ValueTask VisitInterfaces(IHasInterfacesNode node, TContext context) //TODO: remove
         {
             if (node.Interfaces?.Count > 0)
             {
@@ -809,21 +822,6 @@ namespace GraphQLParser.Visitors
                     await Visit(node.Interfaces[i], context).ConfigureAwait(false);
                     if (i < node.Interfaces.Count - 1)
                         await context.Write(" & ").ConfigureAwait(false);
-                }
-            }
-        }
-
-        private async ValueTask VisitDirectives(IHasDirectivesNode node, TContext context)
-        {
-            if (node.Directives?.Count > 0)
-            {
-                await context.Write(" ").ConfigureAwait(false);
-
-                for (int i = 0; i < node.Directives.Count; ++i)
-                {
-                    await Visit(node.Directives[i], context).ConfigureAwait(false);
-                    if (i < node.Directives.Count - 1)
-                        await context.Write(" ").ConfigureAwait(false);
                 }
             }
         }

--- a/src/GraphQLParser/Visitors/SDLWriter.cs
+++ b/src/GraphQLParser/Visitors/SDLWriter.cs
@@ -308,12 +308,7 @@ namespace GraphQLParser.Visitors
             await Visit(directiveDefinition.Description, context).ConfigureAwait(false);
             await context.Write("directive ").ConfigureAwait(false);
             await Visit(directiveDefinition.Name, context).ConfigureAwait(false);
-            if (directiveDefinition.Arguments != null)
-            {
-                await context.Write("(").ConfigureAwait(false);
-                await Visit(directiveDefinition, context).ConfigureAwait(false);
-                await context.Write(")").ConfigureAwait(false);
-            }
+            await Visit(directiveDefinition.Arguments, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -626,17 +621,7 @@ namespace GraphQLParser.Visitors
             await WriteIndent(context, level).ConfigureAwait(false);
 
             await Visit(fieldDefinition.Name, context).ConfigureAwait(false);
-            if (fieldDefinition.Arguments?.Count > 0)
-            {
-                await context.Write("(").ConfigureAwait(false);
-                for (int i = 0; i < fieldDefinition.Arguments.Count; ++i)
-                {
-                    await Visit(fieldDefinition.Arguments[i], context).ConfigureAwait(false);
-                    if (i < fieldDefinition.Arguments.Count - 1)
-                        await context.Write(", ").ConfigureAwait(false);
-                }
-                await context.Write(")").ConfigureAwait(false);
-            }
+            await Visit(fieldDefinition.Arguments, context).ConfigureAwait(false);
             await context.Write(": ").ConfigureAwait(false);
             await Visit(fieldDefinition.Type, context).ConfigureAwait(false);
             await VisitDirectives(fieldDefinition, context).ConfigureAwait(false);
@@ -744,6 +729,18 @@ namespace GraphQLParser.Visitors
             await Visit(argument.Name, context).ConfigureAwait(false);
             await context.Write(": ").ConfigureAwait(false);
             await Visit(argument.Value, context).ConfigureAwait(false);
+        }
+
+        public override async ValueTask VisitArgumentsDefinition(GraphQLArgumentsDefinition argumentsDefinition, TContext context)
+        {
+            await context.Write("(").ConfigureAwait(false);
+            for (int i = 0; i < argumentsDefinition.InputValueDefinitions.Count; ++i)
+            {
+                await Visit(argumentsDefinition.InputValueDefinitions[i], context).ConfigureAwait(false);
+                if (i < argumentsDefinition.InputValueDefinitions.Count - 1)
+                    await context.Write(", ").ConfigureAwait(false);
+            }
+            await context.Write(")").ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/GraphQLParser/Visitors/SDLWriter.cs
+++ b/src/GraphQLParser/Visitors/SDLWriter.cs
@@ -364,19 +364,7 @@ namespace GraphQLParser.Visitors
             await context.Write("enum ").ConfigureAwait(false);
             await Visit(enumTypeDefinition.Name, context).ConfigureAwait(false);
             await VisitDirectives(enumTypeDefinition, context).ConfigureAwait(false);
-            if (enumTypeDefinition.Values?.Count > 0)
-            {
-                await context.WriteLine().ConfigureAwait(false);
-                await context.Write("{").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-                for (int i = 0; i < enumTypeDefinition.Values.Count; ++i)
-                {
-                    await Visit(enumTypeDefinition.Values[i], context).ConfigureAwait(false);
-                    await context.WriteLine().ConfigureAwait(false);
-                }
-                await context.Write("}").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-            }
+            await Visit(enumTypeDefinition.Values, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -386,19 +374,7 @@ namespace GraphQLParser.Visitors
             await context.Write("extend enum ").ConfigureAwait(false);
             await Visit(enumTypeExtension.Name, context).ConfigureAwait(false);
             await VisitDirectives(enumTypeExtension, context).ConfigureAwait(false);
-            if (enumTypeExtension.Values?.Count > 0)
-            {
-                await context.WriteLine().ConfigureAwait(false);
-                await context.Write("{").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-                for (int i = 0; i < enumTypeExtension.Values.Count; ++i)
-                {
-                    await Visit(enumTypeExtension.Values[i], context).ConfigureAwait(false);
-                    await context.WriteLine().ConfigureAwait(false);
-                }
-                await context.Write("}").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-            }
+            await Visit(enumTypeExtension.Values, context).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -412,6 +388,23 @@ namespace GraphQLParser.Visitors
 
             await Visit(enumValueDefinition.Name, context).ConfigureAwait(false);
             await VisitDirectives(enumValueDefinition, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public override async ValueTask VisitEnumValuesDefinition(GraphQLEnumValuesDefinition enumValuesDefinition, TContext context)
+        {
+            await context.WriteLine().ConfigureAwait(false);
+            await context.Write("{").ConfigureAwait(false);
+            await context.WriteLine().ConfigureAwait(false);
+
+            for (int i = 0; i < enumValuesDefinition.Items.Count; ++i)
+            {
+                await Visit(enumValuesDefinition.Items[i], context).ConfigureAwait(false);
+                await context.WriteLine().ConfigureAwait(false);
+            }
+
+            await context.Write("}").ConfigureAwait(false);
+            await context.WriteLine().ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/src/GraphQLParser/Visitors/SDLWriter.cs
+++ b/src/GraphQLParser/Visitors/SDLWriter.cs
@@ -214,6 +214,19 @@ namespace GraphQLParser.Visitors
         }
 
         /// <inheritdoc/>
+        public override async ValueTask VisitImplementsInterfaces(GraphQLImplementsInterfaces implementsInterfaces, TContext context)
+        {
+            await context.Write(" implements ").ConfigureAwait(false);
+
+            for (int i = 0; i < implementsInterfaces.Items.Count; ++i)
+            {
+                await Visit(implementsInterfaces.Items[i], context).ConfigureAwait(false);
+                if (i < implementsInterfaces.Items.Count - 1)
+                    await context.Write(" & ").ConfigureAwait(false);
+            }
+        }
+
+        /// <inheritdoc/>
         public override async ValueTask VisitSelectionSet(GraphQLSelectionSet selectionSet, TContext context)
         {
             await Visit(selectionSet.Comment, context).ConfigureAwait(false);
@@ -476,7 +489,7 @@ namespace GraphQLParser.Visitors
             await Visit(objectTypeDefinition.Description, context).ConfigureAwait(false);
             await context.Write("type ").ConfigureAwait(false);
             await Visit(objectTypeDefinition.Name, context).ConfigureAwait(false);
-            await VisitInterfaces(objectTypeDefinition, context).ConfigureAwait(false);
+            await Visit(objectTypeDefinition.Interfaces, context).ConfigureAwait(false);
             await Visit(objectTypeDefinition.Directives, context).ConfigureAwait(false);
             await Visit(objectTypeDefinition.Fields, context).ConfigureAwait(false);
             if (objectTypeDefinition.Fields == null)
@@ -489,7 +502,7 @@ namespace GraphQLParser.Visitors
             await Visit(objectTypeExtension.Comment, context).ConfigureAwait(false);
             await context.Write("extend type ").ConfigureAwait(false);
             await Visit(objectTypeExtension.Name, context).ConfigureAwait(false);
-            await VisitInterfaces(objectTypeExtension, context).ConfigureAwait(false);
+            await Visit(objectTypeExtension.Interfaces, context).ConfigureAwait(false);
             await Visit(objectTypeExtension.Directives, context).ConfigureAwait(false);
             await Visit(objectTypeExtension.Fields, context).ConfigureAwait(false);
             if (objectTypeExtension.Fields == null)
@@ -503,7 +516,7 @@ namespace GraphQLParser.Visitors
             await Visit(interfaceTypeDefinition.Description, context).ConfigureAwait(false);
             await context.Write("interface ").ConfigureAwait(false);
             await Visit(interfaceTypeDefinition.Name, context).ConfigureAwait(false);
-            await VisitInterfaces(interfaceTypeDefinition, context).ConfigureAwait(false);
+            await Visit(interfaceTypeDefinition.Interfaces, context).ConfigureAwait(false);
             await Visit(interfaceTypeDefinition.Directives, context).ConfigureAwait(false);
             await Visit(interfaceTypeDefinition.Fields, context).ConfigureAwait(false);
         }
@@ -514,7 +527,7 @@ namespace GraphQLParser.Visitors
             await Visit(interfaceTypeExtension.Comment, context).ConfigureAwait(false);
             await context.Write("extend interface ").ConfigureAwait(false);
             await Visit(interfaceTypeExtension.Name, context).ConfigureAwait(false);
-            await VisitInterfaces(interfaceTypeExtension, context).ConfigureAwait(false);
+            await Visit(interfaceTypeExtension.Interfaces, context).ConfigureAwait(false);
             await Visit(interfaceTypeExtension.Directives, context).ConfigureAwait(false);
             await Visit(interfaceTypeExtension.Fields, context).ConfigureAwait(false);
         }
@@ -809,21 +822,6 @@ namespace GraphQLParser.Visitors
             await base.Visit(node, context).ConfigureAwait(false);
 
             context.Parents.Pop();
-        }
-
-        private async ValueTask VisitInterfaces(IHasInterfacesNode node, TContext context) //TODO: remove
-        {
-            if (node.Interfaces?.Count > 0)
-            {
-                await context.Write(" implements ").ConfigureAwait(false);
-
-                for (int i = 0; i < node.Interfaces.Count; ++i)
-                {
-                    await Visit(node.Interfaces[i], context).ConfigureAwait(false);
-                    if (i < node.Interfaces.Count - 1)
-                        await context.Write(" & ").ConfigureAwait(false);
-                }
-            }
         }
 
         private string GetOperationType(OperationType type) => type switch

--- a/src/GraphQLParser/Visitors/SDLWriter.cs
+++ b/src/GraphQLParser/Visitors/SDLWriter.cs
@@ -269,29 +269,13 @@ namespace GraphQLParser.Visitors
         public override async ValueTask VisitOperationDefinition(GraphQLOperationDefinition operationDefinition, TContext context)
         {
             await Visit(operationDefinition.Comment, context).ConfigureAwait(false);
-
             if (operationDefinition.Name != null)
             {
                 await context.Write(GetOperationType(operationDefinition.Operation)).ConfigureAwait(false);
                 await context.Write(" ").ConfigureAwait(false);
                 await Visit(operationDefinition.Name, context).ConfigureAwait(false);
             }
-
-            if (operationDefinition.VariableDefinitions?.Count > 0)
-            {
-                await context.Write("(").ConfigureAwait(false);
-                if (operationDefinition.VariableDefinitions?.Count > 0)
-                {
-                    for (int i = 0; i < operationDefinition.VariableDefinitions.Count; ++i)
-                    {
-                        await Visit(operationDefinition.VariableDefinitions[i], context).ConfigureAwait(false);
-                        if (i < operationDefinition.VariableDefinitions.Count - 1)
-                            await context.Write(", ").ConfigureAwait(false);
-                    }
-                }
-                await context.Write(")").ConfigureAwait(false);
-            }
-
+            await Visit(operationDefinition.Variables, context).ConfigureAwait(false);
             await VisitDirectives(operationDefinition, context).ConfigureAwait(false);
             await Visit(operationDefinition.SelectionSet, context).ConfigureAwait(false);
         }
@@ -319,6 +303,21 @@ namespace GraphQLParser.Visitors
                 await Visit(variableDefinition.DefaultValue, context).ConfigureAwait(false);
             }
             await VisitDirectives(variableDefinition, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public override async ValueTask VisitVariablesDefinition(GraphQLVariablesDefinition variablesDefinition, TContext context)
+        {
+            await context.Write("(").ConfigureAwait(false);
+
+            for (int i = 0; i < variablesDefinition.Items.Count; ++i)
+            {
+                await Visit(variablesDefinition.Items[i], context).ConfigureAwait(false);
+                if (i < variablesDefinition.Items.Count - 1)
+                    await context.Write(", ").ConfigureAwait(false);
+            }
+
+            await context.Write(")").ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -710,12 +709,14 @@ namespace GraphQLParser.Visitors
         public override async ValueTask VisitArgumentsDefinition(GraphQLArgumentsDefinition argumentsDefinition, TContext context)
         {
             await context.Write("(").ConfigureAwait(false);
+
             for (int i = 0; i < argumentsDefinition.Items.Count; ++i)
             {
                 await Visit(argumentsDefinition.Items[i], context).ConfigureAwait(false);
                 if (i < argumentsDefinition.Items.Count - 1)
                     await context.Write(", ").ConfigureAwait(false);
             }
+
             await context.Write(")").ConfigureAwait(false);
         }
 

--- a/src/GraphQLParser/Visitors/SDLWriter.cs
+++ b/src/GraphQLParser/Visitors/SDLWriter.cs
@@ -423,25 +423,9 @@ namespace GraphQLParser.Visitors
             await context.Write("input ").ConfigureAwait(false);
             await Visit(inputObjectTypeDefinition.Name, context).ConfigureAwait(false);
             await VisitDirectives(inputObjectTypeDefinition, context).ConfigureAwait(false);
-            if (inputObjectTypeDefinition.Fields?.Count > 0)
-            {
-                await context.WriteLine().ConfigureAwait(false);
-                await context.Write("{").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-
-                for (int i = 0; i < inputObjectTypeDefinition.Fields.Count; ++i)
-                {
-                    await Visit(inputObjectTypeDefinition.Fields[i], context).ConfigureAwait(false);
-                    await context.WriteLine().ConfigureAwait(false);
-                }
-
-                await context.Write("}").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-            }
-            else
-            {
-                await context.WriteLine().ConfigureAwait(false);
-            }
+            await Visit(inputObjectTypeDefinition.Fields, context).ConfigureAwait(false);
+            if (inputObjectTypeDefinition.Fields == null)
+                await context.WriteLine().ConfigureAwait(false); // TODO: ???
         }
 
         /// <inheritdoc/>
@@ -451,25 +435,9 @@ namespace GraphQLParser.Visitors
             await context.Write("extend input ").ConfigureAwait(false);
             await Visit(inputObjectTypeExtension.Name, context).ConfigureAwait(false);
             await VisitDirectives(inputObjectTypeExtension, context).ConfigureAwait(false);
-            if (inputObjectTypeExtension.Fields?.Count > 0)
-            {
-                await context.WriteLine().ConfigureAwait(false);
-                await context.Write("{").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-
-                for (int i = 0; i < inputObjectTypeExtension.Fields.Count; ++i)
-                {
-                    await Visit(inputObjectTypeExtension.Fields[i], context).ConfigureAwait(false);
-                    await context.WriteLine().ConfigureAwait(false);
-                }
-
-                await context.Write("}").ConfigureAwait(false);
-                await context.WriteLine().ConfigureAwait(false);
-            }
-            else
-            {
-                await context.WriteLine().ConfigureAwait(false);
-            }
+            await Visit(inputObjectTypeExtension.Fields, context).ConfigureAwait(false);
+            if (inputObjectTypeExtension.Fields == null)
+                await context.WriteLine().ConfigureAwait(false); // TODO: ???
         }
 
         /// <inheritdoc/>
@@ -490,6 +458,23 @@ namespace GraphQLParser.Visitors
                 await Visit(inputValueDefinition.DefaultValue, context).ConfigureAwait(false);
             }
             await VisitDirectives(inputValueDefinition, context).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public override async ValueTask VisitInputFieldsDefinition(GraphQLInputFieldsDefinition inputFieldsDefinition, TContext context)
+        {
+            await context.WriteLine().ConfigureAwait(false);
+            await context.Write("{").ConfigureAwait(false);
+            await context.WriteLine().ConfigureAwait(false);
+
+            for (int i = 0; i < inputFieldsDefinition.Items.Count; ++i)
+            {
+                await Visit(inputFieldsDefinition.Items[i], context).ConfigureAwait(false);
+                await context.WriteLine().ConfigureAwait(false);
+            }
+
+            await context.Write("}").ConfigureAwait(false);
+            await context.WriteLine().ConfigureAwait(false);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Introduce new AST nodes:
- http://spec.graphql.org/October2021/#ArgumentsDefinition
- http://spec.graphql.org/October2021/#InputFieldsDefinition
- http://spec.graphql.org/October2021/#Arguments
- http://spec.graphql.org/October2021/#FieldsDefinition
- http://spec.graphql.org/October2021/#EnumValuesDefinition
- http://spec.graphql.org/October2021/#VariableDefinitions
- http://spec.graphql.org/October2021/#Directives
- http://spec.graphql.org/October2021/#ImplementsInterfaces

Goals:
- More strict grammar/parsing
- Less copy-paste in node visitors because of new virtual methods