### PR TITLE
ROM optimizations

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -363,6 +363,7 @@ namespace GraphQLParser.AST
     public class GraphQLName : GraphQLParser.AST.ASTNode
     {
         public GraphQLName() { }
+        public GraphQLName(GraphQLParser.ROM value) { }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
         public GraphQLParser.ROM Value { get; set; }
         public static string op_Explicit(GraphQLParser.AST.GraphQLName node) { }

--- a/src/GraphQLParser.Tests/GraphQLParser.Tests.csproj
+++ b/src/GraphQLParser.Tests/GraphQLParser.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6;net5;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6</TargetFramework>
     <Nullable>disable</Nullable>
     <NoWarn>$(NoWarn);1591;IDE0008;IDE0022;IDE0058;IDE1006</NoWarn>
   </PropertyGroup>

--- a/src/GraphQLParser.Tests/MemoryTests.cs
+++ b/src/GraphQLParser.Tests/MemoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using GraphQLParser.AST;
 using Shouldly;
 using Xunit;
@@ -7,6 +8,16 @@ namespace GraphQLParser.Tests;
 
 public class MemoryTests
 {
+    [Fact]
+    public void SizeOf_ROM_Should_Be_The_Same_As_ReadOnlyMemory()
+    {
+        ROM r = default;
+        Marshal.SizeOf(r).ShouldBe(16);
+
+        ReadOnlyMemory<char> m = default;
+        Marshal.SizeOf(m).ShouldBe(16);
+    }
+
     [Fact]
     public void Operators()
     {
@@ -46,6 +57,17 @@ public class MemoryTests
         rom.Equals((object)rom).ShouldBeTrue();
         rom.Equals((object)str).ShouldBeFalse();
         rom.Equals("strin").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Casted_To_String_From_Original_String_Should_Be_Equal()
+    {
+        var str = "string";
+        ROM rom = str;
+
+        // so no heap allocation when ROM is actually backed by whole string object
+        ReferenceEquals(rom.ToString(), str).ShouldBeTrue();
+        ReferenceEquals((string)rom, str).ShouldBeTrue();
     }
 
     [Fact]

--- a/src/GraphQLParser.Tests/MemoryTests.cs
+++ b/src/GraphQLParser.Tests/MemoryTests.cs
@@ -90,14 +90,14 @@ public class MemoryTests
     [Fact]
     public void GraphQLName_Implicit_Cast()
     {
-        var name = new GraphQLName { Value = "abc" };
+        var name = new GraphQLName("abc");
         FuncROM(name).ShouldBe(name);
     }
 
     [Fact]
     public void GraphQLName_Explicit_Cast()
     {
-        var name = new GraphQLName { Value = "abc" };
+        var name = new GraphQLName("abc");
         FuncString((string)name).ShouldBe("abc");
     }
 

--- a/src/GraphQLParser.Tests/MemoryTests.cs
+++ b/src/GraphQLParser.Tests/MemoryTests.cs
@@ -40,7 +40,9 @@ public class MemoryTests
         rom2.Length.ShouldBe(5);
         rom2.GetHashCode().ShouldNotBe(0);
         rom2.GetHashCode().ShouldNotBe(rom.GetHashCode());
-        rom.Slice(6).GetHashCode().ShouldBe(0);
+        rom.Slice(6).GetHashCode().ShouldNotBe(0);
+
+        default(ROM).GetHashCode().ShouldBe(0);
 
         (rom2 == str).ShouldBeFalse();
         (str == rom2).ShouldBeFalse();

--- a/src/GraphQLParser.Tests/MemoryTests.cs
+++ b/src/GraphQLParser.Tests/MemoryTests.cs
@@ -11,11 +11,8 @@ public class MemoryTests
     [Fact]
     public void SizeOf_ROM_Should_Be_The_Same_As_ReadOnlyMemory()
     {
-        ROM r = default;
-        Marshal.SizeOf(r).ShouldBe(16);
-
-        ReadOnlyMemory<char> m = default;
-        Marshal.SizeOf(m).ShouldBe(16);
+        Marshal.SizeOf<ROM>().ShouldBe(16);
+        Marshal.SizeOf<ReadOnlyMemory<char>>().ShouldBe(16);
     }
 
     [Fact]

--- a/src/GraphQLParser.Tests/MemoryTests.cs
+++ b/src/GraphQLParser.Tests/MemoryTests.cs
@@ -11,8 +11,11 @@ public class MemoryTests
     [Fact]
     public void SizeOf_ROM_Should_Be_The_Same_As_ReadOnlyMemory()
     {
-        Marshal.SizeOf<ROM>().ShouldBe(16);
-        Marshal.SizeOf(default(ReadOnlyMemory<char>)).ShouldBe(16);
+        if (OperatingSystem.IsWindows()) // TODO: weird errors on Linux
+        {
+            Marshal.SizeOf(default(ROM)).ShouldBe(16);
+            Marshal.SizeOf(default(ReadOnlyMemory<char>)).ShouldBe(16);
+        }
     }
 
     [Fact]

--- a/src/GraphQLParser.Tests/MemoryTests.cs
+++ b/src/GraphQLParser.Tests/MemoryTests.cs
@@ -12,7 +12,7 @@ public class MemoryTests
     public void SizeOf_ROM_Should_Be_The_Same_As_ReadOnlyMemory()
     {
         Marshal.SizeOf<ROM>().ShouldBe(16);
-        Marshal.SizeOf<ReadOnlyMemory<char>>().ShouldBe(16);
+        Marshal.SizeOf(default(ReadOnlyMemory<char>)).ShouldBe(16);
     }
 
     [Fact]

--- a/src/GraphQLParser/AST/GraphQLName.cs
+++ b/src/GraphQLParser/AST/GraphQLName.cs
@@ -12,6 +12,21 @@ public class GraphQLName : ASTNode
     public override ASTNodeKind Kind => ASTNodeKind.Name;
 
     /// <summary>
+    /// Creates a new instance (with empty value).
+    /// </summary>
+    public GraphQLName()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance with the specified value.
+    /// </summary>
+    public GraphQLName(ROM value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
     /// Name value represented as <see cref="ROM"/>.
     /// </summary>
     public ROM Value { get; set; }

--- a/src/GraphQLParser/ROM.cs
+++ b/src/GraphQLParser/ROM.cs
@@ -53,10 +53,28 @@ public readonly struct ROM : IEquatable<ROM>
         if (_memory.Equals(other._memory))
             return true;
 
-        // then check byte by byte
-        if (_memory.Length != other._memory.Length)
-            return false;
+        // then check byte by byte, SequenceEqual already has length check
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //public static bool SequenceEqual<T>(this ReadOnlySpan<T> span, ReadOnlySpan<T> other) where T : IEquatable<T>
+        //{
+        //    int length = span.Length;
+        //    if (default(T) != null && IsTypeComparableAsBytes<T>(out NUInt size))
+        //    {
+        //        if (length == other.Length)
+        //        {
+        //            return SpanHelpers.SequenceEqual(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)), ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(other)), (NUInt)length * size);
+        //        }
 
+        //        return false;
+        //    }
+
+        //    if (length == other.Length)
+        //    {
+        //        return SpanHelpers.SequenceEqual(ref MemoryMarshal.GetReference(span), ref MemoryMarshal.GetReference(other), length);
+        //    }
+
+        //    return false;
+        //}
         return _memory.Span.SequenceEqual(other._memory.Span);
     }
 

--- a/src/GraphQLParser/ROM.cs
+++ b/src/GraphQLParser/ROM.cs
@@ -38,41 +38,10 @@ public readonly struct ROM : IEquatable<ROM>
     public override bool Equals(object obj) => obj is ROM rom && Equals(rom);
 
     /// <inheritdoc/>
-    public bool Equals(ROM other)
-    {
-        if (_memory.Length != other._memory.Length)
-            return false;
-
-        return _memory.Span.SequenceEqual(other._memory.Span);
-    }
+    public bool Equals(ROM other) => _memory.Equals(other._memory);
 
     /// <inheritdoc/>
-    public override int GetHashCode() // TODO: find a better implementation
-    {
-        if (_memory.Length == 0)
-            return 0;
-
-        int num1 = 5381;
-        int num2 = num1;
-        int num3;
-        int end = _memory.Length - 1;
-        var span = _memory.Span;
-
-        for (int i = 0; i <= end; i += 2)
-        {
-            num3 = span[i];
-            num1 = (num1 << 5) + num1 ^ num3;
-            if (i == end)
-                break;
-            int num4 = span[i + 1];
-            //if (num4 != 0)
-            num2 = (num2 << 5) + num2 ^ num4;
-            //else
-            //    break;
-        }
-
-        return num1 + num2 * 1566083941;
-    }
+    public override int GetHashCode() => _memory.GetHashCode();
 
     /// <inheritdoc/>
     public override string ToString() => _memory.ToString();

--- a/src/GraphQLParser/ROM.cs
+++ b/src/GraphQLParser/ROM.cs
@@ -38,7 +38,27 @@ public readonly struct ROM : IEquatable<ROM>
     public override bool Equals(object obj) => obj is ROM rom && Equals(rom);
 
     /// <inheritdoc/>
-    public bool Equals(ROM other) => _memory.Equals(other._memory);
+    public bool Equals(ROM other)
+    {
+        // fast check in case of memory is backed by the same string object
+        //public bool Equals(ReadOnlyMemory<T> other)
+        //{
+        //    if (_object == other._object && _index == other._index)
+        //    {
+        //        return _length == other._length;
+        //    }
+
+        //    return false;
+        //}
+        if (_memory.Equals(other._memory))
+            return true;
+
+        // then check byte by byte
+        if (_memory.Length != other._memory.Length)
+            return false;
+
+        return _memory.Span.SequenceEqual(other._memory.Span);
+    }
 
     /// <inheritdoc/>
     public override int GetHashCode() => _memory.GetHashCode();


### PR DESCRIPTION
These changes will allow us to work with ROM more widely/freely in the main project. Many places that use `string` can be changed to `ROM` without performance drop (I think).