### PR TITLE
Add GraphQLName.ToString/StringValue

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -365,7 +365,9 @@ namespace GraphQLParser.AST
         public GraphQLName() { }
         public GraphQLName(GraphQLParser.ROM value) { }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+        public string StringValue { get; }
         public GraphQLParser.ROM Value { get; set; }
+        public override string ToString() { }
         public static string op_Explicit(GraphQLParser.AST.GraphQLName? node) { }
         public static GraphQLParser.ROM op_Implicit(GraphQLParser.AST.GraphQLName? node) { }
     }

--- a/src/GraphQLParser.Tests/MemoryTests.cs
+++ b/src/GraphQLParser.Tests/MemoryTests.cs
@@ -9,6 +9,22 @@ namespace GraphQLParser.Tests;
 
 public class MemoryTests
 {
+    [Fact]
+    public void GraphQLName_Cache_StringValue()
+    {
+        var name = new GraphQLName();
+        name.StringValue.ShouldBe(string.Empty);
+        name.ToString().ShouldBe(string.Empty);
+
+        name.Value = "abc";
+        name.StringValue.ShouldBe("abc");
+        name.ToString().ShouldBe("abc");
+
+        name.Value = "def";
+        name.StringValue.ShouldBe("def");
+        name.ToString().ShouldBe("def");
+    }
+
     [Fact(Skip = "ReadOnlyMemory<T>.GetHashCode demonstration")]
     public void GetHashCode_Issue()
     {

--- a/src/GraphQLParser/AST/GraphQLName.cs
+++ b/src/GraphQLParser/AST/GraphQLName.cs
@@ -8,6 +8,9 @@ namespace GraphQLParser.AST;
 [DebuggerDisplay("GraphQLName: {Value}")]
 public class GraphQLName : ASTNode
 {
+    private ROM _value;
+    private string? _string;
+
     /// <inheritdoc/>
     public override ASTNodeKind Kind => ASTNodeKind.Name;
 
@@ -26,10 +29,42 @@ public class GraphQLName : ASTNode
         Value = value;
     }
 
+
     /// <summary>
     /// Name value represented as <see cref="ROM"/>.
     /// </summary>
-    public ROM Value { get; set; }
+    public ROM Value
+    {
+        get => _value;
+        set
+        {
+            _value = value;
+            _string = null;
+        }
+    }
+
+    /// <summary>
+    /// Name value represented as <see cref="string"/>.
+    /// <br/>
+    /// This property allocates the string on the heap on first access
+    /// and then caches it until <see cref="Value"/> does not change.
+    /// </summary>
+    public string StringValue
+    {
+        get
+        {
+            if (_value.Length == 0)
+                return string.Empty;
+
+            if (_string == null)
+                _string = (string)_value;
+
+            return _string;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => StringValue;
 
     /// <summary>
     /// Implicitly casts <see cref="GraphQLName"/> to <see cref="ROM"/>.


### PR DESCRIPTION
A lot of cases use `GraphQLName` in printing error messages:
![изображение](https://user-images.githubusercontent.com/21261007/149598610-bdacd42c-35e6-43d4-a1b9-00553567f660.png)

`ToString` is called during string interpolation.