### PR TITLE
Add nullable annotations in operators

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -669,13 +669,13 @@ namespace GraphQLParser
         public static GraphQLParser.ROM op_Implicit(char[] array) { }
         public static GraphQLParser.ROM op_Implicit(System.Memory<char> memory) { }
         public static GraphQLParser.ROM op_Implicit(System.ReadOnlyMemory<char> memory) { }
-        public static GraphQLParser.ROM op_Implicit(string s) { }
-        public static bool operator !=(GraphQLParser.ROM rom, string s) { }
+        public static GraphQLParser.ROM op_Implicit(string? s) { }
+        public static bool operator !=(GraphQLParser.ROM rom, string? s) { }
         public static bool operator !=(GraphQLParser.ROM rom1, GraphQLParser.ROM rom2) { }
-        public static bool operator !=(string s, GraphQLParser.ROM rom) { }
-        public static bool operator ==(GraphQLParser.ROM rom, string s) { }
+        public static bool operator !=(string? s, GraphQLParser.ROM rom) { }
+        public static bool operator ==(GraphQLParser.ROM rom, string? s) { }
         public static bool operator ==(GraphQLParser.ROM rom1, GraphQLParser.ROM rom2) { }
-        public static bool operator ==(string s, GraphQLParser.ROM rom) { }
+        public static bool operator ==(string? s, GraphQLParser.ROM rom) { }
     }
     public readonly struct Token
     {

--- a/src/GraphQLParser.Tests/MemoryTests.cs
+++ b/src/GraphQLParser.Tests/MemoryTests.cs
@@ -87,6 +87,14 @@ public class MemoryTests
     }
 
     [Fact]
+    public void Implicit_Operator_From_Null_String()
+    {
+        string s = null;
+        ROM r = s;
+        r.Length.ShouldBe(0);
+    }
+
+    [Fact]
     public void Operators()
     {
         var str = "string";
@@ -119,6 +127,15 @@ public class MemoryTests
 
         ROM.Empty.Length.ShouldBe(0);
         ROM.Empty.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void Default_ROM_ShouldBe_Always_StringEmpty_Instance()
+    {
+        ReferenceEquals((string)default(ROM), (string)default(ROM)).ShouldBeTrue();
+        ReferenceEquals((string)default(ROM), string.Empty).ShouldBeTrue();
+        ReferenceEquals(default(ROM).ToString(), default(ROM).ToString()).ShouldBeTrue();
+        ReferenceEquals(default(ROM).ToString(), string.Empty).ShouldBeTrue();
     }
 
     [Fact]

--- a/src/GraphQLParser.Tests/Values/GraphQLNameTests.cs
+++ b/src/GraphQLParser.Tests/Values/GraphQLNameTests.cs
@@ -91,6 +91,12 @@ public class GraphQLNameTests
         (name != (string)null).ShouldBeFalse();
         ((GraphQLName)null != name).ShouldBeFalse();
         ((string)null != name).ShouldBeFalse();
+
+        var nameNull = (GraphQLName)null;
+        (nameNull == (string)null).ShouldBeTrue();
+        (nameNull != (string)null).ShouldBeFalse();
+
+        (name == "def").ShouldBeFalse();
     }
 
     [Fact]

--- a/src/GraphQLParser/AST/GraphQLName.cs
+++ b/src/GraphQLParser/AST/GraphQLName.cs
@@ -59,7 +59,7 @@ public class GraphQLName : ASTNode, IHasValueNode, IEquatable<GraphQLName>
     /// <summary>
     /// Explicitly casts <see cref="GraphQLName"/> to <see cref="string"/>.
     /// </summary>
-    public static explicit operator string(GraphQLName? node) => node is null ? null! : (string)node.Value; //TODO: not sure about nullability annotations for operators
+    public static explicit operator string(GraphQLName? node) => node is null ? null! : (string)node.Value; //TODO: not sure about nullability annotation for returned string here
 
     /// <summary>
     /// Checks two names for equality. The check is based on the actual contents of the two chunks of memory.

--- a/src/GraphQLParser/ROM.cs
+++ b/src/GraphQLParser/ROM.cs
@@ -167,7 +167,7 @@ public readonly struct ROM : IEquatable<ROM>
     /// <summary>
     /// Implicitly casts string to <see cref="ROM"/>.
     /// </summary>
-    public static implicit operator ROM(string s) => s.AsMemory();
+    public static implicit operator ROM(string? s) => s.AsMemory();
 
     /// <summary>
     /// Explicitly casts <see cref="ROM"/> to string.
@@ -192,20 +192,20 @@ public readonly struct ROM : IEquatable<ROM>
     /// <summary>
     /// Checks ROM and string for equality. The check is based on the actual contents of the two chunks of memory.
     /// </summary>
-    public static bool operator ==(ROM rom, string s) => rom._memory.Span.SequenceEqual(s.AsSpan());
+    public static bool operator ==(ROM rom, string? s) => rom._memory.Span.SequenceEqual(s.AsSpan());
 
     /// <summary>
     /// Checks ROM and string for inequality. The check is based on the actual contents of the two chunks of memory.
     /// </summary>
-    public static bool operator !=(ROM rom, string s) => !rom._memory.Span.SequenceEqual(s.AsSpan());
+    public static bool operator !=(ROM rom, string? s) => !rom._memory.Span.SequenceEqual(s.AsSpan());
 
     /// <summary>
     /// Checks string and ROM and for equality. The check is based on the actual contents of the two chunks of memory.
     /// </summary>
-    public static bool operator ==(string s, ROM rom) => rom == s;
+    public static bool operator ==(string? s, ROM rom) => rom == s;
 
     /// <summary>
     /// Checks string and ROM and for inequality. The check is based on the actual contents of the two chunks of memory.
     /// </summary>
-    public static bool operator !=(string s, ROM rom) => rom != s;
+    public static bool operator !=(string? s, ROM rom) => rom != s;
 }


### PR DESCRIPTION
Both `AsMemory` and `AsSpan` exytensions work well with `null`:
```csharp
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
        public static ReadOnlySpan<char> AsSpan(this string text)
        {
            if (text == null)
            {
                return default(ReadOnlySpan<char>);
            }

            return new ReadOnlySpan<char>(Unsafe.As<Pinnable<char>>(text), StringAdjustment, text.Length);
        }

 public static ReadOnlyMemory<char> AsMemory(this string text)
        {
            if (text == null)
            {
                return default(ReadOnlyMemory<char>);
            }

            return new ReadOnlyMemory<char>(text, 0, text.Length);
        }
```