### PR TITLE
Optimize location conversion

### DIFF
--- a/src/GraphQLParser.Tests/LocationTests.cs
+++ b/src/GraphQLParser.Tests/LocationTests.cs
@@ -126,8 +126,25 @@ query q {
     [Theory]
     [InlineData("\r", 0, 1, 1)]
     [InlineData("\r", 1, 1, 2)]
+
     [InlineData("\n", 0, 1, 1)]
     [InlineData("\n", 1, 1, 2)]
+
+    [InlineData("\n\n", 0, 1, 1)]
+    [InlineData("\n\n", 1, 2, 1)]
+    [InlineData("\n\n", 2, 2, 2)]
+    [InlineData("\n\n ", 2, 3, 1)]
+
+    [InlineData("\r\r", 0, 1, 1)]
+    [InlineData("\r\r", 1, 2, 1)]
+    [InlineData("\r\r", 2, 2, 2)]
+    [InlineData("\r\r ", 2, 3, 1)]
+
+    [InlineData("\r\n", 0, 1, 1)]
+    [InlineData("\r\n", 1, 1, 2)]
+    [InlineData("\r\n", 2, 1, 3)]
+    [InlineData("\r\n ", 2, 2, 1)]
+
     [InlineData("a", 100, 1, 101)]
     public void SpecialCases(string query, int start, int line, int column)
     {

--- a/src/GraphQLParser.Tests/LocationTests.cs
+++ b/src/GraphQLParser.Tests/LocationTests.cs
@@ -116,7 +116,7 @@ query q {
     name
   }
 }";
-        query = query.Replace("\r\n", "\r").Substring(16);
+        query = query.Replace("\r\n", "\n").Substring(16).Replace("\n", "\r");
         query[start].ShouldBe(c);
         var location = new Location(query, start);
         location.Line.ShouldBe(line);

--- a/src/GraphQLParser.Tests/LocationTests.cs
+++ b/src/GraphQLParser.Tests/LocationTests.cs
@@ -31,4 +31,108 @@ public class LocationTests
         var loc = new GraphQLLocation(10, 100);
         loc.ToString().ShouldBe("(10,100)");
     }
+
+    [Theory]
+    [InlineData(0, 1, 1, 'q')]
+    [InlineData(1, 1, 2, 'u')]
+    [InlineData(8, 1, 9, '{')]
+    [InlineData(9, 1, 10, '\r')] // special case, does not occur in practice
+    [InlineData(10, 1, 11, '\n')] // special case, does not occur in practice
+    [InlineData(11, 2, 1, ' ')]
+    [InlineData(13, 2, 3, 'u')]
+    [InlineData(17, 2, 7, ' ')]
+    [InlineData(28, 3, 8, 'r')]
+    [InlineData(74, 7, 5, 'n')]
+    public void ToLocationConvertRN(int start, int line, int column, char c)
+    {
+        var query = @"
+01234567890123
+query q {
+  user {
+    address {
+      street
+      house
+    }
+    name
+  }
+}";
+        query = query.Replace("\r\n", "\n").Substring(16).Replace("\n", "\r\n");
+        query[start].ShouldBe(c);
+        var location = new Location(query, start);
+        location.Line.ShouldBe(line);
+        location.Column.ShouldBe(column);
+    }
+
+    [Theory]
+    [InlineData(0, 1, 1, 'q')]
+    [InlineData(1, 1, 2, 'u')]
+    [InlineData(8, 1, 9, '{')]
+    [InlineData(9, 1, 10, '\n')] // special case, does not occur in practice
+    [InlineData(10, 2, 1, ' ')]
+    [InlineData(12, 2, 3, 'u')]
+    [InlineData(16, 2, 7, ' ')]
+    [InlineData(26, 3, 8, 'r')]
+    [InlineData(68, 7, 5, 'n')]
+    public void ToLocationConvertN(int start, int line, int column, char c)
+    {
+        var query = @"
+01234567890123
+query q {
+  user {
+    address {
+      street
+      house
+    }
+    name
+  }
+}";
+        query = query.Replace("\r\n", "\n").Substring(16);
+        query[start].ShouldBe(c);
+        var location = new Location(query, start);
+        location.Line.ShouldBe(line);
+        location.Column.ShouldBe(column);
+    }
+
+    [Theory]
+    [InlineData(0, 1, 1, 'q')]
+    [InlineData(1, 1, 2, 'u')]
+    [InlineData(8, 1, 9, '{')]
+    [InlineData(9, 1, 10, '\r')] // special case, does not occur in practice
+    [InlineData(10, 2, 1, ' ')]
+    [InlineData(12, 2, 3, 'u')]
+    [InlineData(16, 2, 7, ' ')]
+    [InlineData(26, 3, 8, 'r')]
+    [InlineData(68, 7, 5, 'n')]
+    public void ToLocationConvertR(int start, int line, int column, char c)
+    {
+        var query = @"
+01234567890123
+query q {
+  user {
+    address {
+      street
+      house
+    }
+    name
+  }
+}";
+        query = query.Replace("\r\n", "\r").Substring(16);
+        query[start].ShouldBe(c);
+        var location = new Location(query, start);
+        location.Line.ShouldBe(line);
+        location.Column.ShouldBe(column);
+    }
+
+    [Theory]
+    [InlineData("\r", 0, 1, 1)]
+    [InlineData("\r", 1, 1, 2)]
+    [InlineData("\n", 0, 1, 1)]
+    [InlineData("\n", 1, 1, 2)]
+    [InlineData("a", 100, 1, 101)]
+    public void SpecialCases(string query, int start, int line, int column)
+    {
+        var location = new Location(query, start);
+        location.Line.ShouldBe(line);
+        location.Column.ShouldBe(column);
+    }
 }

--- a/src/GraphQLParser/Location.cs
+++ b/src/GraphQLParser/Location.cs
@@ -27,10 +27,14 @@ public readonly struct Location
 
         for (int i = 0; i <= position; ++i)
         {
+            // each case should either
+            // 1) increment Column by 1
+            // or
+            // 2) increment Line by 1 and reset Column to 0
             switch (span[i])
             {
                 case '\n':
-                    if (i == position)
+                    if (i == position) // \n at the end
                     {
                         ++Column;
                     }
@@ -42,22 +46,21 @@ public readonly struct Location
                     break;
 
                 case '\r':
-                    if (i == position)
+                    if (i == position) // \r at the end
                     {
                         ++Column;
                     }
                     else
                     {
                         char next = span[i + 1];
-                        bool nextIncreaseLine = next == '\r' || next == '\n';
-                        if (!nextIncreaseLine)
+                        if (next == '\n') // \r\n at the end
+                        {
+                            ++Column;
+                        }
+                        else
                         {
                             ++Line;
                             Column = 0;
-                        }
-                        else if (i + 1 == position)
-                        {
-                            ++Column;
                         }
                     }
                     break;

--- a/src/GraphQLParser/ROM.cs
+++ b/src/GraphQLParser/ROM.cs
@@ -4,7 +4,11 @@ namespace GraphQLParser;
 
 /// <summary>
 /// A wrapper around ReadOnlyMemory{char} allowing you to use simple syntax when working with it.
-/// <br/>
+/// <br/><br/>
+/// This struct is designed to unify work with objects of <see cref="ReadOnlyMemory{T}"/>,
+/// <see cref="ReadOnlySpan{T}"/> ans <see cref="string"/>. For example, you can directly
+/// pass the string object to all methods accepting <see cref="ROM"/>.
+/// <br/><br/>
 /// Marshal.SizeOf(ROM) = Marshal.SizeOf(ReadOnlyMemory{char}) = 16
 /// </summary>
 public readonly struct ROM : IEquatable<ROM>


### PR DESCRIPTION
I spent on writing and debugging this algorithm a bunch of time. Although this code is performed only when making exception messages, I wanted to get rid of the regular expression. No memory allocations at all now. If you check code before changes on a rather big query, then you will make sure that the work with a regular expression here generates an abnormal amount of memory allocations.