### PR TITLE
Add GraphQLDocument.Source

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -191,6 +191,7 @@ namespace GraphQLParser.AST
         public GraphQLDocument() { }
         public System.Collections.Generic.List<GraphQLParser.AST.ASTNode> Definitions { get; set; }
         public override GraphQLParser.AST.ASTNodeKind Kind { get; }
+        public GraphQLParser.ROM Source { get; set; }
         public System.Collections.Generic.List<System.Collections.Generic.List<GraphQLParser.AST.GraphQLComment>>? UnattachedComments { get; set; }
     }
     public class GraphQLEnumTypeDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDirectivesNode

--- a/src/GraphQLParser.Tests/ParserTests.cs
+++ b/src/GraphQLParser.Tests/ParserTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections;
 using System.Linq;
+using System.Runtime.InteropServices;
 using GraphQLParser.AST;
 using GraphQLParser.Exceptions;
 using Shouldly;
@@ -9,6 +11,32 @@ namespace GraphQLParser.Tests;
 
 public class ParserTests
 {
+    [Fact]
+    public void GraphQLDocument_Source_ShouldBe_Original_String()
+    {
+        string text = "scalar JSON";
+        var doc = text.Parse();
+        (doc.Source == text).ShouldBeTrue();
+
+        // just to demonstrate how TryGetString works
+        MemoryMarshal.TryGetString(doc.Source, out var str1, out var start1, out var length1).ShouldBeTrue();
+        ReferenceEquals(text, str1).ShouldBeTrue();
+        start1.ShouldBe(0);
+        length1.ShouldBe(11);
+
+        var text2 = text.AsMemory().Slice(1);
+        MemoryMarshal.TryGetString(text2, out var str2, out var start2, out var length2).ShouldBeTrue();
+        ReferenceEquals(text, str2).ShouldBeTrue();
+        start2.ShouldBe(1);
+        length2.ShouldBe(10);
+
+        var text3 = text.AsMemory().Slice(2, 4);
+        MemoryMarshal.TryGetString(text3, out var str3, out var start3, out var length3).ShouldBeTrue();
+        ReferenceEquals(text, str3).ShouldBeTrue();
+        start3.ShouldBe(2);
+        length3.ShouldBe(4);
+    }
+
     [Fact]
     public void Should_Throw_With_Deep_Query()
     {

--- a/src/GraphQLParser/AST/GraphQLDocument.cs
+++ b/src/GraphQLParser/AST/GraphQLDocument.cs
@@ -19,6 +19,11 @@ public class GraphQLDocument : ASTNode
     /// Comments that have not been correlated to any AST node of GraphQL document.
     /// </summary>
     public List<List<GraphQLComment>>? UnattachedComments { get; set; }
+
+    /// <summary>
+    /// Input data from which this document was built.
+    /// </summary>
+    public ROM Source { get; set; }
 }
 
 internal sealed class GraphQLDocumentWithLocation : GraphQLDocument

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -91,6 +91,7 @@ internal partial struct ParserContext
         _maxDepth = options.MaxDepth ?? 128;
         // should create document beforehand to use RentedMemoryTracker while parsing comments
         _document = NodeHelper.CreateGraphQLDocument(options.Ignore);
+        _document.Source = source;
         _currentToken = _prevToken = new Token
         (
             TokenKind.UNKNOWN,


### PR DESCRIPTION
`Source` is better than `OriginalQuery` IMO since parser can parse any GraphQL document, not only executable definitions. 