### PR TITLE
Prettify new lines

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -850,6 +850,7 @@ namespace GraphQLParser.Visitors
     public interface IPrintContext : GraphQLParser.Visitors.IASTVisitorContext
     {
         int IndentLevel { get; set; }
+        bool LastDefinitionPrinted { get; set; }
         System.Collections.Generic.Stack<GraphQLParser.AST.ASTNode> Parents { get; }
         System.IO.TextWriter Writer { get; }
     }
@@ -862,6 +863,8 @@ namespace GraphQLParser.Visitors
     public static class PrintContextExtensions
     {
         public static System.Threading.Tasks.ValueTask WriteAsync<TContext>(this TContext context, GraphQLParser.ROM value)
+            where TContext : GraphQLParser.Visitors.IPrintContext { }
+        public static System.Threading.Tasks.ValueTask WriteDoubleLineAsync<TContext>(this TContext context)
             where TContext : GraphQLParser.Visitors.IPrintContext { }
         public static System.Threading.Tasks.ValueTask WriteLineAsync<TContext>(this TContext context)
             where TContext : GraphQLParser.Visitors.IPrintContext { }
@@ -876,6 +879,7 @@ namespace GraphQLParser.Visitors
             public DefaultPrintContext(System.IO.TextWriter writer) { }
             public System.Threading.CancellationToken CancellationToken { get; set; }
             public int IndentLevel { get; set; }
+            public bool LastDefinitionPrinted { get; set; }
             public System.Collections.Generic.Stack<GraphQLParser.AST.ASTNode> Parents { get; set; }
             public System.IO.TextWriter Writer { get; }
         }

--- a/src/GraphQLParser.Tests/Visitors/MaxDepthVisitorTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/MaxDepthVisitorTests.cs
@@ -10,7 +10,7 @@ public class MaxDepthVisitorTests
 {
     /// <summary>
     /// For structure examples see
-    /// <see cref="StructureWriterTests.WriteTreeVisitor_Should_Print_Tree(string, string)"/>
+    /// <see cref="StructurePrinterTests.WriteTreeVisitor_Should_Print_Tree(string, string)"/>
     /// </summary>
     [Theory]
     [InlineData("query a { name age }", 5)]

--- a/src/GraphQLParser.Tests/Visitors/MaxDepthVisitorTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/MaxDepthVisitorTests.cs
@@ -10,7 +10,7 @@ public class MaxDepthVisitorTests
 {
     /// <summary>
     /// For structure examples see
-    /// <see cref="StructurePrinterTests.WriteTreeVisitor_Should_Print_Tree(string, string)"/>
+    /// <see cref="StructurePrinterTests.StructurePrinter_Should_Print_Tree(string, string)"/>
     /// </summary>
     [Theory]
     [InlineData("query a { name age }", 5)]

--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
@@ -143,6 +143,7 @@ String!) repeatable on QUERY|MUTATION|SUBSCRIPTION|FIELD|FRAGMENT_DEFINITION|FRA
     [InlineData(19,
 @"#comment
 input Example @x
+#comment on fields
 {
   self: [Example!]!
   value: String = ""xyz""
@@ -150,7 +151,9 @@ input Example @x
 input B
 input C",
 @"#comment
-input Example @x {
+input Example @x
+#comment on fields
+{
   self: [Example!]!
   value: String = ""xyz""
 }
@@ -296,7 +299,9 @@ query summary($id: ID!, $detailed: Boolean! = true) {
 """"""
 scalar JSON @exportable
 # A dog
-type Dog implements &Animal {
+type Dog implements &Animal
+     #comment on fields
+ {
   """"""inline docs""""""
   volume: Float
   """"""
@@ -314,7 +319,9 @@ description
 scalar JSON @exportable
 
 # A dog
-type Dog implements Animal {
+type Dog implements Animal
+#comment on fields
+{
   ""inline docs""
   volume: Float
   """"""
@@ -453,6 +460,28 @@ extend union Unity =   C
 
 extend union Unity =
   | C", true, false, true)]
+    [InlineData(38,
+@"enum Color
+    #comment
+ {
+     GREEN   RED }
+
+extend enum Color
+#comment
+{   YELLOW }
+",
+@"enum Color
+#comment
+{
+  GREEN
+  RED
+}
+
+extend enum Color
+#comment
+{
+  YELLOW
+}", true)]
     public async Task SDLPrinter_Should_Print_Document(
         int number,
         string text,

--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterVerticalIndentationTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterVerticalIndentationTests.cs
@@ -11,17 +11,17 @@ public class SDLPrinterVerticalIndentationTests
 {
     [Theory]
     [InlineData(1,
-@"schema { query: Q }
+@"
 extend schema @good
-scalar A
+scalar A schema { query: Q }
 ",
-@"schema {
+@"extend schema @good
+
+scalar A
+
+schema {
   query: Q
-}
-
-extend schema @good
-
-scalar A")]
+}")]
     [InlineData(2,
 @"scalar A1
 scalar B
@@ -197,16 +197,6 @@ string expected)
 
     private class MyPrinter : SDLPrinter
     {
-        //protected override ValueTask VisitSchemaDefinitionAsync(GraphQLSchemaDefinition schemaDefinition, DefaultPrintContext context)
-        //{
-        //    return default;
-        //}
-
-        //protected override ValueTask VisitSchemaExtensionAsync(GraphQLSchemaExtension schemaExtension, DefaultPrintContext context)
-        //{
-        //    return default;
-        //}
-
         protected override ValueTask VisitObjectTypeExtensionAsync(GraphQLObjectTypeExtension objectTypeExtension, DefaultPrintContext context)
         {
             return objectTypeExtension.Name.Value.Span[0] == 'A'

--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterVerticalIndentationTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterVerticalIndentationTests.cs
@@ -151,6 +151,34 @@ union D = X | Y
 @"union A1 @vip
 
 union A2 = X | Y")]
+    [InlineData(13,
+@"extend input A1 { a: Int }
+extend input B { a: Int }
+extend input A2 { a: Int }
+extend input E { a: Int }
+extend input D { a: Int }
+",
+@"extend input A1 {
+  a: Int
+}
+
+extend input A2 {
+  a: Int
+}")]
+    [InlineData(14,
+@"extend type A1 { a: Int }
+extend type B { a: Int }
+extend type A2 { a: Int }
+extend type E { a: Int }
+extend type D { a: Int }
+",
+@"extend type A1 {
+  a: Int
+}
+
+extend type A2 {
+  a: Int
+}")]
     public async Task Printer_Should_Print_Pretty_If_Definitions_Skipped(
 int number,
 string text,
@@ -178,6 +206,20 @@ string expected)
         //{
         //    return default;
         //}
+
+        protected override ValueTask VisitObjectTypeExtensionAsync(GraphQLObjectTypeExtension objectTypeExtension, DefaultPrintContext context)
+        {
+            return objectTypeExtension.Name.Value.Span[0] == 'A'
+                ? base.VisitObjectTypeExtensionAsync(objectTypeExtension, context)
+                : default;
+        }
+
+        protected override ValueTask VisitInputObjectTypeExtensionAsync(GraphQLInputObjectTypeExtension inputObjectTypeExtension, DefaultPrintContext context)
+        {
+            return inputObjectTypeExtension.Name.Value.Span[0] == 'A'
+                ? base.VisitInputObjectTypeExtensionAsync(inputObjectTypeExtension, context)
+                : default;
+        }
 
         protected override ValueTask VisitUnionTypeDefinitionAsync(GraphQLUnionTypeDefinition unionTypeDefinition, DefaultPrintContext context)
         {

--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterVerticalIndentationTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterVerticalIndentationTests.cs
@@ -14,6 +14,7 @@ public class SDLPrinterVerticalIndentationTests
 @"
 extend schema @good
 scalar A schema { query: Q }
+extend schema @bad
 ",
 @"extend schema @good
 
@@ -21,7 +22,9 @@ scalar A
 
 schema {
   query: Q
-}")]
+}
+
+extend schema @bad")]
     [InlineData(2,
 @"scalar A1
 scalar B

--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterVerticalIndentationTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterVerticalIndentationTests.cs
@@ -1,0 +1,252 @@
+using System.IO;
+using System.Threading.Tasks;
+using GraphQLParser.AST;
+using GraphQLParser.Visitors;
+using Shouldly;
+using Xunit;
+
+namespace GraphQLParser.Tests.Visitors;
+
+public class SDLPrinterVerticalIndentationTests
+{
+    [Theory]
+    [InlineData(1,
+@"schema { query: Q }
+extend schema @good
+scalar A
+",
+@"schema {
+  query: Q
+}
+
+extend schema @good
+
+scalar A")]
+    [InlineData(2,
+@"scalar A1
+scalar B
+scalar C
+scalar A2
+",
+@"scalar A1
+
+scalar A2")]
+    [InlineData(3,
+@"scalar A1
+scalar B
+scalar A2
+scalar E
+scalar D
+",
+@"scalar A1
+
+scalar A2")]
+    [InlineData(4,
+@"query A1 { x }
+query B { y }
+query A2 { z }
+",
+@"query A1 {
+  x
+}
+
+query A2 {
+  z
+}")]
+    [InlineData(5,
+@"directive @A1 on FIELD
+directive @B on FIELD
+directive @A2 on FIELD
+",
+@"directive @A1 on FIELD
+
+directive @A2 on FIELD")]
+    [InlineData(6,
+@"enum A1 { X Y }
+enum B { X Y }
+enum A2 { X Y }
+enum E { X Y }
+enum D { X Y }
+",
+@"enum A1 {
+  X
+  Y
+}
+
+enum A2 {
+  X
+  Y
+}")]
+    [InlineData(7,
+@"extend enum A1 { X Y }
+extend enum B { X Y }
+extend enum A2 { X Y }
+extend enum E { X Y }
+extend enum D { X Y }
+",
+@"extend enum A1 {
+  X
+  Y
+}
+
+extend enum A2 {
+  X
+  Y
+}")]
+    [InlineData(8,
+@"input A1 @vip
+input B
+input A2 { a: Int }
+input E
+input D
+",
+@"input A1 @vip
+
+input A2 {
+  a: Int
+}")]
+    [InlineData(9,
+@"type A1 @vip
+type B
+type A2 { a: Int }
+type E
+type D
+",
+@"type A1 @vip
+
+type A2 {
+  a: Int
+}")]
+    [InlineData(10,
+@"interface A1 @vip
+interface B
+interface A2 { a: Int }
+interface E
+interface D
+",
+@"interface A1 @vip
+
+interface A2 {
+  a: Int
+}")]
+    [InlineData(11,
+@"extend interface A1 @vip
+extend interface B { a: Int }
+extend interface A2 { a: Int }
+extend interface E { a: Int }
+extend interface D { a: Int }
+",
+@"extend interface A1 @vip
+
+extend interface A2 {
+  a: Int
+}")]
+    [InlineData(12,
+@"union A1 @vip
+union B = X | Y
+union A2 = X | Y
+union E = X | Y
+union D = X | Y
+",
+@"union A1 @vip
+
+union A2 = X | Y")]
+    public async Task Printer_Should_Print_Pretty_If_Definitions_Skipped(
+int number,
+string text,
+string expected)
+    {
+        var printer = new MyPrinter();
+        var writer = new StringWriter();
+        var document = text.Parse();
+
+        await printer.PrintAsync(document, writer).ConfigureAwait(false);
+        var actual = writer.ToString();
+        actual.ShouldBe(expected, $"Test {number} failed");
+
+        actual.Parse(); // should be parsed back
+    }
+
+    private class MyPrinter : SDLPrinter
+    {
+        //protected override ValueTask VisitSchemaDefinitionAsync(GraphQLSchemaDefinition schemaDefinition, DefaultPrintContext context)
+        //{
+        //    return default;
+        //}
+
+        //protected override ValueTask VisitSchemaExtensionAsync(GraphQLSchemaExtension schemaExtension, DefaultPrintContext context)
+        //{
+        //    return default;
+        //}
+
+        protected override ValueTask VisitUnionTypeDefinitionAsync(GraphQLUnionTypeDefinition unionTypeDefinition, DefaultPrintContext context)
+        {
+            return unionTypeDefinition.Name.Value.Span[0] == 'A'
+                ? base.VisitUnionTypeDefinitionAsync(unionTypeDefinition, context)
+                : default;
+        }
+
+        protected override ValueTask VisitInterfaceTypeExtensionAsync(GraphQLInterfaceTypeExtension interfaceTypeExtension, DefaultPrintContext context)
+        {
+            return interfaceTypeExtension.Name.Value.Span[0] == 'A'
+                ? base.VisitInterfaceTypeExtensionAsync(interfaceTypeExtension, context)
+                : default;
+        }
+
+        protected override ValueTask VisitInterfaceTypeDefinitionAsync(GraphQLInterfaceTypeDefinition interfaceTypeDefinition, DefaultPrintContext context)
+        {
+            return interfaceTypeDefinition.Name.Value.Span[0] == 'A'
+                ? base.VisitInterfaceTypeDefinitionAsync(interfaceTypeDefinition, context)
+                : default;
+        }
+
+        protected override ValueTask VisitObjectTypeDefinitionAsync(GraphQLObjectTypeDefinition objectTypeDefinition, DefaultPrintContext context)
+        {
+            return objectTypeDefinition.Name.Value.Span[0] == 'A'
+                ? base.VisitObjectTypeDefinitionAsync(objectTypeDefinition, context)
+                : default;
+        }
+
+        protected override ValueTask VisitInputObjectTypeDefinitionAsync(GraphQLInputObjectTypeDefinition inputObjectTypeDefinition, DefaultPrintContext context)
+        {
+            return inputObjectTypeDefinition.Name.Value.Span[0] == 'A'
+                ? base.VisitInputObjectTypeDefinitionAsync(inputObjectTypeDefinition, context)
+                : default;
+        }
+
+        protected override ValueTask VisitEnumTypeExtensionAsync(GraphQLEnumTypeExtension enumTypeExtension, DefaultPrintContext context)
+        {
+            return enumTypeExtension.Name.Value.Span[0] == 'A'
+                ? base.VisitEnumTypeExtensionAsync(enumTypeExtension, context)
+                : default;
+        }
+
+        protected override ValueTask VisitDirectiveDefinitionAsync(GraphQLDirectiveDefinition directiveDefinition, DefaultPrintContext context)
+        {
+            return directiveDefinition.Name.Value.Span[0] == 'A'
+                ? base.VisitDirectiveDefinitionAsync(directiveDefinition, context)
+                : default;
+        }
+
+        protected override ValueTask VisitOperationDefinitionAsync(GraphQLOperationDefinition operationDefinition, DefaultPrintContext context)
+        {
+            return operationDefinition.Name.Value.Span[0] == 'A'
+                ? base.VisitOperationDefinitionAsync(operationDefinition, context)
+                : default;
+        }
+
+        protected override ValueTask VisitScalarTypeDefinitionAsync(GraphQLScalarTypeDefinition scalarTypeDefinition, DefaultPrintContext context)
+        {
+            return scalarTypeDefinition.Name.Value.Span[0] == 'A'
+                ? base.VisitScalarTypeDefinitionAsync(scalarTypeDefinition, context)
+                : default;
+        }
+
+        protected override ValueTask VisitEnumTypeDefinitionAsync(GraphQLEnumTypeDefinition enumTypeDefinition, DefaultPrintContext context)
+        {
+            return enumTypeDefinition.Name.Value.Span[0] == 'A'
+                ? base.VisitEnumTypeDefinitionAsync(enumTypeDefinition, context)
+                : default;
+        }
+    }
+}

--- a/src/GraphQLParser.Tests/Visitors/SDLWriterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLWriterTests.cs
@@ -27,8 +27,7 @@ public class SDLWriterTests
     [InlineData(1,
 @"#comment that ignored
   scalar A     ",
-@"scalar A
-", false)]
+@"scalar A", false)]
     [InlineData(2,
 @"{
   #
@@ -37,8 +36,7 @@ public class SDLWriterTests
 @"{
   #
   field
-}
-")]
+}")]
     [InlineData(3,
 @"{
   complicatedArgs {
@@ -49,8 +47,7 @@ public class SDLWriterTests
   complicatedArgs {
     intArgField(intArg: 2)
   }
-}
-")]
+}")]
     [InlineData(4,
 @"mutation createUser($userInput: UserInput!) {
   createUser(userInput: $userInput) {
@@ -66,8 +63,7 @@ public class SDLWriterTests
     gender
     profileImage
   }
-}
-")]
+}")]
     [InlineData(5,
 @"query users {
   users {
@@ -95,69 +91,55 @@ public class SDLWriterTests
       }
     }
   }
-}
-")]
+}")]
     [InlineData(6,
 @"{ a(list: [], obj: {}) }",
 @"{
   a(list: [], obj: {})
-}
-")]
+}")]
     [InlineData(7,
 @"directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT",
 @"directive @skip(if: Boolean!) on
   | FIELD
   | FRAGMENT_SPREAD
-  | INLINE_FRAGMENT
-", false, true)]
+  | INLINE_FRAGMENT", false, true)]
     [InlineData(8,
 @"directive @twoArgs
 (a: Int, b:
 String!) repeatable on QUERY|MUTATION|SUBSCRIPTION|FIELD|FRAGMENT_DEFINITION|FRAGMENT_SPREAD|INLINE_FRAGMENT|VARIABLE_DEFINITION|SCHEMA|SCALAR|OBJECT|FIELD_DEFINITION|ARGUMENT_DEFINITION|INTERFACE|UNION|ENUM|ENUM_VALUE|INPUT_OBJECT|INPUT_FIELD_DEFINITION",
-@"directive @twoArgs(a: Int, b: String!) repeatable on QUERY | MUTATION | SUBSCRIPTION | FIELD | FRAGMENT_DEFINITION | FRAGMENT_SPREAD | INLINE_FRAGMENT | VARIABLE_DEFINITION | SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-")]
+@"directive @twoArgs(a: Int, b: String!) repeatable on QUERY | MUTATION | SUBSCRIPTION | FIELD | FRAGMENT_DEFINITION | FRAGMENT_SPREAD | INLINE_FRAGMENT | VARIABLE_DEFINITION | SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION")]
     [InlineData(9,
 @"directive @exportable on | SCHEMA",
-@"directive @exportable on SCHEMA
-")]
+@"directive @exportable on SCHEMA")]
     [InlineData(10,
 @"directive @exportable on | SCHEMA | ENUM",
-@"directive @exportable on SCHEMA | ENUM
-")]
+@"directive @exportable on SCHEMA | ENUM")]
     [InlineData(11,
 @"extend schema @exportable ",
-@"extend schema @exportable
-")]
+@"extend schema @exportable")]
     [InlineData(12,
 @"extend schema @exportable { mutation: M }",
 @"extend schema @exportable {
   mutation: M
-}
-")]
+}")]
     [InlineData(13,
 @"extend scalar Foo @exportable",
-@"extend scalar Foo @exportable
-")]
+@"extend scalar Foo @exportable")]
     [InlineData(14,
 @"extend type Foo @exportable",
-@"extend type Foo @exportable
-")]
+@"extend type Foo @exportable")]
     [InlineData(15,
 @"extend interface Foo @exportable",
-@"extend interface Foo @exportable
-")]
+@"extend interface Foo @exportable")]
     [InlineData(16,
 @"extend union Foo @exportable",
-@"extend union Foo @exportable
-")]
+@"extend union Foo @exportable")]
     [InlineData(17,
 @"extend enum Foo @exportable",
-@"extend enum Foo @exportable
-")]
+@"extend enum Foo @exportable")]
     [InlineData(18,
 @"extend input Foo @exportable",
-@"extend input Foo @exportable
-")]
+@"extend input Foo @exportable")]
     [InlineData(19,
 @"#comment
 input Example @x {
@@ -165,8 +147,7 @@ input Example @x {
   value: String = ""xyz""
 }
 input B
-input C
-",
+input C",
 @"#comment
 input Example @x
 {
@@ -176,8 +157,7 @@ input Example @x
 
 input B
 
-input C
-")]
+input C")]
     [InlineData(20,
 @"query inlineFragmentTyping {
   profiles(handles: [""zuck"", ""coca - cola""])
@@ -213,16 +193,14 @@ input C
       }
     }
   }
-}
-")]
+}")]
     [InlineData(21,
 @"scalar a scalar b scalar c",
 @"scalar a
 
 scalar b
 
-scalar c
-")]
+scalar c")]
     [InlineData(22,
 @"
 
@@ -237,8 +215,7 @@ fragment Frag on Query
 {
   bar
   baz
-}
-",
+}",
 @"{
   foo
   #comment on fragment
@@ -249,12 +226,10 @@ fragment Frag on Query
 fragment Frag on Query {
   bar
   baz
-}
-")]
+}")]
     [InlineData(23,
 @"union Animal @immutable = |Cat | Dog",
-@"union Animal @immutable = Cat | Dog
-")]
+@"union Animal @immutable = Cat | Dog")]
     [InlineData(24,
 @"query
     q
@@ -266,22 +241,19 @@ fragment Frag on Query {
   a: name
   b
   c: age
-}
-")]
+}")]
     [InlineData(25,
 @"schema @checked @documented { mutation: MyMutation subscription: MySub }",
 @"schema @checked @documented {
   mutation: MyMutation
   subscription: MySub
-}
-")]
+}")]
     [InlineData(26,
 @"interface Dog implements & Eat & Bark { volume: Int! }",
 @"interface Dog implements Eat & Bark
 {
   volume: Int!
-}
-")]
+}")]
     [InlineData(27,
 @"enum Color { RED,
 #good color
@@ -297,8 +269,7 @@ BLUE }",
   GREEN @directive(list: [1, 2.7, 3, null, {}, {name: ""tom"", age: 42}])
   ""another good color""
   BLUE
-}
-")]
+}")]
     [InlineData(28,
 @"# super query
 #
@@ -317,8 +288,7 @@ query summary($id: ID!, $detailed: Boolean! = true) {
     #need
     building
   }
-}
-")]
+}")]
     [InlineData(29,
 @"
 """"""
@@ -356,8 +326,7 @@ type Dog implements Animal
   """"""
   friends: [Dog!]
   age: Int!
-}
-")]
+}")]
     [InlineData(30,
 @"query q
 {
@@ -374,8 +343,7 @@ type Dog implements Animal
   a:
   #field name (GraphQLName) comment
   name
-}
-")]
+}")]
     [InlineData(31,
 @"query q
 {
@@ -389,8 +357,7 @@ type Dog implements Animal
 ",
 @"query q {
   a: name
-}
-", false)]
+}", false)]
     [InlineData(32,
 @"{
   f
@@ -411,8 +378,7 @@ type Dog implements Animal
   (x: 10, y: {
   #comment on object field
   z: 1})
-}
-")]
+}")]
     [InlineData(33,
 @"{
   f
@@ -427,8 +393,7 @@ type Dog implements Animal
 ",
 @"{
   f(x: 10, y: {z: 1})
-}
-", false)]
+}", false)]
     [InlineData(34,
 @"#very good scalar
 scalar JSON
@@ -440,8 +405,7 @@ extend scalar JSON @external
 scalar JSON
 
 #forgot about external!
-extend scalar JSON @external
-")]
+extend scalar JSON @external")]
     [InlineData(35,
 @"#very good scalar
 scalar JSON
@@ -451,8 +415,7 @@ extend scalar JSON @external
 ",
 @"scalar JSON
 
-extend scalar JSON @external
-", false)]
+extend scalar JSON @external", false)]
     [InlineData(36,
 @"#very good union
 union Unity
@@ -468,8 +431,7 @@ union Unity
 = A | B
 
 #forgot about C!
-extend union Unity = C
-")]
+extend union Unity = C")]
     [InlineData(37,
 @"#very good union
 union Unity
@@ -481,8 +443,7 @@ extend union Unity = C
 ",
 @"union Unity = A | B
 
-extend union Unity = C
-", false)]
+extend union Unity = C", false)]
     [InlineData(38,
 @"union Unity
 = A |    B
@@ -494,9 +455,8 @@ extend union Unity =   C
   | B
 
 extend union Unity =
-  | C
-", true, false, true)]
-    public async Task WriteDocumentVisitor_Should_Print_Document(
+  | C", true, false, true)]
+    public async Task SDLPrinter_Should_Print_Document(
         int number,
         string text,
         string expected,
@@ -551,7 +511,7 @@ extend union Unity =
     [InlineData(28, "Test \\n escaping", "Test \\\\n escaping", false)]
     [InlineData(29, "Test \\u1234 escaping", "Test \\\\u1234 escaping", false)]
     [InlineData(30, "Test \\ escaping", "Test \\\\ escaping", false)]
-    public async Task WriteDocumentVisitor_Should_Print_BlockStrings(int number, string input, string expected, bool isBlockString)
+    public async Task SDLPrinter_Should_Print_BlockStrings(int number, string input, string expected, bool isBlockString)
     {
         number.ShouldBeGreaterThan(0);
 
@@ -572,7 +532,7 @@ extend union Unity =
         var renderedOriginal = writer.ToString();
 
         var lines = renderedOriginal.Split(Environment.NewLine);
-        var renderedDescription = string.Join(Environment.NewLine, lines.SkipLast(2));
+        var renderedDescription = string.Join(Environment.NewLine, lines.SkipLast(1));
         renderedDescription = renderedDescription.Replace("\r\n", "\n");
         renderedDescription.ShouldBe(expected);
 
@@ -586,13 +546,12 @@ extend union Unity =
     [InlineData("\"\\tX\\t\"")]
     [InlineData("\" \u1234 \"")]
     [InlineData("\"normal text\"")]
-    public async Task WriteDocumentVisitor_Should_Print_EscapedStrings(string stringValue)
+    public async Task SDLPrinter_Should_Print_EscapedStrings(string stringValue)
     {
         string query = $"{{a(p:{stringValue})}}";
         string expected = @$"{{
   a(p: {stringValue})
-}}
-";
+}}";
         var writer = new StringWriter();
 
         var document = query.Parse();
@@ -635,21 +594,19 @@ extend union Unity =
         var printer = new SDLPrinter(new SDLPrinterOptions { PrintComments = true });
         await printer.PrintAsync(def, writer);
         writer.ToString().ShouldBe(@"{
-}
-");
+}");
         def.SelectionSet.Comments = new List<GraphQLComment> { new GraphQLComment("comment") };
         writer = new StringWriter();
         await printer.PrintAsync(def, writer);
         writer.ToString().ShouldBe(@"#comment
 {
-}
-");
+}");
     }
 
     [Theory]
     [InlineData("query a { name }")]
     [InlineData("directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT")]
-    public async Task WriteDocumentVisitor_Should_Throw_On_Unknown_Values(string text)
+    public async Task SDLPrinter_Should_Throw_On_Unknown_Values(string text)
     {
         var writer = new StringWriter();
         var document = text.Parse();
@@ -659,6 +616,68 @@ extend union Unity =
         var printer = new SDLPrinter();
         var ex = await Should.ThrowAsync<NotSupportedException>(async () => await printer.PrintAsync(document, writer));
         ex.Message.ShouldStartWith("Unknown ");
+    }
+
+    [Theory]
+    [InlineData(1,
+@"schema { query: Q }
+extend schema @good
+scalar A
+",
+@"scalar A")]
+    [InlineData(2,
+@"scalar A1
+scalar B
+scalar C
+scalar A2
+",
+@"scalar A1
+
+scalar A2")]
+    [InlineData(3,
+@"scalar A1
+scalar B
+scalar A2
+scalar E
+scalar D
+",
+@"scalar A1
+
+scalar A2")]
+    public async Task Printer_Should_Print_Pretty_If_Definitions_Skipped(
+ int number,
+ string text,
+ string expected)
+    {
+        var printer = new MyPrinter();
+        var writer = new StringWriter();
+        var document = text.Parse();
+
+        await printer.PrintAsync(document, writer).ConfigureAwait(false);
+        var actual = writer.ToString();
+        actual.ShouldBe(expected, $"Test {number} failed");
+
+        actual.Parse(); // should be parsed back
+    }
+
+    private class MyPrinter : SDLPrinter
+    {
+        protected override ValueTask VisitSchemaDefinitionAsync(GraphQLSchemaDefinition schemaDefinition, DefaultPrintContext context)
+        {
+            return default;
+        }
+
+        protected override ValueTask VisitSchemaExtensionAsync(GraphQLSchemaExtension schemaExtension, DefaultPrintContext context)
+        {
+            return default;
+        }
+
+        protected override ValueTask VisitScalarTypeDefinitionAsync(GraphQLScalarTypeDefinition scalarTypeDefinition, DefaultPrintContext context)
+        {
+            return scalarTypeDefinition.Name.Value.Span[0] == 'A'
+                ? base.VisitScalarTypeDefinitionAsync(scalarTypeDefinition, context)
+                : default;
+        }
     }
 
     private class Context : IASTVisitorContext

--- a/src/GraphQLParser.Tests/Visitors/StructurePrinterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/StructurePrinterTests.cs
@@ -284,7 +284,7 @@ field: Int }", @"Document
       Directive
         Name [dir]
 ")]
-    public async Task WriteTreeVisitor_Should_Print_Tree(string text, string expected)
+    public async Task StructurePrinter_Should_Print_Tree(string text, string expected)
     {
         var writer = new StringWriter();
         var document = text.Parse();
@@ -303,7 +303,7 @@ field: Int }", @"Document
       Field
         Name
 ")]
-    public async Task WriteTreeVisitor_Should_Print_Tree_Without_Names(string text, string expected)
+    public async Task StructurePrinter_Should_Print_Tree_Without_Names(string text, string expected)
     {
         var writer = new StringWriter();
         var document = text.Parse();
@@ -542,7 +542,7 @@ scalar S", @"Document (10,30)
             Name [b] (34,35)
             IntValue (36,38)
 ")]
-    public async Task WriteTreeVisitor_Should_Print_Tree_With_Locations(string text, string expected, bool ignoreComments = true)
+    public async Task StructurePrinter_Should_Print_Tree_With_Locations(string text, string expected, bool ignoreComments = true)
     {
         text = text.Replace("\r\n", "\n");
         foreach (var option in new[] { IgnoreOptions.None, IgnoreOptions.Comments })

--- a/src/GraphQLParser.Tests/Visitors/StructurePrinterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/StructurePrinterTests.cs
@@ -6,14 +6,14 @@ using Xunit;
 
 namespace GraphQLParser.Tests.Visitors;
 
-public class StructureWriterTests
+public class StructurePrinterTests
 {
     private static readonly StructurePrinter _structPrinter1 = new(new StructurePrinterOptions { PrintNames = true });
     private static readonly StructurePrinter _structPrinter2 = new(new StructurePrinterOptions { PrintNames = false });
     private static readonly StructurePrinter _structPrinter3 = new(new StructurePrinterOptions { PrintNames = true, PrintLocations = true });
 
     [Fact]
-    public void StructureWriter_Should_Have_Default_Options()
+    public void StructurePrinter_Should_Have_Default_Options()
     {
         var writer = new StructurePrinter();
         writer.Options.ShouldNotBeNull();

--- a/src/GraphQLParser/Visitors/IPrintContext.cs
+++ b/src/GraphQLParser/Visitors/IPrintContext.cs
@@ -23,4 +23,12 @@ public interface IPrintContext : IASTVisitorContext
     /// Tracks the current indent level.
     /// </summary>
     int IndentLevel { get; set; }
+
+    /// <summary>
+    /// Indicates whether last GraphQL AST definition node (executable definition,
+    /// type system definition or type system extension) from printed document was
+    /// actualy printed. This property is required to properly print vertical
+    /// indents between definitions.
+    /// </summary>
+    bool LastDefinitionPrinted { get; set; }
 }

--- a/src/GraphQLParser/Visitors/PrintContextExtensions.cs
+++ b/src/GraphQLParser/Visitors/PrintContextExtensions.cs
@@ -12,6 +12,7 @@ namespace GraphQLParser.Visitors;
 public static class PrintContextExtensions
 {
     private static readonly ROM _newLine = Environment.NewLine;
+    private static readonly ROM _newLineDoubled = Environment.NewLine + Environment.NewLine;
 
     /// <summary>
     /// Writes the specified <see cref="ROM"/> to the provided context
@@ -39,4 +40,13 @@ public static class PrintContextExtensions
     public static ValueTask WriteLineAsync<TContext>(this TContext context)
         where TContext : IPrintContext
         => WriteAsync(context, _newLine);
+
+    /// <summary>
+    /// Writes doubled <see cref="Environment.NewLine"/> to the provided context
+    /// using <see cref="CancellationToken"/> from it.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ValueTask WriteDoubleLineAsync<TContext>(this TContext context)
+        where TContext : IPrintContext
+        => WriteAsync(context, _newLineDoubled);
 }

--- a/src/GraphQLParser/Visitors/SDLPrinter.cs
+++ b/src/GraphQLParser/Visitors/SDLPrinter.cs
@@ -73,7 +73,10 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
                 node is GraphQLArguments ||
                 node is GraphQLObjectField ||
                 node is GraphQLName ||
-                node is GraphQLUnionMemberTypes;
+                node is GraphQLUnionMemberTypes ||
+                node is GraphQLEnumValuesDefinition ||
+                node is GraphQLFieldsDefinition ||
+                node is GraphQLInputFieldsDefinition;
         }
     }
 
@@ -1036,11 +1039,13 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
 
         if (node is GraphQLField ||
             node is GraphQLFieldDefinition ||
-            node is GraphQLInputFieldsDefinition ||
             node is GraphQLEnumValueDefinition ||
             node is GraphQLFragmentSpread ||
             node is GraphQLInlineFragment ||
             node is GraphQLRootOperationTypeDefinition)
+            ++context.IndentLevel;
+
+        if (node is GraphQLInputValueDefinition && context.Parents.Peek() is GraphQLInputFieldsDefinition)
             ++context.IndentLevel;
 
         if (node is GraphQLDirectiveLocations && Options.EachDirectiveLocationOnNewLine)

--- a/src/GraphQLParser/Visitors/SDLPrinter.cs
+++ b/src/GraphQLParser/Visitors/SDLPrinter.cs
@@ -548,8 +548,9 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     protected override async ValueTask VisitEnumValuesDefinitionAsync(GraphQLEnumValuesDefinition enumValuesDefinition, TContext context)
     {
         await VisitAsync(enumValuesDefinition.Comments, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
-        await context.WriteAsync("{").ConfigureAwait(false);
+
+        bool freshLine = enumValuesDefinition.Comments != null && Options.PrintComments;
+        await context.WriteAsync(freshLine ? "{" : " {").ConfigureAwait(false);
         await context.WriteLineAsync().ConfigureAwait(false);
 
         for (int i = 0; i < enumValuesDefinition.Items.Count; ++i)
@@ -621,8 +622,9 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     protected override async ValueTask VisitInputFieldsDefinitionAsync(GraphQLInputFieldsDefinition inputFieldsDefinition, TContext context)
     {
         await VisitAsync(inputFieldsDefinition.Comments, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
-        await context.WriteAsync("{").ConfigureAwait(false);
+
+        bool freshLine = inputFieldsDefinition.Comments != null && Options.PrintComments;
+        await context.WriteAsync(freshLine ? "{" : " {").ConfigureAwait(false);
         await context.WriteLineAsync().ConfigureAwait(false);
 
         for (int i = 0; i < inputFieldsDefinition.Items.Count; ++i)
@@ -731,8 +733,9 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     protected override async ValueTask VisitFieldsDefinitionAsync(GraphQLFieldsDefinition fieldsDefinition, TContext context)
     {
         await VisitAsync(fieldsDefinition.Comments, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
-        await context.WriteAsync("{").ConfigureAwait(false);
+
+        bool freshLine = fieldsDefinition.Comments != null && Options.PrintComments;
+        await context.WriteAsync(freshLine ? "{" : " {").ConfigureAwait(false);
         await context.WriteLineAsync().ConfigureAwait(false);
 
         for (int i = 0; i < fieldsDefinition.Items.Count; ++i)

--- a/src/GraphQLParser/Visitors/SDLPrinter.cs
+++ b/src/GraphQLParser/Visitors/SDLPrinter.cs
@@ -45,14 +45,7 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         if (document.Definitions.Count > 0) // Definitions always > 0
         {
             for (int i = 0; i < document.Definitions.Count; ++i)
-            {
                 await VisitAsync(document.Definitions[i], context).ConfigureAwait(false);
-
-                if (i < document.Definitions.Count - 1)
-                {
-                    await context.WriteLineAsync().ConfigureAwait(false);
-                }
-            }
         }
     }
 
@@ -192,6 +185,12 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     /// <inheritdoc/>
     protected override async ValueTask VisitFragmentDefinitionAsync(GraphQLFragmentDefinition fragmentDefinition, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(fragmentDefinition.Comments, context).ConfigureAwait(false);
         await context.WriteAsync("fragment ").ConfigureAwait(false);
         await VisitAsync(fragmentDefinition.FragmentName, context).ConfigureAwait(false);
@@ -199,6 +198,8 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         await VisitAsync(fragmentDefinition.TypeCondition, context).ConfigureAwait(false);
         await VisitAsync(fragmentDefinition.Directives, context).ConfigureAwait(false);
         await VisitAsync(fragmentDefinition.SelectionSet, context).ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
@@ -255,7 +256,8 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         await VisitAsync(selectionSet.Comments, context).ConfigureAwait(false);
 
         bool freshLine = selectionSet.Comments != null && Options.PrintComments;
-        if (!freshLine && TryPeekParent(context, out var node) && (node is GraphQLOperationDefinition op && op.Name is not null || node is not GraphQLOperationDefinition))
+        bool hasParent = TryPeekParent(context, out var node);
+        if (!freshLine && hasParent && (node is GraphQLOperationDefinition op && op.Name is not null || node is not GraphQLOperationDefinition))
         {
             await context.WriteAsync(" {").ConfigureAwait(false);
         }
@@ -271,7 +273,9 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
 
         await WriteIndentAsync(context).ConfigureAwait(false);
         await context.WriteAsync("}").ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        if (node is not GraphQLOperationDefinition && node is not GraphQLFragmentDefinition)
+            await context.WriteLineAsync().ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -308,6 +312,12 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     /// <inheritdoc/>
     protected override async ValueTask VisitOperationDefinitionAsync(GraphQLOperationDefinition operationDefinition, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(operationDefinition.Comments, context).ConfigureAwait(false);
         if (operationDefinition.Name is not null)
         {
@@ -318,11 +328,19 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         await VisitAsync(operationDefinition.Variables, context).ConfigureAwait(false);
         await VisitAsync(operationDefinition.Directives, context).ConfigureAwait(false);
         await VisitAsync(operationDefinition.SelectionSet, context).ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
     protected override async ValueTask VisitDirectiveDefinitionAsync(GraphQLDirectiveDefinition directiveDefinition, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(directiveDefinition.Comments, context).ConfigureAwait(false);
         await VisitAsync(directiveDefinition.Description, context).ConfigureAwait(false);
         await context.WriteAsync("directive @").ConfigureAwait(false);
@@ -331,7 +349,8 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         if (directiveDefinition.Repeatable)
             await context.WriteAsync(" repeatable").ConfigureAwait(false);
         await VisitAsync(directiveDefinition.Locations, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
@@ -412,17 +431,30 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     /// <inheritdoc/>
     protected override async ValueTask VisitScalarTypeDefinitionAsync(GraphQLScalarTypeDefinition scalarTypeDefinition, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(scalarTypeDefinition.Comments, context).ConfigureAwait(false);
         await VisitAsync(scalarTypeDefinition.Description, context).ConfigureAwait(false);
         await context.WriteAsync("scalar ").ConfigureAwait(false);
         await VisitAsync(scalarTypeDefinition.Name, context).ConfigureAwait(false);
         await VisitAsync(scalarTypeDefinition.Directives, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
     protected override async ValueTask VisitSchemaExtensionAsync(GraphQLSchemaExtension schemaExtension, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(schemaExtension.Comments, context).ConfigureAwait(false);
         await context.WriteAsync("extend schema").ConfigureAwait(false);
         await VisitAsync(schemaExtension.Directives, context).ConfigureAwait(false);
@@ -442,40 +474,62 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
 
             await context.WriteAsync("}").ConfigureAwait(false);
         }
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
     protected override async ValueTask VisitScalarTypeExtensionAsync(GraphQLScalarTypeExtension scalarTypeExtension, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(scalarTypeExtension.Comments, context).ConfigureAwait(false);
         await context.WriteAsync("extend scalar ").ConfigureAwait(false);
         await VisitAsync(scalarTypeExtension.Name, context).ConfigureAwait(false);
         await VisitAsync(scalarTypeExtension.Directives, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
     protected override async ValueTask VisitEnumTypeDefinitionAsync(GraphQLEnumTypeDefinition enumTypeDefinition, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(enumTypeDefinition.Comments, context).ConfigureAwait(false);
         await VisitAsync(enumTypeDefinition.Description, context).ConfigureAwait(false);
         await context.WriteAsync("enum ").ConfigureAwait(false);
         await VisitAsync(enumTypeDefinition.Name, context).ConfigureAwait(false);
         await VisitAsync(enumTypeDefinition.Directives, context).ConfigureAwait(false);
         await VisitAsync(enumTypeDefinition.Values, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
     protected override async ValueTask VisitEnumTypeExtensionAsync(GraphQLEnumTypeExtension enumTypeExtension, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(enumTypeExtension.Comments, context).ConfigureAwait(false);
         await context.WriteAsync("extend enum ").ConfigureAwait(false);
         await VisitAsync(enumTypeExtension.Name, context).ConfigureAwait(false);
         await VisitAsync(enumTypeExtension.Directives, context).ConfigureAwait(false);
         await VisitAsync(enumTypeExtension.Values, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
@@ -510,24 +564,38 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     /// <inheritdoc/>
     protected override async ValueTask VisitInputObjectTypeDefinitionAsync(GraphQLInputObjectTypeDefinition inputObjectTypeDefinition, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(inputObjectTypeDefinition.Comments, context).ConfigureAwait(false);
         await VisitAsync(inputObjectTypeDefinition.Description, context).ConfigureAwait(false);
         await context.WriteAsync("input ").ConfigureAwait(false);
         await VisitAsync(inputObjectTypeDefinition.Name, context).ConfigureAwait(false);
         await VisitAsync(inputObjectTypeDefinition.Directives, context).ConfigureAwait(false);
         await VisitAsync(inputObjectTypeDefinition.Fields, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
     protected override async ValueTask VisitInputObjectTypeExtensionAsync(GraphQLInputObjectTypeExtension inputObjectTypeExtension, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(inputObjectTypeExtension.Comments, context).ConfigureAwait(false);
         await context.WriteAsync("extend input ").ConfigureAwait(false);
         await VisitAsync(inputObjectTypeExtension.Name, context).ConfigureAwait(false);
         await VisitAsync(inputObjectTypeExtension.Directives, context).ConfigureAwait(false);
         await VisitAsync(inputObjectTypeExtension.Fields, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
@@ -569,6 +637,12 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     /// <inheritdoc/>
     protected override async ValueTask VisitObjectTypeDefinitionAsync(GraphQLObjectTypeDefinition objectTypeDefinition, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(objectTypeDefinition.Comments, context).ConfigureAwait(false);
         await VisitAsync(objectTypeDefinition.Description, context).ConfigureAwait(false);
         await context.WriteAsync("type ").ConfigureAwait(false);
@@ -576,24 +650,38 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         await VisitAsync(objectTypeDefinition.Interfaces, context).ConfigureAwait(false);
         await VisitAsync(objectTypeDefinition.Directives, context).ConfigureAwait(false);
         await VisitAsync(objectTypeDefinition.Fields, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
     protected override async ValueTask VisitObjectTypeExtensionAsync(GraphQLObjectTypeExtension objectTypeExtension, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(objectTypeExtension.Comments, context).ConfigureAwait(false);
         await context.WriteAsync("extend type ").ConfigureAwait(false);
         await VisitAsync(objectTypeExtension.Name, context).ConfigureAwait(false);
         await VisitAsync(objectTypeExtension.Interfaces, context).ConfigureAwait(false);
         await VisitAsync(objectTypeExtension.Directives, context).ConfigureAwait(false);
         await VisitAsync(objectTypeExtension.Fields, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
     protected override async ValueTask VisitInterfaceTypeDefinitionAsync(GraphQLInterfaceTypeDefinition interfaceTypeDefinition, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(interfaceTypeDefinition.Comments, context).ConfigureAwait(false);
         await VisitAsync(interfaceTypeDefinition.Description, context).ConfigureAwait(false);
         await context.WriteAsync("interface ").ConfigureAwait(false);
@@ -601,19 +689,27 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         await VisitAsync(interfaceTypeDefinition.Interfaces, context).ConfigureAwait(false);
         await VisitAsync(interfaceTypeDefinition.Directives, context).ConfigureAwait(false);
         await VisitAsync(interfaceTypeDefinition.Fields, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
     protected override async ValueTask VisitInterfaceTypeExtensionAsync(GraphQLInterfaceTypeExtension interfaceTypeExtension, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(interfaceTypeExtension.Comments, context).ConfigureAwait(false);
         await context.WriteAsync("extend interface ").ConfigureAwait(false);
         await VisitAsync(interfaceTypeExtension.Name, context).ConfigureAwait(false);
         await VisitAsync(interfaceTypeExtension.Interfaces, context).ConfigureAwait(false);
         await VisitAsync(interfaceTypeExtension.Directives, context).ConfigureAwait(false);
         await VisitAsync(interfaceTypeExtension.Fields, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
@@ -651,6 +747,12 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     /// <inheritdoc/>
     protected override async ValueTask VisitSchemaDefinitionAsync(GraphQLSchemaDefinition schemaDefinition, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(schemaDefinition.Comments, context).ConfigureAwait(false);
         await VisitAsync(schemaDefinition.Description, context).ConfigureAwait(false);
         await context.WriteAsync("schema").ConfigureAwait(false);
@@ -670,7 +772,8 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         }
 
         await context.WriteAsync("}").ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
@@ -688,24 +791,38 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     /// <inheritdoc/>
     protected override async ValueTask VisitUnionTypeDefinitionAsync(GraphQLUnionTypeDefinition unionTypeDefinition, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(unionTypeDefinition.Comments, context).ConfigureAwait(false);
         await VisitAsync(unionTypeDefinition.Description, context).ConfigureAwait(false);
         await context.WriteAsync("union ").ConfigureAwait(false);
         await VisitAsync(unionTypeDefinition.Name, context).ConfigureAwait(false);
         await VisitAsync(unionTypeDefinition.Directives, context).ConfigureAwait(false);
         await VisitAsync(unionTypeDefinition.Types, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
     protected override async ValueTask VisitUnionTypeExtensionAsync(GraphQLUnionTypeExtension unionTypeExtension, TContext context)
     {
+        if (context.LastDefinitionPrinted)
+        {
+            await context.WriteDoubleLineAsync().ConfigureAwait(false);
+            context.LastDefinitionPrinted = false;
+        }
+
         await VisitAsync(unionTypeExtension.Comments, context).ConfigureAwait(false);
         await context.WriteAsync("extend union ").ConfigureAwait(false);
         await VisitAsync(unionTypeExtension.Name, context).ConfigureAwait(false);
         await VisitAsync(unionTypeExtension.Directives, context).ConfigureAwait(false);
         await VisitAsync(unionTypeExtension.Types, context).ConfigureAwait(false);
-        await context.WriteLineAsync().ConfigureAwait(false);
+
+        context.LastDefinitionPrinted = true;
     }
 
     /// <inheritdoc/>
@@ -1072,6 +1189,9 @@ public class SDLPrinter : SDLPrinter<SDLPrinter.DefaultPrintContext>
 
         /// <inheritdoc/>
         public int IndentLevel { get; set; }
+
+        /// <inheritdoc/>
+        public bool LastDefinitionPrinted { get; set; }
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
PR helps to rewrite `SchemaPrinter`. `SchemaPrinter` can skip definitions.

```graphql
type A
{
  a: Int
}
```
->
```graphql
type A {
  a: Int
}
```

and so on