### PR TITLE
Prettify indentation

### DIFF
--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterSkipDirectivesTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterSkipDirectivesTests.cs
@@ -50,7 +50,7 @@ public class SDLPrinterSkipDirectivesTests
   f: Int
   k: Boolean
 }")]
-    public async Task Printer_Should_Print_Pretty_If_Direcives_Skipped(
+    public async Task Printer_Should_Print_Pretty_If_Directives_Skipped(
 int number,
 string text,
 string expected)

--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
@@ -517,6 +517,11 @@ type Foo {
 type Query {
   foo: Foo
 }", true)]
+    [InlineData(41,
+@"directive @skip(""Skipped when true."" if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT",
+@"directive @skip(
+  ""Skipped when true.""
+  if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT")]
     public async Task SDLPrinter_Should_Print_Document(
         int number,
         string text,

--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
@@ -522,6 +522,18 @@ type Query {
 @"directive @skip(
   ""Skipped when true.""
   if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT")]
+    [InlineData(42,
+@"directive @skip(""Skipped when true."" if: Boolean!, x: Some) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT",
+@"directive @skip(
+  ""Skipped when true.""
+  if: Boolean!, x: Some) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT")]
+    [InlineData(43,
+@"directive @skip(""Skipped when true."" if: Boolean!, ""Second argument"" x: Some) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT",
+@"directive @skip(
+  ""Skipped when true.""
+  if: Boolean!,
+  ""Second argument""
+  x: Some) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT")]
     public async Task SDLPrinter_Should_Print_Document(
         int number,
         string text,

--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
@@ -703,6 +703,22 @@ multilined
         writer.ToString().ShouldBe(expected);
     }
 
+    [Fact]
+    public async Task InputValueDefinition_Without_Parent_Should_Be_Printed()
+    {
+        var def = new GraphQLInputValueDefinition
+        {
+            Name = new GraphQLName("field"),
+            Type = new GraphQLNamedType { Name = new GraphQLName("String") },
+            DefaultValue = new GraphQLStringValue("abc")
+        };
+
+        var writer = new StringWriter();
+        var printer = new SDLPrinter();
+        await printer.PrintAsync(def, writer);
+        writer.ToString().ShouldBe("field: String = \"abc\"");
+    }
+
     [Theory]
     [InlineData("query a { name }")]
     [InlineData("directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT")]

--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
@@ -682,6 +682,28 @@ type Query {
     }
 
     [Theory]
+    [InlineData(
+@"description",
+@"""description""
+")]
+    [InlineData(
+@"description
+multilined",
+@"""""""
+description
+multilined
+""""""
+")]
+    public async Task Description_Without_Parent_Should_Be_Printed(string text, string expected)
+    {
+        var description = new GraphQLDescription(text);
+        var writer = new StringWriter();
+        var printer = new SDLPrinter();
+        await printer.PrintAsync(description, writer);
+        writer.ToString().ShouldBe(expected);
+    }
+
+    [Theory]
     [InlineData("query a { name }")]
     [InlineData("directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT")]
     public async Task SDLPrinter_Should_Throw_On_Unknown_Values(string text)

--- a/src/GraphQLParser/Visitors/SDLPrinter.cs
+++ b/src/GraphQLParser/Visitors/SDLPrinter.cs
@@ -169,14 +169,6 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         static bool DescribedNodeShouldBeCloseToPreviousNode(TContext context)
         {
             return TryPeekParent(context, out var node) &&
-                node is GraphQLArguments ||
-                node is GraphQLArgument ||
-                node is GraphQLObjectField ||
-                node is GraphQLName ||
-                node is GraphQLUnionMemberTypes ||
-                node is GraphQLEnumValuesDefinition ||
-                node is GraphQLFieldsDefinition ||
-                node is GraphQLInputFieldsDefinition ||
                 node is GraphQLInputValueDefinition;
         }
 

--- a/src/GraphQLParser/Visitors/SDLPrinter.cs
+++ b/src/GraphQLParser/Visitors/SDLPrinter.cs
@@ -578,9 +578,9 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         await context.WriteAsync(freshLine ? "{" : " {").ConfigureAwait(false);
         await context.WriteLineAsync().ConfigureAwait(false);
 
-        for (int i = 0; i < enumValuesDefinition.Items.Count; ++i)
+        foreach (var enumValueDefinition in enumValuesDefinition.Items)
         {
-            await VisitAsync(enumValuesDefinition.Items[i], context).ConfigureAwait(false);
+            await VisitAsync(enumValueDefinition, context).ConfigureAwait(false);
             await context.WriteLineAsync().ConfigureAwait(false);
         }
 
@@ -627,11 +627,19 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     /// <inheritdoc/>
     protected override async ValueTask VisitInputValueDefinitionAsync(GraphQLInputValueDefinition inputValueDefinition, TContext context)
     {
+        bool hasParent = TryPeekParent(context, out var node);
+
+        if (hasParent && node is GraphQLArgumentsDefinition argsDef)
+        {
+            if (argsDef.Items.IndexOf(inputValueDefinition) > 0)
+                await context.WriteAsync(inputValueDefinition.Description == null ? ", " : ",").ConfigureAwait(false);
+        }
+
         await VisitAsync(inputValueDefinition.Comments, context).ConfigureAwait(false);
         await VisitAsync(inputValueDefinition.Description, context).ConfigureAwait(false);
 
         // Indent only input fields since for arguments indentation is always handled in VisitCommentAsync/VisitDescriptionAsync
-        if (TryPeekParent(context, out var node) && node is GraphQLInputFieldsDefinition)
+        if (hasParent && node is GraphQLInputFieldsDefinition)
             await WriteIndentAsync(context).ConfigureAwait(false);
 
         await VisitAsync(inputValueDefinition.Name, context).ConfigureAwait(false);
@@ -654,9 +662,9 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         await context.WriteAsync(freshLine ? "{" : " {").ConfigureAwait(false);
         await context.WriteLineAsync().ConfigureAwait(false);
 
-        for (int i = 0; i < inputFieldsDefinition.Items.Count; ++i)
+        foreach (var inputFieldDefinition in inputFieldsDefinition.Items)
         {
-            await VisitAsync(inputFieldsDefinition.Items[i], context).ConfigureAwait(false);
+            await VisitAsync(inputFieldDefinition, context).ConfigureAwait(false);
             await context.WriteLineAsync().ConfigureAwait(false);
         }
 
@@ -765,9 +773,9 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         await context.WriteAsync(freshLine ? "{" : " {").ConfigureAwait(false);
         await context.WriteLineAsync().ConfigureAwait(false);
 
-        for (int i = 0; i < fieldsDefinition.Items.Count; ++i)
+        foreach (var fieldDefinition in fieldsDefinition)
         {
-            await VisitAsync(fieldsDefinition.Items[i], context).ConfigureAwait(false);
+            await VisitAsync(fieldDefinition, context).ConfigureAwait(false);
             await context.WriteLineAsync().ConfigureAwait(false);
         }
 
@@ -904,8 +912,8 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
     {
         await VisitAsync(directives.Comments, context).ConfigureAwait(false); // Comment always null - see ParserContext.ParseDirectives
 
-        for (int i = 0; i < directives.Items.Count; ++i)
-            await VisitAsync(directives.Items[i], context).ConfigureAwait(false);
+        foreach (var directive in directives.Items)
+            await VisitAsync(directive, context).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -923,12 +931,8 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         await VisitAsync(argumentsDefinition.Comments, context).ConfigureAwait(false);
         await context.WriteAsync("(").ConfigureAwait(false);
 
-        for (int i = 0; i < argumentsDefinition.Items.Count; ++i)
-        {
-            await VisitAsync(argumentsDefinition.Items[i], context).ConfigureAwait(false);
-            if (i < argumentsDefinition.Items.Count - 1)
-                await context.WriteAsync(", ").ConfigureAwait(false);
-        }
+        foreach (var argumentDefinition in argumentsDefinition.Items)
+            await VisitAsync(argumentDefinition, context).ConfigureAwait(false);
 
         await context.WriteAsync(")").ConfigureAwait(false);
     }

--- a/src/GraphQLParser/Visitors/SDLPrinter.cs
+++ b/src/GraphQLParser/Visitors/SDLPrinter.cs
@@ -1068,7 +1068,7 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
             node is GraphQLRootOperationTypeDefinition)
             ++context.IndentLevel;
 
-        if (node is GraphQLInputValueDefinition && context.Parents.Peek() is GraphQLInputFieldsDefinition)
+        if (node is GraphQLInputValueDefinition && (context.Parents.Count > 0 && context.Parents.Peek() is GraphQLInputFieldsDefinition))
             ++context.IndentLevel;
 
         if (node is GraphQLDescription && TryPeekParent(context, out var p) && p is GraphQLArgumentsDefinition)


### PR DESCRIPTION
```graphql
directive @skip(""Skipped when true.""
if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
```
->
```graphql
directive @skip(
  ""Skipped when true.""
  if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
```

Changes are required to rewrite `SchemaPrinter`.