### PR TITLE
Allow to parse value literals

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -661,6 +661,7 @@ namespace GraphQLParser
     public static class Parser
     {
         public static GraphQLParser.AST.GraphQLDocument Parse(GraphQLParser.ROM source, GraphQLParser.ParserOptions options = default) { }
+        public static GraphQLParser.AST.GraphQLValue ParseValue(GraphQLParser.ROM source, GraphQLParser.ParserOptions options = default) { }
     }
     public struct ParserOptions
     {

--- a/src/GraphQLParser/GraphQLParser.csproj
+++ b/src/GraphQLParser/GraphQLParser.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-    <InternalsVisibleTo Condition="'$(SignAssembly)' == 'true'" Include="$(MSBuildProjectName).Tests, $(_FriendAssembliesPublicKey);$(MSBuildProjectName).Benchmarks, $(_FriendAssembliesPublicKey)"/>
-    <InternalsVisibleTo Condition="'$(SignAssembly)' != 'true'" Include="$(MSBuildProjectName).Tests;$(MSBuildProjectName).Benchmarks"/>
+    <InternalsVisibleTo Condition="'$(SignAssembly)' == 'true'" Include="$(MSBuildProjectName).Tests, $(_FriendAssembliesPublicKey);$(MSBuildProjectName).Benchmarks, $(_FriendAssembliesPublicKey)" />
+    <InternalsVisibleTo Condition="'$(SignAssembly)' != 'true'" Include="$(MSBuildProjectName).Tests;$(MSBuildProjectName).Benchmarks" />
   </ItemGroup>
 
 </Project>

--- a/src/GraphQLParser/Parser.cs
+++ b/src/GraphQLParser/Parser.cs
@@ -18,4 +18,20 @@ public static class Parser
     /// <exception cref="GraphQLMaxDepthExceededException">In case of syntax error.</exception>
     public static GraphQLDocument Parse(ROM source, ParserOptions options = default)
         => new ParserContext(source, options).ParseDocument();
+
+    /// <summary>
+    /// Generates AST of GraphQL value based on input text.
+    /// </summary>
+    /// <param name="source">Input data as a sequence of characters.</param>
+    /// <param name="options">Parser options.</param>
+    /// <returns>AST (Abstract Syntax Tree) for GraphQL value.</returns>
+    /// <exception cref="GraphQLSyntaxErrorException">In case when parser recursion depth exceeds <see cref="ParserOptions.MaxDepth"/>.</exception>
+    /// <exception cref="GraphQLMaxDepthExceededException">In case of syntax error.</exception>
+    public static GraphQLValue ParseValue(ROM source, ParserOptions options = default)
+    {
+        var context = new ParserContext(source, options);
+        var value = context.ParseValueLiteral(true);
+        context.Expect(TokenKind.EOF);
+        return value;
+    }
 }

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -1418,7 +1418,7 @@ internal ref partial struct ParserContext
         return extension;
     }
 
-    private GraphQLValue ParseValueLiteral(bool isConstant)
+    internal GraphQLValue ParseValueLiteral(bool isConstant)
     {
         return _currentToken.Kind switch
         {

--- a/src/GraphQLParser/ParserContext.cs
+++ b/src/GraphQLParser/ParserContext.cs
@@ -46,28 +46,28 @@ internal ref partial struct ParserContext
 
     private static string[] DirectiveLocationOneOf { get; set; } = new[]
     {
-            // http://spec.graphql.org/October2021/#ExecutableDirectiveLocation
-            "QUERY",
-            "MUTATION",
-            "SUBSCRIPTION",
-            "FIELD",
-            "FRAGMENT_DEFINITION",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT",
-            "VARIABLE_DEFINITION",
-            // http://spec.graphql.org/October2021/#TypeSystemDirectiveLocation
-            "SCHEMA",
-            "SCALAR",
-            "OBJECT",
-            "FIELD_DEFINITION",
-            "ARGUMENT_DEFINITION",
-            "INTERFACE",
-            "UNION",
-            "ENUM",
-            "ENUM_VALUE",
-            "INPUT_OBJECT",
-            "INPUT_FIELD_DEFINITION",
-        };
+        // http://spec.graphql.org/October2021/#ExecutableDirectiveLocation
+        "QUERY",
+        "MUTATION",
+        "SUBSCRIPTION",
+        "FIELD",
+        "FRAGMENT_DEFINITION",
+        "FRAGMENT_SPREAD",
+        "INLINE_FRAGMENT",
+        "VARIABLE_DEFINITION",
+        // http://spec.graphql.org/October2021/#TypeSystemDirectiveLocation
+        "SCHEMA",
+        "SCALAR",
+        "OBJECT",
+        "FIELD_DEFINITION",
+        "ARGUMENT_DEFINITION",
+        "INTERFACE",
+        "UNION",
+        "ENUM",
+        "ENUM_VALUE",
+        "INPUT_OBJECT",
+        "INPUT_FIELD_DEFINITION",
+    };
 
     private delegate TResult ParseCallback<out TResult>(ref ParserContext context);
 
@@ -176,7 +176,7 @@ internal ref partial struct ParserContext
         }
     }
 
-    private void Expect(TokenKind kind, string? description = null)
+    internal void Expect(TokenKind kind, string? description = null)
     {
         if (_currentToken.Kind == kind)
         {

--- a/src/GraphQLParser/Visitors/SDLPrinter.cs
+++ b/src/GraphQLParser/Visitors/SDLPrinter.cs
@@ -1213,7 +1213,7 @@ public class SDLPrinter : SDLPrinter<SDLPrinter.DefaultPrintContext>
         public TextWriter Writer { get; }
 
         /// <inheritdoc/>
-        public Stack<ASTNode> Parents { get; init; } = new Stack<ASTNode>();
+        public Stack<ASTNode> Parents { get; init; } = new();
 
         /// <inheritdoc/>
         public CancellationToken CancellationToken { get; init; }


### PR DESCRIPTION
I need to parse values returned from introspection request, mostly default values of arguments. Our current design allows to parse only entire GraphQL document. 

Related project - https://github.com/sungam3r/graphql-introspection-model