### PR TITLE
Add PrintDeprecationReasons option

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -899,6 +899,7 @@ namespace GraphQLParser.Visitors
     public class SDLPrinterOptions
     {
         public SDLPrinterOptions() { }
+        public bool PrintDeprecationReasons { get; set; }
         public bool EachDirectiveLocationOnNewLine { get; init; }
         public bool EachUnionMemberOnNewLine { get; init; }
         public bool PrintComments { get; init; }

--- a/src/GraphQLParser/Visitors/SDLPrinter.cs
+++ b/src/GraphQLParser/Visitors/SDLPrinter.cs
@@ -890,7 +890,8 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
         await VisitAsync(directive.Comments, context).ConfigureAwait(false);
         await context.WriteAsync(TryPeekParent(context, out _) ? " @" : "@").ConfigureAwait(false);
         await VisitAsync(directive.Name, context).ConfigureAwait(false);
-        await VisitAsync(directive.Arguments, context).ConfigureAwait(false);
+        if (Options.PrintDeprecationReasons || directive.Name.Value != "deprecated")
+            await VisitAsync(directive.Arguments, context).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -1254,6 +1255,12 @@ public class SDLPrinterOptions
     /// Print comments into the output.
     /// </summary>
     public bool PrintComments { get; init; }
+
+    /// <summary>
+    /// Print deprecation reasons into the output.
+    /// By default <see langword="true"/>.
+    /// </summary>
+    public bool PrintDeprecationReasons { get; set; } = true;
 
     /// <summary>
     /// Whether to print each directive location on its own line.


### PR DESCRIPTION
This feature mimics the similar feature available within GraphQL.NET's SchemaPrinter.  It defaults to true.  Disabling it simply omits the `reason` argument from `@deprecated` directives throughout the document.

Todo:
- add tests