### PR TITLE
Add SDLSorter

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -762,7 +762,7 @@ namespace GraphQLParser.Visitors
         protected virtual System.Threading.Tasks.ValueTask VisitArgumentsAsync(GraphQLParser.AST.GraphQLArguments arguments, TContext context) { }
         protected virtual System.Threading.Tasks.ValueTask VisitArgumentsDefinitionAsync(GraphQLParser.AST.GraphQLArgumentsDefinition argumentsDefinition, TContext context) { }
         public virtual System.Threading.Tasks.ValueTask VisitAsync(GraphQLParser.AST.ASTNode? node, TContext context) { }
-        protected System.Threading.Tasks.ValueTask VisitAsync<T>(System.Collections.Generic.List<T>? nodes, TContext context)
+        protected virtual System.Threading.Tasks.ValueTask VisitAsync<T>(System.Collections.Generic.List<T>? nodes, TContext context)
             where T : GraphQLParser.AST.ASTNode { }
         protected virtual System.Threading.Tasks.ValueTask VisitBooleanValueAsync(GraphQLParser.AST.GraphQLBooleanValue booleanValue, TContext context) { }
         protected virtual System.Threading.Tasks.ValueTask VisitCommentAsync(GraphQLParser.AST.GraphQLComment comment, TContext context) { }
@@ -968,6 +968,21 @@ namespace GraphQLParser.Visitors
         protected override System.Threading.Tasks.ValueTask VisitVariableAsync(GraphQLParser.AST.GraphQLVariable variable, TContext context) { }
         protected override System.Threading.Tasks.ValueTask VisitVariableDefinitionAsync(GraphQLParser.AST.GraphQLVariableDefinition variableDefinition, TContext context) { }
         protected override System.Threading.Tasks.ValueTask VisitVariablesDefinitionAsync(GraphQLParser.AST.GraphQLVariablesDefinition variablesDefinition, TContext context) { }
+    }
+    public sealed class SDLSorter : GraphQLParser.Visitors.ASTVisitor<GraphQLParser.Visitors.SDLSorterOptions>
+    {
+        protected override System.Threading.Tasks.ValueTask VisitAsync<T>(System.Collections.Generic.List<T>? nodes, GraphQLParser.Visitors.SDLSorterOptions context)
+            where T : GraphQLParser.AST.ASTNode { }
+        protected override System.Threading.Tasks.ValueTask VisitDirectiveLocationsAsync(GraphQLParser.AST.GraphQLDirectiveLocations directiveLocations, GraphQLParser.Visitors.SDLSorterOptions context) { }
+        public static void Sort(GraphQLParser.AST.ASTNode node, GraphQLParser.Visitors.SDLSorterOptions? options = null) { }
+    }
+    public class SDLSorterOptions : GraphQLParser.Visitors.IASTVisitorContext, System.Collections.Generic.IComparer<GraphQLParser.AST.ASTNode>, System.Collections.Generic.IComparer<GraphQLParser.AST.DirectiveLocation>
+    {
+        public SDLSorterOptions(System.StringComparison stringComparison) { }
+        public System.StringComparison StringComparison { get; }
+        public static GraphQLParser.Visitors.SDLSorterOptions Default { get; }
+        public virtual int Compare(GraphQLParser.AST.ASTNode x, GraphQLParser.AST.ASTNode y) { }
+        public int Compare(GraphQLParser.AST.DirectiveLocation x, GraphQLParser.AST.DirectiveLocation y) { }
     }
     public class StructurePrinter : GraphQLParser.Visitors.StructurePrinter<GraphQLParser.Visitors.SDLPrinter.DefaultPrintContext>
     {

--- a/src/GraphQLParser.Tests/Files/DefinitionSortTests.graphql
+++ b/src/GraphQLParser.Tests/Files/DefinitionSortTests.graphql
@@ -1,0 +1,31 @@
+scalar Type3
+
+schema {
+  mutation: Type2
+  query: Type3
+  subscription: Type1
+}
+
+type Type1 @dir3 @dir1 @dir2 {
+  f1(arg3: [ID], arg1: Float, arg2: Int!): String
+  f3: ID
+  f2: Float
+}
+
+# Type2 comment
+"Type2 description"
+input Type2 {
+  "f1 description"
+  f1: String
+  "f3 description"
+  f3: ID!
+  "f2 description"
+  f2: [[Float!]!]!
+}
+
+directive @zdir3(arg3: [ID], arg1: Float, arg2: Int!)
+  on FRAGMENT_SPREAD | FIELD | INLINE_FRAGMENT
+
+directive @zdir1 on FIELD
+
+directive @zdir2 on INLINE_FRAGMENT

--- a/src/GraphQLParser.Tests/Files/ExecutableSortTests.graphql
+++ b/src/GraphQLParser.Tests/Files/ExecutableSortTests.graphql
@@ -1,0 +1,68 @@
+mutation m2 {
+  field
+}
+
+# comments for q2
+query q2 {
+  dummy
+}
+
+subscription s3 @dir3 @dir1 @dir2 {
+  dummy
+}
+
+mutation m1 {
+  field
+}
+
+subscription s1 {
+  dummy
+}
+
+# l2 - comments on default query line 1
+# l1 - comments on default query line 2
+# l3 - comments on default query line 3
+{
+  ...fragment8
+  field2
+  ... on Type2 {
+    field5
+  }
+  ...fragment7
+  field1 (arg2: "value1", arg1: [3, 1, 2], arg3: { sub2: 1, sub1: 2, sub3: 3 })
+  ... {
+    field4
+  }
+  field3 @dir2 @dir1(arg2: "value1", arg1: [3, 1, 2], arg3: { sub2: 1, sub1: 2, sub3: 3 }) @dir3
+  ...fragment9
+  ... on Type3 {
+    field6
+  }
+}
+
+fragment frag2 on Type1 {
+  dummy
+}
+
+fragment frag1 on Type2 {
+  dummy
+}
+
+mutation m3 {
+  field
+}
+
+fragment frag3 on Type3 {
+  dummy3
+  dummy1
+  dummy2
+}
+
+subscription s2 {
+  dummy
+}
+
+# comments for q3
+query q3 ($arg2: ID, $arg1: String, $arg3: Float) {
+  dummy
+}

--- a/src/GraphQLParser.Tests/Visitors/SDLSorterTests.SortsSchemaDefinition.approved.DefinitionSortTests.graphql
+++ b/src/GraphQLParser.Tests/Visitors/SDLSorterTests.SortsSchemaDefinition.approved.DefinitionSortTests.graphql
@@ -1,0 +1,33 @@
+schema {
+  query: Type3
+  mutation: Type2
+  subscription: Type1
+}
+
+directive @zdir1 on FIELD
+
+directive @zdir2 on INLINE_FRAGMENT
+
+directive @zdir3(arg1: Float, arg2: Int!, arg3: [ID]) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Type1 @dir1 @dir2 @dir3 {
+  f1(arg1: Float, arg2: Int!, arg3: [ID]): String
+  f2: Float
+  f3: ID
+}
+
+# Type2 comment
+"Type2 description"
+input Type2 {
+
+  "f1 description"
+    f1: String
+
+  "f2 description"
+    f2: [[Float!]!]!
+
+  "f3 description"
+    f3: ID!
+}
+
+scalar Type3

--- a/src/GraphQLParser.Tests/Visitors/SDLSorterTests.SortsSchemaDefinition.approved.ExecutableSortTests.graphql
+++ b/src/GraphQLParser.Tests/Visitors/SDLSorterTests.SortsSchemaDefinition.approved.ExecutableSortTests.graphql
@@ -1,0 +1,68 @@
+# l2 - comments on default query line 1
+# l1 - comments on default query line 2
+# l3 - comments on default query line 3
+{
+  field1(arg1: [3, 1, 2], arg2: "value1", arg3: {sub1: 2, sub2: 1, sub3: 3})
+  field2
+  field3 @dir1(arg1: [3, 1, 2], arg2: "value1", arg3: {sub1: 2, sub2: 1, sub3: 3}) @dir2 @dir3
+  ...  {
+    field4
+  }
+  ... on Type2 {
+    field5
+  }
+  ... on Type3 {
+    field6
+  }
+  ...fragment7
+  ...fragment8
+  ...fragment9
+}
+
+# comments for q2
+query q2 {
+  dummy
+}
+
+# comments for q3
+query q3($arg1: String, $arg2: ID, $arg3: Float) {
+  dummy
+}
+
+mutation m1 {
+  field
+}
+
+mutation m2 {
+  field
+}
+
+mutation m3 {
+  field
+}
+
+subscription s1 {
+  dummy
+}
+
+subscription s2 {
+  dummy
+}
+
+subscription s3 @dir1 @dir2 @dir3 {
+  dummy
+}
+
+fragment frag2 on Type1 {
+  dummy
+}
+
+fragment frag1 on Type2 {
+  dummy
+}
+
+fragment frag3 on Type3 {
+  dummy1
+  dummy2
+  dummy3
+}

--- a/src/GraphQLParser.Tests/Visitors/SDLSorterTests.SortsSchemaDefinition.approved.KitchenSink.graphql
+++ b/src/GraphQLParser.Tests/Visitors/SDLSorterTests.SortsSchemaDefinition.approved.KitchenSink.graphql
@@ -1,0 +1,142 @@
+{
+  query
+  unnamed(falsey: false, truthy: true)
+}
+
+# Copyright (c) 2015, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+query queryName($foo: ComplexType, $site: Site = MOBILE) {
+  whoever123is: node(id: [123, 456]) {
+    id
+    ...  @skip(unless: $foo) {
+      id
+    }
+    ...  {
+      id
+    }
+    ... on User @defer {
+      field2 {
+        alias: field1(after: $foo, first: 10) @include(if: $foo) {
+          id
+          ...frag
+        }
+        id
+      }
+    }
+  }
+}
+
+mutation likeStory {
+  like(story: 123) @defer {
+    story {
+      id
+    }
+  }
+}
+
+mutation updateStory {
+  like(story: {EndDate: null, id: 123}) {
+    story {
+      id
+    }
+  }
+}
+
+subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
+  storyLikeSubscribe(input: $input) {
+    story {
+      likers {
+        count
+      }
+      likeSentence {
+        text
+      }
+    }
+  }
+}
+
+fragment frag on Friend {
+  foo(bar: $b, obj: {key: "value"}, size: $size)
+}
+
+# Copyright (c) 2015, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+schema {
+  query: QueryType
+  mutation: MutationType
+}
+
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+enum AnnotatedEnum @onEnum {
+  ANNOTATED_VALUE @onEnumValue
+  OTHER_VALUE
+}
+
+input AnnotatedInput @onInputObjectType {
+  annotatedField: Type @onField
+}
+
+interface AnnotatedInterface @onInterface {
+  annotatedField(arg: Type @onArg): Type @onField
+}
+
+type AnnotatedObject @onObject(arg: "value") {
+  # a comment
+  annotatedField(arg: Type = "default" @onArg): Type @onField
+}
+
+scalar AnnotatedScalar @onScalar
+
+union AnnotatedUnion @onUnion = A | B
+
+interface Bar {
+  four(argument: String = "string"): String
+  one: Type
+}
+
+scalar CustomScalar
+
+union Feed = Advert | Article | Story
+
+type Foo implements Bar {
+  five(argument: [String] = ["string", "string"]): String
+  four(argument: String = "string"): String
+  # comment 1
+  one: Type
+  six(argument: InputType = {key: "value"}): Type
+  # multiline comments
+  # with very important description #
+  # # and symbol # and ##
+  three(argument: InputType, other: String): Int
+  # comment 2
+  two(argument: InputType!): Type
+}
+
+input InputType {
+  answer: Int = 42
+  key: String!
+}
+
+type NoFields
+
+enum Site {
+  DESKTOP
+  MOBILE
+}
+
+extend type Foo {
+  seven(argument: [String]): Type
+}
+
+extend type Foo @onType

--- a/src/GraphQLParser.Tests/Visitors/SDLSorterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLSorterTests.cs
@@ -1,0 +1,24 @@
+using GraphQLParser.Visitors;
+
+namespace GraphQLParser.Tests.Visitors;
+
+public class SDLSorterTests
+{
+    [Theory]
+    [InlineData("KitchenSink")]
+    [InlineData("ExecutableSortTests")]
+    [InlineData("DefinitionSortTests")]
+    public void SortsSchemaDefinition(string file)
+    {
+        var input = file.ReadGraphQLFile();
+        var parsed = Parser.Parse(input);
+        SDLSorter.Sort(parsed);
+        var actual = new SDLPrinter(new SDLPrinterOptions { PrintComments = true }).Print(parsed);
+        actual.ShouldMatchApproved(o =>
+        {
+            o.NoDiff();
+            o.WithFileExtension($"{file}.graphql");
+            o.WithStringCompareOptions(StringCompareShould.IgnoreLineEndings);
+        });
+    }
+}

--- a/src/GraphQLParser/Visitors/ASTVisitor.cs
+++ b/src/GraphQLParser/Visitors/ASTVisitor.cs
@@ -668,7 +668,7 @@ public class ASTVisitor<TContext> where TContext : IASTVisitorContext
     /// sibling nodes of some parent node, for example, argument nodes for
     /// parent field node or value nodes for parent list node.
     /// </summary>
-    protected async ValueTask VisitAsync<T>(List<T>? nodes, TContext context)
+    protected virtual async ValueTask VisitAsync<T>(List<T>? nodes, TContext context)
         where T : ASTNode
     {
         if (nodes != null)

--- a/src/GraphQLParser/Visitors/SDLSorter.cs
+++ b/src/GraphQLParser/Visitors/SDLSorter.cs
@@ -1,0 +1,75 @@
+using GraphQLParser.AST;
+
+namespace GraphQLParser.Visitors;
+
+/// <summary>
+/// Sorts AST nodes in the specified document.
+/// </summary>
+public sealed class SDLSorter : ASTVisitor<SDLSorterOptions>
+{
+    private static readonly SDLSorter _sorter = new();
+
+    private SDLSorter()
+    {
+    }
+
+    /// <summary>
+    /// Sorts the specified document or node tree.
+    /// Nodes that have the same sort order will be retain their relative position.
+    /// </summary>
+    public static void Sort(ASTNode node, SDLSorterOptions? options = null)
+#pragma warning disable CA2012 // Use ValueTasks correctly
+        => _ = _sorter.VisitAsync(node, options ?? SDLSorterOptions.Default);
+#pragma warning restore CA2012 // Use ValueTasks correctly
+
+    /// <inheritdoc/>
+    protected override ValueTask VisitAsync<T>(List<T>? nodes, SDLSorterOptions context)
+    {
+        if (nodes == null)
+            return default;
+
+        // do not use List<T>.Sort as it is an unstable sorting algorithm
+        // a stable sorting algorithm is necessary for (a) lists of literal values (b) comments
+        StableSort(nodes, context);
+        return base.VisitAsync(nodes, context);
+    }
+
+    /// <inheritdoc/>
+    protected override ValueTask VisitDirectiveLocationsAsync(GraphQLDirectiveLocations directiveLocations, SDLSorterOptions context)
+    {
+        StableSort(directiveLocations.Items, context);
+        return base.VisitDirectiveLocationsAsync(directiveLocations, context);
+    }
+
+    /// <summary>
+    /// Performs a stable sort on the list.
+    /// Uses a 'bubble sort' sorting algorithm if there are 20 or less items;
+    /// otherwise uses LINQ to sort, which is a much faster algorithm when
+    /// there are a greater quantity of items, at the cost of higher memory requirements.
+    /// </summary>
+    private static void StableSort<T>(List<T> list, IComparer<T> comparer)
+    {
+        var n = list.Count;
+        if (n > 20)
+        {
+            var list2 = list.OrderBy(static x => x, comparer).ToArray();
+            for (int i = 0; i < list2.Length; i++)
+            {
+                list[i] = list2[i];
+            }
+            return;
+        }
+        for (int i = 0; i < n - 1; i++)
+        {
+            for (int j = 0; j < n - i - 1; j++)
+            {
+                if (comparer.Compare(list[j], list[j + 1]) > 0)
+                {
+                    var temp = list[j];
+                    list[j] = list[j + 1];
+                    list[j + 1] = temp;
+                }
+            }
+        }
+    }
+}

--- a/src/GraphQLParser/Visitors/SDLSorterOptions.cs
+++ b/src/GraphQLParser/Visitors/SDLSorterOptions.cs
@@ -1,0 +1,75 @@
+using GraphQLParser.AST;
+
+namespace GraphQLParser.Visitors;
+
+/// <summary>
+/// Options for <see cref="SDLSorter"/>.
+/// </summary>
+public class SDLSorterOptions : IASTVisitorContext, IComparer<ASTNode>, IComparer<DirectiveLocation>
+{
+    CancellationToken IASTVisitorContext.CancellationToken => default;
+
+    /// <summary>
+    /// Returns the <see cref="System.StringComparison"/> used by the comparer.
+    /// </summary>
+    public StringComparison StringComparison { get; } = StringComparison.InvariantCultureIgnoreCase;
+
+    /// <summary>
+    /// Initializes a new instances with the specified <see cref="System.StringComparison"/>.
+    /// </summary>
+    public SDLSorterOptions(StringComparison stringComparison)
+    {
+        StringComparison = stringComparison;
+    }
+
+    /// <summary>
+    /// Returns a default instance which sorts using a culture-invariant case-insensitive string comparison.
+    /// </summary>
+    public static SDLSorterOptions Default { get; } = new SDLSorterOptions(StringComparison.InvariantCultureIgnoreCase);
+
+    /// <inheritdoc cref="IComparer{T}.Compare(T, T)"/>
+    public virtual int Compare(ASTNode x, ASTNode y)
+    {
+        int primaryComparison = Comparer<int>.Default.Compare(PrimarySort(x), PrimarySort(y));
+        if (primaryComparison != 0)
+            return primaryComparison;
+        return SecondarySort(x).CompareTo(SecondarySort(y), StringComparison);
+
+        static int PrimarySort(ASTNode node) => node switch
+        {
+            // comments go first
+            GraphQLComment => 0,
+            // sorting for selection sets
+            GraphQLField => 1,
+            GraphQLInlineFragment => 2,
+            GraphQLFragmentSpread => 3,
+            // sorting for executable documents
+            GraphQLOperationDefinition op when op.Operation == OperationType.Query => 4,
+            GraphQLOperationDefinition op when op.Operation == OperationType.Mutation => 5,
+            GraphQLOperationDefinition op when op.Operation == OperationType.Subscription => 6,
+            GraphQLFragmentDefinition => 7,
+            // sorting for SDL documents
+            GraphQLSchemaDefinition => 8,
+            GraphQLDirectiveDefinition => 9,
+            GraphQLTypeDefinition => 10,
+            _ => 11 // sort other definitions together
+        };
+
+        static ReadOnlySpan<char> SecondarySort(ASTNode node) => node switch
+        {
+            GraphQLOperationDefinition x => x.Name?.Value ?? "", // although this implements INamedNode, it may be nullable here
+            INamedNode x => x.Name.Value, // note: this includes values in map literals (GraphQLObjectField instances)
+            GraphQLInlineFragment x => x.TypeCondition != null ? x.TypeCondition.Type.Name.Value : "",
+            GraphQLFragmentSpread x => x.FragmentName.Name.Value,
+            GraphQLRootOperationTypeDefinition x => x.Operation switch { OperationType.Query => "a", OperationType.Mutation => "b", _ => "c" },
+            GraphQLVariableDefinition x => x.Variable.Name.Value,
+            _ => "", // do not sort values, comments, etc
+        };
+    }
+
+    /// <inheritdoc/>
+    public int Compare(DirectiveLocation x, DirectiveLocation y)
+        => Comparer<string>.Default.Compare(x.ToString(), y.ToString());
+
+    int IComparer<ASTNode>.Compare(ASTNode? x, ASTNode? y) => Compare(x!, y!);
+}


### PR DESCRIPTION
This PR adds another visitor implementation to sort a SDL -- that is, to walk the tree and sort each list of nodes that are encountered. Some node types, such as comments and literal arrays, are left in their original order. Fortunately the implementation turned out to be quite simple to implement. This implementation has a fixed sort order, generally by name ascending, but the string comparison used can be selected, with culture-invariant case-insensitive as default. It can sort execution or definition documents. Of course, execution documents will execute differently since the execution order is defined by the order of the fields in the selection set. However, sorting definition documents will not cause any executional changes. Some lists of nodes will have a primary sort based on what makes sense, with the secondary sort being by name:

- A definition document will have the schema first, directives second, and types third
- A schema definition will have the query first, mutation second, and subscription defined third
- Executable documents will have queries first, mutations second, subscriptions third, and fragments fourth
- Selection sets will have fields first, inline fragments second, and fragment spreads third