### PR TITLE
Add DefaultVisitorContext and NullVisitorContext

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -933,6 +933,10 @@ namespace GraphQLParser.Visitors
         public System.Threading.CancellationToken CancellationToken { get; init; }
         public System.Collections.Generic.Stack<GraphQLParser.AST.ASTNode> Parents { get; init; }
     }
+    public struct DefaultVisitorContext : GraphQLParser.Visitors.IASTVisitorContext
+    {
+        public System.Threading.CancellationToken CancellationToken { get; set; }
+    }
     public interface IASTVisitorContext
     {
         System.Threading.CancellationToken CancellationToken { get; }
@@ -959,6 +963,10 @@ namespace GraphQLParser.Visitors
     {
         public MaxDepthVisitor() { }
         public override System.Threading.Tasks.ValueTask VisitAsync(GraphQLParser.AST.ASTNode? node, TContext context) { }
+    }
+    public struct NullVisitorContext : GraphQLParser.Visitors.IASTVisitorContext
+    {
+        public System.Threading.CancellationToken CancellationToken { get; }
     }
     public static class PrintContextExtensions
     {

--- a/src/GraphQLParser/Visitors/DefaultVisitorContext.cs
+++ b/src/GraphQLParser/Visitors/DefaultVisitorContext.cs
@@ -1,0 +1,11 @@
+namespace GraphQLParser.Visitors;
+
+/// <summary>
+/// An implementation of <see cref="IASTVisitorContext"/> that only contains a <see cref="CancellationToken"/>.
+/// Ideal for use in cases where there is no context variables.
+/// </summary>
+public struct DefaultVisitorContext : IASTVisitorContext
+{
+    /// <inheritdoc/>
+    public CancellationToken CancellationToken { get; set; }
+}

--- a/src/GraphQLParser/Visitors/NullVisitorContext.cs
+++ b/src/GraphQLParser/Visitors/NullVisitorContext.cs
@@ -1,0 +1,12 @@
+namespace GraphQLParser.Visitors;
+
+/// <summary>
+/// An implementation of <see cref="IASTVisitorContext"/> that does nothing.
+/// Ideal for use in cases where the visitor runs synchronously, there is no context
+/// variables, and cancellation is not required.
+/// </summary>
+public struct NullVisitorContext : IASTVisitorContext
+{
+    /// <inheritdoc/>
+    public readonly CancellationToken CancellationToken => default;
+}


### PR DESCRIPTION
- Adds `NullVisitorContext` for use with synchronous visitors that do not hold context variables
- Adds `DefaultVisitorContext` for use with asynchronous visitors that do not hold context variables
