### PR TITLE
Remove ThrowIfCancellationRequested from VisitAsync

### DIFF
--- a/src/GraphQLParser.Tests/Visitors/ASTVisitorTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/ASTVisitorTests.cs
@@ -33,12 +33,13 @@ public class ASTVisitorTests
     }
 
     [Fact]
-    public void ASTVisitor_Should_Respect_CancellationToken()
+    public void ASTVisitor_Should_Pass_CancellationToken()
     {
         var document = "scalar JSON".Parse();
         var visitor = new MyVisitor();
         using var cts = new CancellationTokenSource(500);
         var context = new Context { CancellationToken = cts.Token };
+        context.CancellationToken.ThrowIfCancellationRequested();
 
         Should.Throw<OperationCanceledException>(() => visitor.VisitAsync(document, context).GetAwaiter().GetResult());
     }
@@ -48,6 +49,7 @@ public class ASTVisitorTests
         protected override async ValueTask VisitScalarTypeDefinitionAsync(GraphQLScalarTypeDefinition scalarTypeDefinition, Context context)
         {
             await Task.Delay(700);
+            context.CancellationToken.ThrowIfCancellationRequested();
             await base.VisitScalarTypeDefinitionAsync(scalarTypeDefinition, context);
         }
     }

--- a/src/GraphQLParser/Visitors/ASTVisitor.cs
+++ b/src/GraphQLParser/Visitors/ASTVisitor.cs
@@ -595,8 +595,6 @@ public class ASTVisitor<TContext> where TContext : IASTVisitorContext
     /// <param name="context">Context passed into all INodeVisitor.VisitXXX methods.</param>
     public virtual ValueTask VisitAsync(ASTNode? node, TContext context)
     {
-        context.CancellationToken.ThrowIfCancellationRequested();
-
         return node == null
             ? default
             : node switch


### PR DESCRIPTION
As `VisitAsync` is a very 'hot' path with very little execution time, `context.CancellationToken.ThrowIfCancellationRequested();` has been removed for faster execution.

See https://devblogs.microsoft.com/premier-developer/recommended-patterns-for-cancellationtoken/

>Consider not checking the token at all if your work is very quick, or you propagate it to the methods you call.