### PR TITLE
Fix quad quote handling

### DIFF
--- a/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
+++ b/src/GraphQLParser.Tests/Visitors/SDLPrinterTests.cs
@@ -623,6 +623,7 @@ directive @skip(
     [InlineData(30, "Test \\ escaping", "Test \\\\ escaping", false)]
     [InlineData(31, "t\"est\n  line2", "\nt\"est\nline2\n", true)] // BlockString with double quote inside
     [InlineData(32, "t\\\"\"\"est\n  line2", "\nt\\\"\"\"est\nline2\n", true)] // BlockString with triple double quote inside
+    [InlineData(32, "t\\\"\"\"\"est\n  line2", "\nt\\\"\"\"\"est\nline2\n", true)] // BlockString with quad double quote inside
     public async Task SDLPrinter_Should_Print_BlockStrings(int number, string input, string expected, bool isBlockString)
     {
         number.ShouldBeGreaterThan(0);

--- a/src/GraphQLParser/LexerContext.cs
+++ b/src/GraphQLParser/LexerContext.cs
@@ -217,7 +217,30 @@ internal ref struct LexerContext
                 // if last character was \ then go ahead and write out the """, skipping the \
                 if (escape)
                 {
+                    // write """ to buffer
+                    if ((index + 2) < buffer.Length)
+                    {
+                        buffer[index++] = '\"';
+                        buffer[index++] = '\"';
+                        buffer[index++] = '\"';
+                    }
+                    else // fallback to StringBuilder in case of buffer overflow
+                    {
+                        sb ??= new StringBuilder(buffer.Length * 2);
+
+                        for (int i = 0; i < index; ++i)
+                            sb.Append(buffer[i]);
+
+                        sb.Append("\"\"\"");
+                        index = 0;
+                    }
+                    // skip \""" from source
+                    _currentIndex += 2;
                     escape = false;
+                    lastWasCr = false;
+                    // advance to next character
+                    code = NextCode();
+                    continue;
                 }
                 else
                 {

--- a/src/GraphQLParser/Visitors/SDLPrinter.cs
+++ b/src/GraphQLParser/Visitors/SDLPrinter.cs
@@ -134,7 +134,8 @@ public class SDLPrinter<TContext> : ASTVisitor<TContext>
                     case '"':
                         if (i < length - 2 && description.Value.Span[i + 1] == '"' && description.Value.Span[i + 2] == '"')
                         {
-                            await context.WriteAsync("\\\"").ConfigureAwait(false);
+                            await context.WriteAsync("\\\"\"\"").ConfigureAwait(false);
+                            i += 2;
                         }
                         else
                         {


### PR DESCRIPTION
Quad quotes within a block string was broken for parsing, and did not print well.

So this did not parse:

```gql
"""
Testing\""""123
"""
```

Which should parse as

```
Testing""""123
```

And when attempting to print it, it printed this, while valid, was not ideal:

```gql
"""
Testing\"\"""123
"""
```

Both are fixed in this PR.