### PR TITLE
Bump xunit packages and PublicApiGenerator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
             6.0.x
             7.0.x
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json

--- a/src/GraphQLParser.ApiTests/GraphQLParser.ApiTests.csproj
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.ApiTests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.6.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
-    <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
+    <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GraphQLParser.Tests/GraphQLParser.Tests.csproj
+++ b/src/GraphQLParser.Tests/GraphQLParser.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SingleTestPlatform)' != 'true'">
-    <TargetFrameworks>netcoreapp3.1;net6;net7</TargetFrameworks>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
   </PropertyGroup>
 
@@ -27,8 +27,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Drops netcoreapp3.1 in tests since it was dropped by xunit package.