### PR TITLE
Add GetDirectiveLocation extension method

### DIFF
--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -643,6 +643,7 @@ namespace GraphQLParser
             where TNode :  class, GraphQLParser.AST.INamedNode { }
         public static GraphQLParser.AST.GraphQLFragmentDefinition? FindFragmentDefinition(this GraphQLParser.AST.GraphQLDocument document, GraphQLParser.ROM name) { }
         public static int FragmentsCount(this GraphQLParser.AST.GraphQLDocument document) { }
+        public static GraphQLParser.AST.DirectiveLocation GetDirectiveLocation(this GraphQLParser.AST.ASTNode node) { }
         public static int MaxNestedDepth(this GraphQLParser.AST.ASTNode node) { }
         public static GraphQLParser.AST.GraphQLOperationDefinition? OperationWithName(this GraphQLParser.AST.GraphQLDocument document, GraphQLParser.ROM operationName) { }
         public static int OperationsCount(this GraphQLParser.AST.GraphQLDocument document) { }

--- a/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
+++ b/src/GraphQLParser.ApiTests/GraphQLParser.approved.txt
@@ -130,6 +130,10 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLName Name { get; set; }
         public GraphQLParser.AST.GraphQLValue Value { get; set; }
     }
+    public class GraphQLArgumentDefinition : GraphQLParser.AST.GraphQLInputValueDefinition
+    {
+        public GraphQLArgumentDefinition(GraphQLParser.AST.GraphQLName name, GraphQLParser.AST.GraphQLType type) { }
+    }
     public class GraphQLArguments : GraphQLParser.AST.ASTListNode<GraphQLParser.AST.GraphQLArgument>
     {
         public GraphQLArguments(System.Collections.Generic.List<GraphQLParser.AST.GraphQLArgument> items) { }
@@ -304,6 +308,10 @@ namespace GraphQLParser.AST
         public GraphQLParser.AST.GraphQLSelectionSet SelectionSet { get; set; }
         public GraphQLParser.AST.GraphQLTypeCondition? TypeCondition { get; set; }
     }
+    public class GraphQLInputFieldDefinition : GraphQLParser.AST.GraphQLInputValueDefinition
+    {
+        public GraphQLInputFieldDefinition(GraphQLParser.AST.GraphQLName name, GraphQLParser.AST.GraphQLType type) { }
+    }
     public class GraphQLInputFieldsDefinition : GraphQLParser.AST.ASTListNode<GraphQLParser.AST.GraphQLInputValueDefinition>
     {
         public GraphQLInputFieldsDefinition(System.Collections.Generic.List<GraphQLParser.AST.GraphQLInputValueDefinition> items) { }
@@ -325,6 +333,8 @@ namespace GraphQLParser.AST
     }
     public class GraphQLInputValueDefinition : GraphQLParser.AST.GraphQLTypeDefinition, GraphQLParser.AST.IHasDefaultValueNode, GraphQLParser.AST.IHasDirectivesNode
     {
+        [System.Obsolete("Please use the GraphQLArgumentDefinition or GraphQLInputFieldDefinition construct" +
+            "or.")]
         public GraphQLInputValueDefinition(GraphQLParser.AST.GraphQLName name, GraphQLParser.AST.GraphQLType type) { }
         public GraphQLParser.AST.GraphQLValue? DefaultValue { get; set; }
         public GraphQLParser.AST.GraphQLDirectives? Directives { get; set; }

--- a/src/GraphQLParser.Tests/GetDirectiveLocationTests.cs
+++ b/src/GraphQLParser.Tests/GetDirectiveLocationTests.cs
@@ -1,0 +1,86 @@
+using GraphQLParser.Visitors;
+
+namespace GraphQLParser.Tests;
+
+public class GetDirectiveLocationTests
+{
+    [Fact]
+    public async Task ItWorks()
+    {
+        var sdl = $$"""
+            schema @test(value: "{{DirectiveLocation.Schema}}") {
+                query: Query
+            }
+
+            type Query @test(value: "{{DirectiveLocation.Object}}") {
+                field(arg:String @test(value:"{{DirectiveLocation.ArgumentDefinition}}")): String @test(value: "{{DirectiveLocation.FieldDefinition}}")
+            }
+
+            scalar CustomScalar @test(value: "{{DirectiveLocation.Scalar}}")
+
+            interface CustomInterface @test(value: "{{DirectiveLocation.Interface}}") {
+                field: String @test(value: "{{DirectiveLocation.FieldDefinition}}")
+            }
+
+            union CustomUnion @test(value: "{{DirectiveLocation.Union}}") = A | B
+
+            enum CustomEnum @test(value: "{{DirectiveLocation.Enum}}") {
+                A @test(value: "{{DirectiveLocation.EnumValue}}")
+            }
+
+            input CustomInput @test(value: "{{DirectiveLocation.InputObject}}") {
+                field: String @test(value: "{{DirectiveLocation.InputFieldDefinition}}")
+            }
+
+            query Query @test(value: "{{DirectiveLocation.Query}}") {
+                field @test(value: "{{DirectiveLocation.Field}}")
+                ...fragment1 @test(value: "{{DirectiveLocation.FragmentSpread}}")
+                ... on CustomType @test(value: "{{DirectiveLocation.InlineFragment}}") {
+                    field @test(value: "{{DirectiveLocation.Field}}")
+                }
+            }
+
+            fragment fragment1 on CustomType @test(value: "{{DirectiveLocation.FragmentDefinition}}") {
+                field @test(value: "{{DirectiveLocation.Field}}")
+            }
+
+            mutation($arg: String @test(value: "{{DirectiveLocation.VariableDefinition}}")) @test(value: "{{DirectiveLocation.Mutation}}") {
+                field @test(value: "{{DirectiveLocation.Field}}")
+            }
+
+            subscription @test(value: "{{DirectiveLocation.Subscription}}") {
+                field @test(value: "{{DirectiveLocation.Field}}")
+            }
+            """;
+        var ast = Parser.Parse(sdl);
+        var context = new MyVisitor.MyContext();
+        await new MyVisitor().VisitAsync(ast, context);
+        context.Count.ShouldBe(24);
+    }
+
+    private sealed class MyVisitor : ASTVisitor<MyVisitor.MyContext>
+    {
+        public override ValueTask VisitAsync(ASTNode node, MyContext context)
+        {
+            if (node is IHasDirectivesNode directivesNode)
+            {
+                var d = directivesNode.Directives?.FirstOrDefault(x => x.Name == "test");
+                if (d != null)
+                {
+                    var arg = d?.Arguments?.FirstOrDefault(x => x.Name == "value")?.Value;
+                    var argValue = (arg as GraphQLStringValue)?.Value;
+                    var location = node.GetDirectiveLocation();
+                    location.ToString().ShouldBe(argValue?.ToString());
+                    context.Count++;
+                }
+            }
+            return base.VisitAsync(node, context);
+        }
+
+        internal sealed class MyContext : IASTVisitorContext
+        {
+            public int Count { get; set; }
+            public CancellationToken CancellationToken => default;
+        }
+    }
+}

--- a/src/GraphQLParser/AST/Definitions/GraphQLInputValueDefinition.cs
+++ b/src/GraphQLParser/AST/Definitions/GraphQLInputValueDefinition.cs
@@ -16,6 +16,7 @@ public class GraphQLInputValueDefinition : GraphQLTypeDefinition, IHasDirectives
     /// <summary>
     /// Creates a new instance of <see cref="GraphQLInputValueDefinition"/>.
     /// </summary>
+    [Obsolete($"Please use the {nameof(GraphQLArgumentDefinition)} or {nameof(GraphQLInputFieldDefinition)} constructor.")]
     public GraphQLInputValueDefinition(GraphQLName name, GraphQLType type)
         : base(name)
     {
@@ -63,6 +64,120 @@ internal sealed class GraphQLInputValueDefinitionWithComment : GraphQLInputValue
 }
 
 internal sealed class GraphQLInputValueDefinitionFull : GraphQLInputValueDefinition
+{
+    private GraphQLLocation _location;
+    private List<GraphQLComment>? _comments;
+
+    public override GraphQLLocation Location
+    {
+        get => _location;
+        set => _location = value;
+    }
+
+    public override List<GraphQLComment>? Comments
+    {
+        get => _comments;
+        set => _comments = value;
+    }
+}
+
+/// <summary>
+/// AST node for <see cref="ASTNodeKind.InputValueDefinition"/>, where it is used as an argument definition.
+/// </summary>
+[DebuggerDisplay("GraphQLArgumentDefinition: {Name}: {Type}")]
+public class GraphQLArgumentDefinition : GraphQLInputValueDefinition
+{
+    internal GraphQLArgumentDefinition() : base() { }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="GraphQLArgumentDefinition"/>.
+    /// </summary>
+    public GraphQLArgumentDefinition(GraphQLName name, GraphQLType type)
+#pragma warning disable CS0618 // Type or member is obsolete
+        : base(name, type) { }
+#pragma warning restore CS0618 // Type or member is obsolete
+}
+
+internal sealed class GraphQLArgumentDefinitionWithLocation : GraphQLArgumentDefinition
+{
+    private GraphQLLocation _location;
+
+    public override GraphQLLocation Location
+    {
+        get => _location;
+        set => _location = value;
+    }
+}
+
+internal sealed class GraphQLArgumentDefinitionWithComment : GraphQLArgumentDefinition
+{
+    private List<GraphQLComment>? _comments;
+
+    public override List<GraphQLComment>? Comments
+    {
+        get => _comments;
+        set => _comments = value;
+    }
+}
+
+internal sealed class GraphQLArgumentDefinitionFull : GraphQLArgumentDefinition
+{
+    private GraphQLLocation _location;
+    private List<GraphQLComment>? _comments;
+
+    public override GraphQLLocation Location
+    {
+        get => _location;
+        set => _location = value;
+    }
+
+    public override List<GraphQLComment>? Comments
+    {
+        get => _comments;
+        set => _comments = value;
+    }
+}
+
+/// <summary>
+/// AST node for <see cref="ASTNodeKind.InputValueDefinition"/>, where it is used as an input field definition.
+/// </summary>
+[DebuggerDisplay("GraphQLInputFieldDefinition: {Name}: {Type}")]
+public class GraphQLInputFieldDefinition : GraphQLInputValueDefinition
+{
+    internal GraphQLInputFieldDefinition() : base() { }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="GraphQLInputFieldDefinition"/>.
+    /// </summary>
+    public GraphQLInputFieldDefinition(GraphQLName name, GraphQLType type)
+#pragma warning disable CS0618 // Type or member is obsolete
+        : base(name, type) { }
+#pragma warning restore CS0618 // Type or member is obsolete
+}
+
+internal sealed class GraphQLInputFieldDefinitionWithLocation : GraphQLInputFieldDefinition
+{
+    private GraphQLLocation _location;
+
+    public override GraphQLLocation Location
+    {
+        get => _location;
+        set => _location = value;
+    }
+}
+
+internal sealed class GraphQLInputFieldDefinitionWithComment : GraphQLInputFieldDefinition
+{
+    private List<GraphQLComment>? _comments;
+
+    public override List<GraphQLComment>? Comments
+    {
+        get => _comments;
+        set => _comments = value;
+    }
+}
+
+internal sealed class GraphQLInputFieldDefinitionFull : GraphQLInputFieldDefinition
 {
     private GraphQLLocation _location;
     private List<GraphQLComment>? _comments;

--- a/src/GraphQLParser/Extensions/ASTNodeExtensions.cs
+++ b/src/GraphQLParser/Extensions/ASTNodeExtensions.cs
@@ -132,4 +132,36 @@ public static class ASTNodeExtensions
 
         return null;
     }
+
+    /// <summary>
+    /// Returns the directive location for the specified AST node.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException"/>
+    public static DirectiveLocation GetDirectiveLocation(this ASTNode node) => node switch
+    {
+        // type definitions
+        GraphQLSchemaDefinition => DirectiveLocation.Schema,
+        GraphQLScalarTypeDefinition => DirectiveLocation.Scalar,
+        GraphQLObjectTypeDefinition => DirectiveLocation.Object,
+        GraphQLFieldDefinition => DirectiveLocation.FieldDefinition,
+        GraphQLArgumentDefinition => DirectiveLocation.ArgumentDefinition,
+        GraphQLInterfaceTypeDefinition => DirectiveLocation.Interface,
+        GraphQLUnionTypeDefinition => DirectiveLocation.Union,
+        GraphQLEnumTypeDefinition => DirectiveLocation.Enum,
+        GraphQLEnumValueDefinition => DirectiveLocation.EnumValue,
+        GraphQLInputObjectTypeDefinition => DirectiveLocation.InputObject,
+        GraphQLInputFieldDefinition => DirectiveLocation.InputFieldDefinition,
+
+        // executable definitions
+        GraphQLOperationDefinition opDef when opDef.Operation == OperationType.Query => DirectiveLocation.Query,
+        GraphQLOperationDefinition opDef when opDef.Operation == OperationType.Mutation => DirectiveLocation.Mutation,
+        GraphQLOperationDefinition opDef when opDef.Operation == OperationType.Subscription => DirectiveLocation.Subscription,
+        GraphQLField => DirectiveLocation.Field,
+        GraphQLFragmentDefinition => DirectiveLocation.FragmentDefinition,
+        GraphQLFragmentSpread => DirectiveLocation.FragmentSpread,
+        GraphQLInlineFragment => DirectiveLocation.InlineFragment,
+        GraphQLVariableDefinition => DirectiveLocation.VariableDefinition,
+
+        _ => throw new ArgumentOutOfRangeException(nameof(node), "The supplied node cannot")
+    };
 }

--- a/src/GraphQLParser/NodeHelper.cs
+++ b/src/GraphQLParser/NodeHelper.cs
@@ -483,15 +483,32 @@ internal static class NodeHelper
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static GraphQLInputValueDefinition CreateGraphQLInputValueDefinition(IgnoreOptions options)
+    public static GraphQLInputValueDefinition CreateGraphQLInputValueDefinition(IgnoreOptions options, bool? argument)
     {
-        return options switch
-        {
-            IgnoreOptions.All => new GraphQLInputValueDefinition(),
-            IgnoreOptions.Comments => new GraphQLInputValueDefinitionWithLocation(),
-            IgnoreOptions.Locations => new GraphQLInputValueDefinitionWithComment(),
-            _ => new GraphQLInputValueDefinitionFull(),
-        };
+        if (argument == true)
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLArgumentDefinition(),
+                IgnoreOptions.Comments => new GraphQLArgumentDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLArgumentDefinitionWithComment(),
+                _ => new GraphQLArgumentDefinitionFull(),
+            };
+        else if (argument == false)
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLInputFieldDefinition(),
+                IgnoreOptions.Comments => new GraphQLInputFieldDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLInputFieldDefinitionWithComment(),
+                _ => new GraphQLInputFieldDefinitionFull(),
+            };
+        else
+            return options switch
+            {
+                IgnoreOptions.All => new GraphQLInputValueDefinition(),
+                IgnoreOptions.Comments => new GraphQLInputValueDefinitionWithLocation(),
+                IgnoreOptions.Locations => new GraphQLInputValueDefinitionWithComment(),
+                _ => new GraphQLInputValueDefinitionFull(),
+            };
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/GraphQLParser/Parser.cs
+++ b/src/GraphQLParser/Parser.cs
@@ -80,7 +80,11 @@ public static class Parser
         else if (typeof(T) == typeof(GraphQLInputObjectTypeDefinition))
             result = (T)(object)context.ParseInputObjectTypeDefinition();
         else if (typeof(T) == typeof(GraphQLInputValueDefinition))
-            result = (T)(object)context.ParseInputValueDefinition();
+            result = (T)(object)context.ParseInputValueDefinition(null);
+        else if (typeof(T) == typeof(GraphQLInputFieldDefinition))
+            result = (T)(object)context.ParseInputValueDefinition(false);
+        else if (typeof(T) == typeof(GraphQLArgumentDefinition))
+            result = (T)(object)context.ParseInputValueDefinition(true);
         else if (typeof(T) == typeof(GraphQLInterfaceTypeDefinition))
             result = (T)(object)context.ParseInterfaceTypeDefinition();
         else if (typeof(T) == typeof(GraphQLObjectTypeDefinition))

--- a/src/GraphQLParser/ParserContext.Parse.cs
+++ b/src/GraphQLParser/ParserContext.Parse.cs
@@ -97,7 +97,7 @@ internal ref partial struct ParserContext
         var argsDef = NodeHelper.CreateGraphQLArgumentsDefinition(_ignoreOptions);
 
         argsDef.Comments = GetComments();
-        argsDef.Items = OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseInputValueDefinition(), TokenKind.PAREN_R);
+        argsDef.Items = OneOrMore(TokenKind.PAREN_L, (ref ParserContext context) => context.ParseInputValueDefinition(true), TokenKind.PAREN_R);
         argsDef.Location = GetLocation(start);
 
         DecreaseDepth();
@@ -114,7 +114,7 @@ internal ref partial struct ParserContext
         var inputFieldsDef = NodeHelper.CreateGraphQLInputFieldsDefinition(_ignoreOptions);
 
         inputFieldsDef.Comments = GetComments();
-        inputFieldsDef.Items = OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseInputValueDefinition(), TokenKind.BRACE_R);
+        inputFieldsDef.Items = OneOrMore(TokenKind.BRACE_L, (ref ParserContext context) => context.ParseInputValueDefinition(false), TokenKind.BRACE_R);
         inputFieldsDef.Location = GetLocation(start);
 
         DecreaseDepth();
@@ -735,13 +735,13 @@ internal ref partial struct ParserContext
     }
 
     // http://spec.graphql.org/October2021/#InputValueDefinition
-    public GraphQLInputValueDefinition ParseInputValueDefinition()
+    public GraphQLInputValueDefinition ParseInputValueDefinition(bool? argument)
     {
         IncreaseDepth();
 
         int start = _currentToken.Start;
 
-        var def = NodeHelper.CreateGraphQLInputValueDefinition(_ignoreOptions);
+        var def = NodeHelper.CreateGraphQLInputValueDefinition(_ignoreOptions, argument);
 
         def.Description = Peek(TokenKind.STRING) ? ParseDescription() : null;
         def.Comments = GetComments();


### PR DESCRIPTION
Closes #395 with a non-breaking solution.  Not quite ideal, but good enough; argument fields and input object fields now use derived classes, and an extension method to ASTNode provides the directive location.

Other non-breaking options:
1. Move the method into ASTNode and override it in each derived class
2. Return null instead of throwing in case of error

Breaking options:
1. Move the method into IHasDirectives
2. Make the GraphQLInputValueDefinition ctor internal
3. Remove support for parsing into an GraphQLInputValueDefinition class
